### PR TITLE
Fix failing doc builds

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,8 +24,6 @@ jobs:
           sudo apt -yq --no-install-suggests --no-install-recommends install pandoc make
 
       - uses: actions/checkout@v3
-        with:
-          lfs: false
 
       - name: Create LFS file list
         run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
@@ -34,9 +32,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .git/lfs
-          key: git-lfs-v1-${{ matrix.python-version }}-${{ hashFiles('.lfs-assets-id') }}
+          key: git-lfs-v1-${{ hashFiles('.lfs-assets-id') }}
           restore-keys: |
-            git-lfs-v1-${{ matrix.python-version }}
             git-lfs-v1
             git-lfs
 
@@ -52,7 +49,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -71,20 +68,20 @@ jobs:
           SPHINXBUILD: poetry run sphinx-build
 
       - name: Upload pages artifact
-        if: ${{ github.event_name == "pull_request" && github.base_ref == "main" && github.event.action == "closed" && github.event.pull_request.merged == true }}
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
         uses: actions/upload-pages-artifact@v1
         with:
           path: "build/html/"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
-        if: ${{ github.event_name != "pull_request" || github.base_ref != "main" }}
+        if: ${{ github.event_name != 'pull_request' || github.base_ref != 'main' }}
         with:
           path: "build/html/"
 
   # Deployment job
   deploy:
-    if: ${{ github.event_name == "pull_request" && github.base_ref == "main" && github.event.action == "closed" && github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,6 +24,8 @@ jobs:
           sudo apt -yq --no-install-suggests --no-install-recommends install pandoc make
 
       - uses: actions/checkout@v3
+        with:
+          lfs: false
 
       - name: Create LFS file list
         run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id


### PR DESCRIPTION
This is an attempt to fix the failing doc builds. I used https://rhysd.github.io/actionlint/ to detect the errors.

Examples of failing builds:
* https://github.com/RoseauTechnologies/Roseau_Load_Flow/actions/runs/3940006672
* https://github.com/RoseauTechnologies/Roseau_Load_Flow/actions/runs/3939868535

The failure is the following:

```
Invalid workflow file: .github/workflows/doc.yml#L74
The workflow is not valid. .github/workflows/doc.yml (Line: 74, Col: 13): Unexpected symbol: '"pull_request"'. Located at position 22 within expression: github.event_name == "pull_request" && github.base_ref == "main" && github.event.action == "closed" && github.event.pull_request.merged == true .github/workflows/doc.yml (Line: 81, Col: 13): Unexpected symbol: '"pull_request"'. Located at position 22 within expression: github.event_name != "pull_request" || github.base_ref != "main"
```