### PR TITLE
Transformer phases update

### DIFF
--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -333,8 +333,8 @@ def v0_to_v1_converter(data: JsonDict) -> JsonDict:  # noqa: C901
             branch["type"] = branch_type
             # Transformers have no phases information, we need to infer it from the windings
             w1, w2, _ = TransformerType.extract_windings(transformers_params[params_id]["type"])
-            phases1 = "abcn" if "n" in w1.lower() else "abc"
-            phases2 = "abcn" if "n" in w2.lower() else "abc"
+            phases1 = "abcn" if ("y" in w1.lower() or "z" in w1.lower()) else "abc"
+            phases2 = "abcn" if ("y" in w2.lower() or "z" in w2.lower()) else "abc"
             # Determine the "special element" connected to bus2 of the transformer
             if phases2 == "abcn":  # ground if it has neutral
                 ground["buses"].append({"id": bus2_id, "phase": "n"})

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -51,10 +51,7 @@ class Bus(Element):
         self._check_phases(id, phases=phases)
         self.phases = phases
         if potentials is None:
-            self.initialized = False
             potentials = [0] * len(phases)
-        else:
-            self.initialized = True
         self.potentials = potentials
         self.geometry = geometry
 
@@ -115,7 +112,10 @@ class Bus(Element):
     @classmethod
     def from_dict(cls, data: JsonDict) -> "Bus":
         geometry = cls._parse_geometry(data.get("geometry"))
-        return cls(id=data["id"], phases=data["phases"], geometry=geometry, potentials=data.get("potentials"))
+        potentials = data.get("potentials")
+        if potentials is not None:
+            potentials = [complex(v[0], v[1]) for v in potentials]
+        return cls(id=data["id"], phases=data["phases"], geometry=geometry, potentials=potentials)
 
     def to_dict(self) -> JsonDict:
         res = {"id": self.id, "phases": self.phases}

--- a/roseau/load_flow/models/core.py
+++ b/roseau/load_flow/models/core.py
@@ -193,7 +193,7 @@ class Ground(Element):
                 A unique ID of the ground in the network grounds.
         """
         super().__init__(id, **kwargs)
-        self.phases: dict[Id, str] = {}
+        self._bus_phases: dict[Id, str] = {}
         """A map of bus id to phase connected to this ground."""
 
     def __repr__(self) -> str:
@@ -210,25 +210,25 @@ class Ground(Element):
                 The phase of the connection. It must be one of ``{"a", "b", "c", "n"}`` and must be
                 present in the bus phases. Defaults to ``"n"``.
         """
-        self._check_phases(id, phases=phase)
+        self._check_phases(self.id, phases=phase)
         if phase not in bus.phases:
             msg = f"Cannot connect a ground to phase {phase!r} of bus {bus.id!r} that has phases {bus.phases!r}."
             logger.error(msg)
             raise RoseauLoadFlowException(msg, RoseauLoadFlowExceptionCode.BAD_PHASE)
         self._connect(bus)
-        self.phases[bus.id] = phase
+        self._bus_phases[bus.id] = phase
 
     @classmethod
     def from_dict(cls, data: JsonDict) -> "Ground":
         self = cls(data["id"])
-        self.phases = data["buses"]
+        self._bus_phases = data["buses"]
         return self
 
     def to_dict(self) -> JsonDict:
         # Shunt lines and potential references will have the ground in their dict not here.
         return {
             "id": self.id,
-            "buses": [{"id": bus_id, "phase": phase} for bus_id, phase in self.phases.items()],
+            "buses": [{"id": bus_id, "phase": phase} for bus_id, phase in self._bus_phases.items()],
         }
 
 

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -78,7 +78,9 @@ class Transformer(AbstractBranch):
         if phases1 is None:
             phases1 = "abcn" if w1_has_neutral else "abc"
             phases1 = "".join(p for p in bus1.phases if p in phases1)
+            self._check_phases(id, phases1=phases1)
         else:
+            self._check_phases(id, phases1=phases1)
             # Check that the phases are in the bus
             phases_not_in_bus1 = set(phases1) - set(bus1.phases)
             if phases_not_in_bus1:
@@ -97,12 +99,13 @@ class Transformer(AbstractBranch):
                 )
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
-        self._check_phases(id, phases1=phases1)
 
         if phases2 is None:
             phases2 = "abcn" if w2_has_neutral else "abc"
             phases2 = "".join(p for p in bus2.phases if p in phases2)
+            self._check_phases(id, phases2=phases2)
         else:
+            self._check_phases(id, phases2=phases2)
             # Check that the phases are in the bus
             phases_not_in_bus2 = set(phases2) - set(bus2.phases)
             if phases_not_in_bus2:
