### PR TITLE
Floating neutrals in loads and sources do not work yet

### DIFF
--- a/roseau/load_flow/io/tests/test_dgs.py
+++ b/roseau/load_flow/io/tests/test_dgs.py
@@ -1,7 +1,11 @@
+from roseau.load_flow.models import AbstractLoad, VoltageSource
 from roseau.load_flow.network import ElectricalNetwork
 
 
-def test_from_dgs(dgs_network_path):
+def test_from_dgs(dgs_network_path, monkeypatch):
+    # Test with floating neutral (monkeypatch the whole test function)
+    monkeypatch.setattr(AbstractLoad, "_floating_neutral_allowed", True)
+    monkeypatch.setattr(VoltageSource, "_floating_neutral_allowed", True)
     # Read DGS
     en = ElectricalNetwork.from_dgs(dgs_network_path)
     # Check the validity of the network

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -6,6 +6,7 @@ from roseau.load_flow import Line
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.io.dict import v0_to_v1_converter
 from roseau.load_flow.models import (
+    AbstractLoad,
     Bus,
     Ground,
     LineParameters,
@@ -78,8 +79,11 @@ def test_to_dict():
     en.to_dict()
 
 
-def test_v0_to_v1_converter():
+def test_v0_to_v1_converter(monkeypatch):
     # Do not change `dict_v0` or the network manually, add/update the converters until the test passes
+
+    # Test with floating neutral (monkeypatch the whole test function)
+    monkeypatch.setattr(AbstractLoad, "_floating_neutral_allowed", True)
     dict_v0 = {
         "buses": [
             {

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -25,6 +25,7 @@ class AbstractLoad(Element, metaclass=ABCMeta):
     _flexible_parameter_class = FlexibleParameter
 
     _type: Literal["power", "current", "impedance"]
+    _floating_neutral_allowed: bool = False
 
     allowed_phases = Bus.allowed_phases
 
@@ -51,8 +52,9 @@ class AbstractLoad(Element, metaclass=ABCMeta):
             self._check_phases(id, phases=phases)
             # Also check they are in the bus phases
             phases_not_in_bus = set(phases) - set(bus.phases)
-            if phases_not_in_bus and not (phases_not_in_bus == {"n"} and len(phases) > 2):
-                # "n" is allowed to be absent from the bus only if the load has more than 2 phases
+            # "n" is allowed to be absent from the bus only if the load has more than 2 phases
+            floating_neutral = self._floating_neutral_allowed and phases_not_in_bus == {"n"} and len(phases) > 2
+            if phases_not_in_bus and not floating_neutral:
                 msg = (
                     f"Phases {sorted(phases_not_in_bus)} of load {id!r} are not in bus {bus.id!r} "
                     f"phases {bus.phases!r}"

--- a/roseau/load_flow/models/voltage_sources.py
+++ b/roseau/load_flow/models/voltage_sources.py
@@ -27,6 +27,7 @@ class VoltageSource(Element):
     """
 
     allowed_phases = Bus.allowed_phases
+    _floating_neutral_allowed: bool = False
 
     def __init__(
         self, id: Id, bus: Bus, *, voltages: Sequence[complex], phases: Optional[str] = None, **kwargs: Any
@@ -58,8 +59,9 @@ class VoltageSource(Element):
             self._check_phases(id, phases=phases)
             # Also check they are in the bus phases
             phases_not_in_bus = set(phases) - set(bus.phases)
-            if phases_not_in_bus and not (phases_not_in_bus == {"n"} and len(phases) > 2):
-                # "n" is allowed to be absent from the bus only if the source has more than 2 phases
+            # "n" is allowed to be absent from the bus only if the load has more than 2 phases
+            floating_neutral = self._floating_neutral_allowed and phases_not_in_bus == {"n"} and len(phases) > 2
+            if phases_not_in_bus and not floating_neutral:
                 msg = (
                     f"Phases {sorted(phases_not_in_bus)} of source {id!r} are not in bus "
                     f"{bus.id!r} phases {bus.phases!r}"


### PR DESCRIPTION
Disallow floating neutrals in loads and sources as they do not work as expected.