### PR TITLE
Only build conda package on the main branch

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - '*'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 env:
   CI: true


### PR DESCRIPTION
Building the conda package is a long process and is not really required unless we want to release a new version. Since releases only happen on the main branch, we only need to build when the main branch changes.