### PR TITLE
Small fixes

### DIFF
--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -50,8 +50,9 @@ class AbstractLoad(Element, metaclass=ABCMeta):
         else:
             self._check_phases(id, phases=phases)
             # Also check they are in the bus phases
-            phases_not_in_bus = set(phases) - set(bus.phases) - {"n"}  # "n" is allowed to be absent
-            if phases_not_in_bus:
+            phases_not_in_bus = set(phases) - set(bus.phases)
+            if phases_not_in_bus and not (phases_not_in_bus == {"n"} and len(phases) > 2):
+                # "n" is allowed to be absent from the bus only if the load has more than 2 phases
                 msg = (
                     f"Phases {sorted(phases_not_in_bus)} of load {id!r} are not in bus {bus.id!r} "
                     f"phases {bus.phases!r}"

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -65,7 +65,11 @@ class AbstractLoad(Element, metaclass=ABCMeta):
         self.bus = bus
         self._symbol = {"power": "S", "current": "I", "impedance": "Z"}[self._type]
         self._unit = {"power": "VA", "current": "A", "impedance": "ohm"}[self._type]
-        self._size = len(set(self.phases) - {"n"})
+        if len(phases) == 2 and "n" not in phases:
+            # This is a delta load that has one element connected between two phases
+            self._size = 1
+        else:
+            self._size = len(set(phases) - {"n"})
 
         # Results
         self._res_currents: Optional[np.ndarray] = None

--- a/roseau/load_flow/models/voltage_sources.py
+++ b/roseau/load_flow/models/voltage_sources.py
@@ -57,8 +57,9 @@ class VoltageSource(Element):
         else:
             self._check_phases(id, phases=phases)
             # Also check they are in the bus phases
-            phases_not_in_bus = set(phases) - set(bus.phases) - {"n"}  # "n" is allowed to be absent
-            if phases_not_in_bus:
+            phases_not_in_bus = set(phases) - set(bus.phases)
+            if phases_not_in_bus and not (phases_not_in_bus == {"n"} and len(phases) > 2):
+                # "n" is allowed to be absent from the bus only if the source has more than 2 phases
                 msg = (
                     f"Phases {sorted(phases_not_in_bus)} of source {id!r} are not in bus "
                     f"{bus.id!r} phases {bus.phases!r}"

--- a/roseau/load_flow/models/voltage_sources.py
+++ b/roseau/load_flow/models/voltage_sources.py
@@ -66,7 +66,11 @@ class VoltageSource(Element):
                 )
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
-        self._size = len(set(phases) - {"n"})
+        if len(phases) == 2 and "n" not in phases:
+            # This is a delta source that has one element connected between two phases
+            self._size = 1
+        else:
+            self._size = len(set(phases) - {"n"})
 
         self.phases = phases
         self.bus = bus

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -775,6 +775,7 @@ class ElectricalNetwork:
             res = {"id": load.id, "phases": load.phases, "currents": [[i.real, i.imag] for i in load.res_currents]}
             if isinstance(load, PowerLoad) and load.is_flexible:
                 res["powers"] = [[s.real, s.imag] for s in load.res_flexible_powers]
+            loads_results.append(res)
 
         return {
             "info": self._results_info,

--- a/roseau/load_flow/tests/test_phases.py
+++ b/roseau/load_flow/tests/test_phases.py
@@ -64,8 +64,8 @@ def test_loads_phases():
         assert e.value.msg.startswith(f"PowerLoad of id 'load1' got invalid phases '{ph}', allowed values are")
 
     # Allowed
-    for ph in ("ab", "abc", "abcn"):
-        PowerLoad("load1", bus, phases=ph, powers=[100] * len(set(ph) - {"n"}))
+    for ph, n in (("ab", 1), ("abc", 3), ("abcn", 3)):
+        PowerLoad("load1", bus, phases=ph, powers=[100] * n)
 
     # Not in bus
     bus.phases = "ab"
@@ -83,9 +83,9 @@ def test_loads_phases():
     assert e.value.msg == "Phases ['n'] of load 'load1' are not in bus 'bus' phases 'ab'"
 
     # Default
-    for ph in ("ab", "abc", "abcn"):
+    for ph, n in (("ab", 1), ("abc", 3), ("abcn", 3)):
         bus.phases = ph
-        load = PowerLoad("load1", bus, phases=ph, powers=[100] * len(set(ph) - {"n"}))
+        load = PowerLoad("load1", bus, phases=ph, powers=[100] * n)
         assert load.phases == ph
 
 
@@ -102,8 +102,8 @@ def test_sources_phases():
         assert e.value.msg.startswith(f"VoltageSource of id 'source1' got invalid phases '{ph}', allowed values are")
 
     # Allowed
-    for ph in ("ab", "abc", "abcn"):
-        VoltageSource("source1", bus, phases=ph, voltages=[100] * len(set(ph) - {"n"}))
+    for ph, n in (("ab", 1), ("abc", 3), ("abcn", 3)):
+        VoltageSource("source1", bus, phases=ph, voltages=[100] * n)
 
     # Not in bus
     bus.phases = "ab"
@@ -121,9 +121,9 @@ def test_sources_phases():
     assert e.value.msg == "Phases ['n'] of source 'source1' are not in bus 'bus' phases 'ab'"
 
     # Default
-    for ph in ("ab", "abc", "abcn"):
+    for ph, n in (("ab", 1), ("abc", 3), ("abcn", 3)):
         bus.phases = ph
-        vs = VoltageSource("source1", bus, voltages=[100] * len(set(ph) - {"n"}))
+        vs = VoltageSource("source1", bus, voltages=[100] * n)
         assert vs.phases == ph
 
 

--- a/roseau/load_flow/tests/test_phases.py
+++ b/roseau/load_flow/tests/test_phases.py
@@ -76,6 +76,11 @@ def test_loads_phases():
 
     # "n" not in bus is allowed though
     PowerLoad("load1", bus, phases="abn", powers=[100, 100])
+    # unless it is a single phase load
+    with pytest.raises(RoseauLoadFlowException) as e:
+        PowerLoad("load1", bus, phases="an", powers=[100])
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_PHASE
+    assert e.value.msg == "Phases ['n'] of load 'load1' are not in bus 'bus' phases 'ab'"
 
     # Default
     for ph in ("ab", "abc", "abcn"):
@@ -109,6 +114,11 @@ def test_sources_phases():
 
     # "n" not in bus is allowed though
     VoltageSource("source1", bus, phases="abn", voltages=[100, 100])
+    # unless it is a single phase source
+    with pytest.raises(RoseauLoadFlowException) as e:
+        VoltageSource("source1", bus, phases="an", voltages=[100])
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_PHASE
+    assert e.value.msg == "Phases ['n'] of source 'source1' are not in bus 'bus' phases 'ab'"
 
     # Default
     for ph in ("ab", "abc", "abcn"):


### PR DESCRIPTION
* `ElectricalNetwork.results_to_dict` did ot return the load results
* Single phase loads (PN) loads and sources require a Wye bus
* Fix the size check of delta elements that are connected between two phases only.