### PR TITLE
Simplify Line classes

### DIFF
--- a/roseau/load_flow/__init__.py
+++ b/roseau/load_flow/__init__.py
@@ -14,7 +14,6 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.models import (
     AbstractBranch,
     AbstractBus,
-    AbstractLine,
     AbstractLoad,
     AbstractTransformer,
     AdmittanceLoad,
@@ -31,12 +30,11 @@ from roseau.load_flow.models import (
     FlexibleParameter,
     Ground,
     ImpedanceLoad,
+    Line,
     LineCharacteristics,
     PotentialRef,
     PowerLoad,
     Projection,
-    ShuntLine,
-    SimplifiedLine,
     Switch,
     TransformerCharacteristics,
     VoltageSource,
@@ -71,9 +69,7 @@ __all__ = [
     "AbstractBranch",
     # Lines
     "Switch",
-    "AbstractLine",
-    "ShuntLine",
-    "SimplifiedLine",
+    "Line",
     "LineCharacteristics",
     # Loads
     "AbstractLoad",

--- a/roseau/load_flow/io/dgs.py
+++ b/roseau/load_flow/io/dgs.py
@@ -10,10 +10,10 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.models import (
     AbstractBranch,
     AbstractBus,
-    AbstractLine,
     AbstractTransformer,
     Bus,
     Ground,
+    Line,
     LineCharacteristics,
     PotentialRef,
     PowerLoad,
@@ -140,7 +140,7 @@ def network_from_dgs(  # noqa: C901
         for line_id in elm_lne.index:
             type_id = elm_lne.at[line_id, "typ_id"]  # id of the line type
 
-            branches[line_id] = AbstractLine.from_dict(
+            branches[line_id] = Line.from_dict(
                 id=line_id,
                 bus1=buses[sta_cubic.at[elm_lne.at[line_id, "bus1"], "cterm"]],
                 bus2=buses[sta_cubic.at[elm_lne.at[line_id, "bus2"], "cterm"]],

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -5,10 +5,10 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.models import (
     AbstractBranch,
     AbstractBus,
-    AbstractLine,
     AbstractLoad,
     AbstractTransformer,
     Element,
+    Line,
     LineCharacteristics,
     TransformerCharacteristics,
 )
@@ -99,7 +99,7 @@ def network_to_dict(en: "ElectricalNetwork") -> dict[str, Any]:
     transformer_characteristics_dict = dict()
     for branch in en.branches.values():
         branches.append(branch.to_dict())
-        if isinstance(branch, AbstractLine):
+        if isinstance(branch, Line):
             type_name = branch.line_characteristics.type_name
             if (
                 type_name in line_characteristics_dict

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from roseau.load_flow import ShuntLine
+from roseau.load_flow import Line
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models import (
     Bus,
@@ -33,8 +33,8 @@ def test_to_dict():
     lc1 = LineCharacteristics("test", z_line=np.eye(4, dtype=complex), y_shunt=np.eye(4, dtype=complex))
     lc2 = LineCharacteristics("test", z_line=np.eye(4, dtype=complex), y_shunt=np.eye(4, dtype=complex) * 1.1)
 
-    line1 = ShuntLine(id="line1", n=4, bus1=vs, bus2=bus, ground=ground, line_characteristics=lc1, length=10)
-    line2 = ShuntLine(id="line2", n=4, bus1=vs, bus2=bus, ground=ground, line_characteristics=lc2, length=10)
+    line1 = Line(id="line1", n=4, bus1=vs, bus2=bus, ground=ground, line_characteristics=lc1, length=10)
+    line2 = Line(id="line2", n=4, bus1=vs, bus2=bus, ground=ground, line_characteristics=lc2, length=10)
     en = ElectricalNetwork([vs, bus], [line1, line2], [], [p_ref, ground])
     with pytest.raises(RoseauLoadFlowException) as e:
         en.to_dict()

--- a/roseau/load_flow/models/__init__.py
+++ b/roseau/load_flow/models/__init__.py
@@ -1,6 +1,6 @@
 from roseau.load_flow.models.buses import AbstractBus, Bus, VoltageSource
 from roseau.load_flow.models.core import AbstractBranch, Element, Ground, PotentialRef
-from roseau.load_flow.models.lines import AbstractLine, LineCharacteristics, ShuntLine, SimplifiedLine, Switch
+from roseau.load_flow.models.lines import Line, LineCharacteristics, Switch
 from roseau.load_flow.models.loads import (
     AbstractLoad,
     AdmittanceLoad,
@@ -37,9 +37,7 @@ __all__ = [
     "VoltageSource",
     # Lines
     "Switch",
-    "AbstractLine",
-    "ShuntLine",
-    "SimplifiedLine",
+    "Line",
     "LineCharacteristics",
     # Loads
     "AbstractLoad",

--- a/roseau/load_flow/models/core.py
+++ b/roseau/load_flow/models/core.py
@@ -14,7 +14,7 @@ from roseau.load_flow.utils.units import ureg
 
 if TYPE_CHECKING:
     from roseau.load_flow.models.buses import AbstractBus
-    from roseau.load_flow.models.lines import AbstractLine, Switch
+    from roseau.load_flow.models.lines import Line, Switch
     from roseau.load_flow.models.transformers import AbstractTransformer
 
 logger = logging.getLogger(__name__)
@@ -92,10 +92,10 @@ class AbstractBranch(Element, JsonMixin):
     branch_type: BranchType = NotImplemented
 
     @classmethod
-    def _line_class(cls) -> type["AbstractLine"]:
-        from roseau.load_flow.models.lines.lines import AbstractLine
+    def _line_class(cls) -> type["Line"]:
+        from roseau.load_flow.models.lines.lines import Line
 
-        return AbstractLine
+        return Line
 
     @classmethod
     def _transformer_class(cls) -> type["AbstractTransformer"]:

--- a/roseau/load_flow/models/lines/__init__.py
+++ b/roseau/load_flow/models/lines/__init__.py
@@ -1,3 +1,3 @@
-from roseau.load_flow.models.lines.lines import AbstractLine, LineCharacteristics, ShuntLine, SimplifiedLine, Switch
+from roseau.load_flow.models.lines.lines import Line, LineCharacteristics, Switch
 
-__all__ = ["Switch", "AbstractLine", "ShuntLine", "SimplifiedLine", "LineCharacteristics"]
+__all__ = ["Switch", "Line", "LineCharacteristics"]

--- a/roseau/load_flow/models/lines/tests/test_line_characteristics.py
+++ b/roseau/load_flow/models/lines/tests/test_line_characteristics.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 import pytest
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
-from roseau.load_flow.models import Bus, Ground, LineCharacteristics, ShuntLine
+from roseau.load_flow.models import Bus, Ground, Line, LineCharacteristics
 from roseau.load_flow.utils import ConductorType, IsolationType, LineModel, LineType, Q_
 
 
@@ -18,9 +18,7 @@ def test_line_characteristics():
 
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
-            id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.5
-        )
+        Line(id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.5)
     assert e.value.args[0] == "The line impedance matrix of 'test' has off-diagonal elements with a non-zero real part."
     assert e.value.args[1] == RoseauLoadFlowExceptionCode.BAD_Z_LINE_VALUE
 
@@ -30,9 +28,7 @@ def test_line_characteristics():
     y_shunt = np.ones(shape=(3, 3), dtype=np.complex_)
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
-            id="line", n=3, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.5
-        )
+        Line(id="line", n=3, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.5)
     assert (
         e.value.args[0] == "The shunt admittance matrix of 'test' has off-diagonal elements with a non-zero real part."
     )
@@ -44,9 +40,7 @@ def test_line_characteristics():
     y_shunt = -2 * np.eye(4, dtype=np.complex_)
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
-            id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.4
-        )
+        Line(id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.4)
     assert e.value.args[0] == "Some real part coefficients of the line impedance matrix of 'test' are negative..."
     assert e.value.args[1] == RoseauLoadFlowExceptionCode.BAD_Z_LINE_VALUE
 
@@ -55,9 +49,7 @@ def test_line_characteristics():
     y_shunt[1, 1] = -3
     with pytest.raises(RoseauLoadFlowException):
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
-            id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.4
-        )
+        Line(id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.4)
     assert e.value.args[0] == "Some real part coefficients of the line impedance matrix of 'test' are negative..."
     assert e.value.args[1] == RoseauLoadFlowExceptionCode.BAD_Z_LINE_VALUE
 
@@ -66,9 +58,7 @@ def test_line_characteristics():
     y_shunt = np.eye(4, dtype=np.complex_)
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
-            id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.4
-        )
+        Line(id="line", n=4, bus1=bus, bus2=bus, ground=ground, line_characteristics=line_characteristics, length=2.4)
     assert e.value.args[0] == "Incorrect z_line dimensions for line characteristics 'test': (4, 2)"
     assert e.value.args[1] == RoseauLoadFlowExceptionCode.BAD_Z_LINE_SHAPE
 
@@ -77,7 +67,7 @@ def test_line_characteristics():
     y_shunt = np.eye(3, dtype=np.complex_)
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
+        Line(
             id="line",
             n=4,
             bus1=bus,
@@ -94,7 +84,7 @@ def test_line_characteristics():
     y_shunt = np.eye(3, dtype=np.complex_)
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
+        Line(
             id="line",
             n=3,
             bus1=bus,
@@ -111,7 +101,7 @@ def test_line_characteristics():
     y_shunt = np.eye(6, dtype=np.complex_)
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
+        Line(
             id="line",
             n=3,
             bus1=bus,
@@ -128,7 +118,7 @@ def test_line_characteristics():
     y_shunt = np.eye(3, dtype=np.complex_)
     with pytest.raises(RoseauLoadFlowException) as e:
         line_characteristics = LineCharacteristics("test", z_line, y_shunt)
-        ShuntLine(
+        Line(
             id="line",
             n=4,
             bus1=bus,

--- a/roseau/load_flow/models/lines/tests/test_switch.py
+++ b/roseau/load_flow/models/lines/tests/test_switch.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
-from roseau.load_flow.models import Bus, Ground, LineCharacteristics, SimplifiedLine, Switch, VoltageSource
+from roseau.load_flow.models import Bus, Ground, Line, LineCharacteristics, Switch, VoltageSource
 
 
 def test_switch_loop():
@@ -13,7 +13,7 @@ def test_switch_loop():
     bus3 = Bus("bus3", 4)
 
     _ = Switch("switch1", 4, bus1, bus2)
-    _ = SimplifiedLine(id="line", n=4, bus1=bus1, bus2=bus3, line_characteristics=line_characteristics, length=10)
+    _ = Line(id="line", n=4, bus1=bus1, bus2=bus3, line_characteristics=line_characteristics, length=10)
 
     with pytest.raises(RoseauLoadFlowException) as e:
         Switch("switch2", 4, bus1, bus2)

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -12,10 +12,10 @@ from roseau.load_flow.models import (
     Bus,
     DeltaWyeTransformer,
     Ground,
+    Line,
     LineCharacteristics,
     PotentialRef,
     PowerLoad,
-    SimplifiedLine,
     Switch,
     TransformerCharacteristics,
     VoltageSource,
@@ -40,7 +40,7 @@ def small_network() -> ElectricalNetwork:
     pref = PotentialRef(ground)
 
     lc = LineCharacteristics("test", 10 * np.eye(4, dtype=complex))
-    line = SimplifiedLine(
+    line = Line(
         id="line",
         n=4,
         bus1=vs,
@@ -128,9 +128,7 @@ def test_add_and_remove():
     load_bus = Bus(id="load bus", n=4)
     load = PowerLoad(id="power load", n=4, bus=load_bus, s=[100 + 0j, 100 + 0j, 100 + 0j])
     line_characteristics = LineCharacteristics("test", z_line=np.eye(4, dtype=complex))
-    line = SimplifiedLine(
-        id="line", n=4, bus1=vs, bus2=load_bus, line_characteristics=line_characteristics, length=10  # km
-    )
+    line = Line(id="line", n=4, bus1=vs, bus2=load_bus, line_characteristics=line_characteristics, length=10)  # km
     _ = PotentialRef(element=ground)
     en = ElectricalNetwork.from_element(vs)
     en.remove_element(load.id)
@@ -165,7 +163,7 @@ def test_bad_networks():
     bus2 = Bus("bus2", 3)
     ground.connect(bus2)
     line_characteristics = LineCharacteristics("test", z_line=np.eye(3, dtype=complex))
-    line = SimplifiedLine(id="line", n=3, bus1=bus1, bus2=bus2, line_characteristics=line_characteristics, length=10)
+    line = Line(id="line", n=3, bus1=bus1, bus2=bus2, line_characteristics=line_characteristics, length=10)
     p_ref = PotentialRef(ground)
     with pytest.raises(RoseauLoadFlowException) as e:
         ElectricalNetwork.from_element(bus1)


### PR DESCRIPTION
No more `AbstractLine` vs `SimplifiedLine` vs `ShuntLine` but a single `Line` instead. The documentation change will be made in a separate PR.