### PR TITLE
Simplify ElecticalNetwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ en = ElectricalNetwork(
     branches=[line],
     loads=[load],
     voltage_sources=[vs],
-    special_elements=[p_ref, ground],
+    grounds=[ground],
+    potential_refs=[p_ref],
 )
 # or simply using the main bus
 # en = ElectricalNetwork.from_element(source_bus)

--- a/roseau/load_flow/exceptions.py
+++ b/roseau/load_flow/exceptions.py
@@ -11,6 +11,10 @@ class RoseauLoadFlowExceptionCode(Enum):
     BAD_PHASE = auto()
     BAD_ID_TYPE = auto()
 
+    # Grounds and Potential references
+    DUPLICATE_GROUND_ID = auto()
+    DUPLICATE_POTENTIAL_REF_ID = auto()
+
     # Buses
     DUPLICATE_BUS_ID = auto()
     BAD_BUS_TYPE = auto()

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -107,11 +107,10 @@ def network_to_dict(en: "ElectricalNetwork") -> JsonDict:
     # Export the grounds and the pref
     grounds: list[JsonDict] = []
     potential_refs: list[JsonDict] = []
-    for se in en.special_elements:
-        if isinstance(se, Ground):
-            grounds.append(se.to_dict())
-        elif isinstance(se, PotentialRef):
-            potential_refs.append(se.to_dict())
+    for ground in en.grounds.values():
+        grounds.append(ground.to_dict())
+    for p_ref in en.potential_refs.values():
+        potential_refs.append(p_ref.to_dict())
 
     # Export the buses and the loads
     buses: list[JsonDict] = []

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -31,7 +31,14 @@ def test_to_dict():
 
     line1 = Line("line1", source_bus, load_bus, phases="abcn", ground=ground, parameters=lp1, length=10)
     line2 = Line("line2", source_bus, load_bus, phases="abcn", ground=ground, parameters=lp2, length=10)
-    en = ElectricalNetwork([source_bus, load_bus], [line1, line2], [], [vs], [p_ref, ground])
+    en = ElectricalNetwork(
+        buses=[source_bus, load_bus],
+        branches=[line1, line2],
+        loads=[],
+        voltage_sources=[vs],
+        grounds=[ground],
+        potential_refs=[p_ref],
+    )
     with pytest.raises(RoseauLoadFlowException) as e:
         en.to_dict()
     assert "There are multiple line parameters with id 'test'" in e.value.msg

--- a/roseau/load_flow/network/__init__.py
+++ b/roseau/load_flow/network/__init__.py
@@ -1,3 +1,0 @@
-from roseau.load_flow.network.electrical_network import ElectricalNetwork
-
-__all__ = ["ElectricalNetwork"]

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -21,8 +21,7 @@ from roseau.load_flow.models import (
     TransformerParameters,
     VoltageSource,
 )
-from roseau.load_flow.network import ElectricalNetwork
-from roseau.load_flow.network.electrical_network import _PHASE_DTYPE, _VOLTAGE_PHASES_DTYPE
+from roseau.load_flow.network import _PHASE_DTYPE, _VOLTAGE_PHASES_DTYPE, ElectricalNetwork
 
 
 @pytest.fixture()
@@ -50,7 +49,8 @@ def small_network() -> ElectricalNetwork:
         branches=[line],
         loads=[load],
         voltage_sources=[vs],
-        special_elements=[pref, ground],
+        grounds=[ground],
+        potential_refs=[pref],
     )
 
 
@@ -86,7 +86,8 @@ def single_phase_network() -> ElectricalNetwork:
         branches=[line],
         loads=[load],
         voltage_sources=[vs],
-        special_elements=[pref, ground],
+        grounds=[ground],
+        potential_refs=[pref],
     )
 
 
@@ -211,7 +212,14 @@ def test_bad_networks():
     vs = VoltageSource("vs", bus0, phases="abcn", voltages=voltages)
     switch = Switch("switch", bus0, bus1, phases="abcn")
     with pytest.raises(RoseauLoadFlowException) as e:
-        ElectricalNetwork([bus0, bus1], [line, switch], [], [vs], [ground, p_ref])  # no bus2
+        ElectricalNetwork(
+            buses=[bus0, bus1],  # no bus2
+            branches=[line, switch],
+            loads=[],
+            voltage_sources=[vs],
+            grounds=[ground],
+            potential_refs=[p_ref],
+        )
     assert "but has not been added to the network, you should add it with 'add_element'." in e.value.msg
     assert bus2.id in e.value.msg
     assert e.value.code == RoseauLoadFlowExceptionCode.UNKNOWN_ELEMENT

--- a/roseau/load_flow/utils/tests/test_converters.py
+++ b/roseau/load_flow/utils/tests/test_converters.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from pandas.testing import assert_series_equal
 
-from roseau.load_flow.network.electrical_network import _PHASE_DTYPE
+from roseau.load_flow.network import _PHASE_DTYPE
 from roseau.load_flow.utils.converters import phasor_to_sym, series_phasor_to_sym, sym_to_phasor
 
 


### PR DESCRIPTION
Closes #17 

* Kill "special elements" and separate grounds and potential refs (#17)
* Make network a module. This simplifies the API doc tree while not affecting the module usage. A similar change was made to the buses subpackage first when this repository was created.