### PR TITLE
Fix default phases for lines where the second becomes 'ac'

### DIFF
--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -57,6 +57,7 @@ class Switch(AbstractBranch):
         """
         if phases is None:
             phases = "".join(p for p in bus1.phases if p in bus2.phases)  # can't use set because order is important
+            phases = phases.replace("ac", "ca")
         else:
             # Also check they are in the intersection of buses phases
             self._check_phases(id, phases=phases)
@@ -190,6 +191,7 @@ class Line(AbstractBranch):
         """
         if phases is None:
             phases = "".join(p for p in bus1.phases if p in bus2.phases)  # can't use set because order is important
+            phases = phases.replace("ac", "ca")
         else:
             # Also check they are in the intersection of buses phases
             self._check_phases(id, phases=phases)

--- a/roseau/load_flow/models/tests/test_phases.py
+++ b/roseau/load_flow/models/tests/test_phases.py
@@ -168,10 +168,10 @@ def test_lines_phases():
 
     # Default
     bus1.phases = "abcn"
-    bus2.phases = "ab"
+    bus2.phases = "ca"
     lp = LineParameters("test", z_line=10 * np.eye(2, dtype=complex))
     line = Line("line1", bus1, bus2, parameters=lp, length=10)
-    assert line.phases == line.phases1 == line.phases2 == "ab"
+    assert line.phases == line.phases1 == line.phases2 == "ca"
 
     # Bad default
     lp = LineParameters("test", z_line=10 * np.eye(3, dtype=complex))  # bad
@@ -212,9 +212,9 @@ def test_switches_phases():
 
     # Default
     bus1 = Bus("bus-1", phases="abcn")
-    bus2 = Bus("bus-2", phases="ab")
+    bus2 = Bus("bus-2", phases="ca")
     switch = Switch("switch1", bus1, bus2)
-    assert switch.phases == switch.phases1 == switch.phases2 == "ab"
+    assert switch.phases == switch.phases1 == switch.phases2 == "ca"
 
 
 def test_transformer_phases():


### PR DESCRIPTION
Fix a bug where the default phases for a line connected to a `abcn` bus and a `ca` bus yields `ac` as the intersection instead of  `ca`