@@ -121,7 +124,6 @@ class Transformer(AbstractBranch):
                 )
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
-        self._check_phases(id, phases2=phases2)
 
         super().__init__(id, bus1, bus2, phases1=phases1, phases2=phases2, geometry=geometry, **kwargs)
         self._parameters = parameters

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -77,43 +77,52 @@ class Transformer(AbstractBranch):
         w2_has_neutral = "y" in parameters.winding2.lower() or "z" in parameters.winding2.lower()
         if phases1 is None:
             phases1 = "abcn" if w1_has_neutral else "abc"
+            phases1 = "".join(p for p in bus1.phases if p in phases1)
         else:
-            self._check_phases(id, phases1=phases1)
-            if not w1_has_neutral and "n" in phases1:
+            # Check that the phases are in the bus
+            phases_not_in_bus1 = set(phases1) - set(bus1.phases)
+            if phases_not_in_bus1:
+                msg = (
+                    f"Phases (1) {sorted(phases_not_in_bus1)} of transformer {id!r} are not in phases "
+                    f"{bus1.phases!r} of bus {bus1.id!r}."
+                )
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
+            transformer_phases = "abcn" if w1_has_neutral else "abc"
+            phases_not_in_transformer = set(phases1) - set(transformer_phases)
+            if phases_not_in_transformer:
                 msg = (
                     f"Phases (1) {phases1!r} of transformer {id!r} are not compatible with its "
                     f"winding {parameters.winding1!r}."
                 )
                 logger.error(msg)
-                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_WINDINGS)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
+        self._check_phases(id, phases1=phases1)
+
         if phases2 is None:
             phases2 = "abcn" if w2_has_neutral else "abc"
+            phases2 = "".join(p for p in bus2.phases if p in phases2)
         else:
-            self._check_phases(id, phases2=phases2)
-            if not w2_has_neutral and "n" in phases2:
+            # Check that the phases are in the bus
+            phases_not_in_bus2 = set(phases2) - set(bus2.phases)
+            if phases_not_in_bus2:
+                msg = (
+                    f"Phases (2) {sorted(phases_not_in_bus2)} of transformer {id!r} are not in phases "
+                    f"{bus2.phases!r} of bus {bus2.id!r}."
+                )
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
+            transformer_phases = "abcn" if w2_has_neutral else "abc"
+            phases_not_in_transformer = set(phases2) - set(transformer_phases)
+            if phases_not_in_transformer:
                 msg = (
                     f"Phases (2) {phases2!r} of transformer {id!r} are not compatible with its "
                     f"winding {parameters.winding2!r}."
                 )
                 logger.error(msg)
-                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_WINDINGS)
-        # Check that the phases are in the bus (computed or provided)
-        phases_not_in_bus1 = set(phases1) - set(bus1.phases)
-        if phases_not_in_bus1:
-            msg = (
-                f"Phases (1) {sorted(phases_not_in_bus1)} of transformer {id!r} are not in phases "
-                f"{bus1.phases!r} of bus {bus1.id!r}."
-            )
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
-        phases_not_in_bus2 = set(phases2) - set(bus2.phases)
-        if phases_not_in_bus2:
-            msg = (
-                f"Phases (2) {sorted(phases_not_in_bus2)} of transformer {id!r} are not in phases "
-                f"{bus2.phases!r} of bus {bus2.id!r}."
-            )
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
+        self._check_phases(id, phases2=phases2)
+
         super().__init__(id, bus1, bus2, phases1=phases1, phases2=phases2, geometry=geometry, **kwargs)
         self._parameters = parameters
 

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -73,13 +73,13 @@ class Transformer(AbstractBranch):
 
         self.tap = tap
         # Compute the phases if not provided, check them if provided
-        w1_has_neutral = "n" in parameters.winding1.lower()
-        w2_has_neutral = "n" in parameters.winding2.lower()
+        w1_has_neutral = "y" in parameters.winding1.lower() or "z" in parameters.winding1.lower()
+        w2_has_neutral = "y" in parameters.winding2.lower() or "z" in parameters.winding2.lower()
         if phases1 is None:
             phases1 = "abcn" if w1_has_neutral else "abc"
         else:
             self._check_phases(id, phases1=phases1)
-            if (w1_has_neutral and "n" not in phases1) or (not w1_has_neutral and "n" in phases1):
+            if not w1_has_neutral and "n" in phases1:
                 msg = (
                     f"Phases (1) {phases1!r} of transformer {id!r} are not compatible with its "
                     f"winding {parameters.winding1!r}."
@@ -90,7 +90,7 @@ class Transformer(AbstractBranch):
             phases2 = "abcn" if w2_has_neutral else "abc"
         else:
             self._check_phases(id, phases2=phases2)
-            if (w2_has_neutral and "n" not in phases2) or (not w2_has_neutral and "n" in phases2):
+            if not w2_has_neutral and "n" in phases2:
                 msg = (
                     f"Phases (2) {phases2!r} of transformer {id!r} are not compatible with its "
                     f"winding {parameters.winding2!r}."

--- a/roseau/load_flow/tests/data/networks/mv_lv_transformers/network_impedance.json
+++ b/roseau/load_flow/tests/data/networks/mv_lv_transformers/network_impedance.json
@@ -193,7 +193,7 @@
         {
             "id": "line2",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 3,
@@ -235,7 +235,7 @@
         {
             "id": "line5",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abc",
             "bus1": 1,
             "bus2": 6,
@@ -249,7 +249,7 @@
         {
             "id": "line6",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 7,
@@ -277,7 +277,7 @@
         {
             "id": "line8",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 9,
@@ -319,7 +319,7 @@
         {
             "id": "line11",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abc",
             "bus1": 1,
             "bus2": 12,
@@ -333,7 +333,7 @@
         {
             "id": "line12",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 13,

--- a/roseau/load_flow/tests/data/networks/mv_lv_transformers/network_power.json
+++ b/roseau/load_flow/tests/data/networks/mv_lv_transformers/network_power.json
@@ -193,7 +193,7 @@
         {
             "id": "line2",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 3,
@@ -235,7 +235,7 @@
         {
             "id": "line5",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abc",
             "bus1": 1,
             "bus2": 6,
@@ -249,7 +249,7 @@
         {
             "id": "line6",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 7,
@@ -277,7 +277,7 @@
         {
             "id": "line8",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 9,
@@ -319,7 +319,7 @@
         {
             "id": "line11",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abc",
             "bus1": 1,
             "bus2": 12,
@@ -333,7 +333,7 @@
         {
             "id": "line12",
             "type": "transformer",
-            "phases1": "abc",
+            "phases1": "abcn",
             "phases2": "abcn",
             "bus1": 1,
             "bus2": 13,

--- a/roseau/load_flow/tests/test_phases.py
+++ b/roseau/load_flow/tests/test_phases.py
@@ -221,22 +221,24 @@ def test_transformer_phases():
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_PHASE
     assert e.value.msg == "Phases (2) ['n'] of transformer 'tr1' are not in phases 'abc' of bus 'bus-2'."
 
-    # Bad phases
+    # Not in transformer
+    bus1.phases = "abcn"
     bus2.phases = "abcn"
     with pytest.raises(RoseauLoadFlowException) as e:
-        Transformer("tr1", bus1, bus2, phases1="abc", phases2="abc", parameters=tp)
-    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_WINDINGS
-    assert e.value.msg == "Phases (2) 'abc' of transformer 'tr1' are not compatible with its winding 'yn'."
+        Transformer("tr1", bus1, bus2, phases1="abcn", phases2="abcn", parameters=tp)
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_PHASE
+    assert e.value.msg == "Phases (1) 'abcn' of transformer 'tr1' are not compatible with its winding 'D'."
 
     # Default
+    bus1.phases = "abc"
+    bus2.phases = "abcn"
     transformer = Transformer(id="tr1", bus1=bus1, bus2=bus2, parameters=tp, length=10)
     assert transformer.phases1 == "abc"
     assert transformer.phases2 == "abcn"
 
-    # Bad default
-    bus1.phases = "abc"
-    bus2.phases = "abc"
-    with pytest.raises(RoseauLoadFlowException) as e:
-        Transformer("tr1", bus1, bus2, parameters=tp)
-    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_PHASE
-    assert e.value.msg == "Phases (2) ['n'] of transformer 'tr1' are not in phases 'abc' of bus 'bus-2'."
+    # Intersection
+    bus1.phases = "abcn"
+    bus2.phases = "abcn"
+    transformer = Transformer(id="tr1", bus1=bus1, bus2=bus2, parameters=tp, length=10)
+    assert transformer.phases1 == "abc"
+    assert transformer.phases2 == "abcn"


### PR DESCRIPTION
Instead of checking if there is a `"n"` in the transformer parameter for the default phases, I prefer to have the intersection between the bus phases and `"abcn"` for `"y/z"` or `"abc"` for `"d"` winding. It seems more coherent with the connections of the other elements of the API (especially the lines) which we could describe as "by default connect everything we can and check that this is coherent with the models we have".

It also seems more natural to me that the phases are **not** determined by a transformer parameter, because a parameter should not define the way the transformer is connected. So with that change, the phases are now determined when the connection is made.

I changed the checks accordingly.

*I'm going to let this PR open for now if I need other changes for `engine`.*