### PR TITLE
Improve installations docs and API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 
 ## Installation ##
 
-The simplest way is to download the docker container attached to this repository and to start it. It will start a
-Jupyterlab session with all the required packages installed.
+The simplest way is to download the docker container attached to this repository and to start it.
+It will start a Jupyterlab session with all the required packages installed.
 
-The entire documentation is available via [GitHub pages](https://roseautechnologies.github.io/Roseau_Load_Flow/)
+The project can also be installed via `pip` or `conda`. Please see the [Installation](https://roseautechnologies.github.io/Roseau_Load_Flow/installation.html) page for more details.
+
+## Documentation ##
+
+The documentation contianing the installation instructions, tutorials, and the API index is
+available at https://roseautechnologies.github.io/Roseau_Load_Flow/
 
 ## Usage ##
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,16 +37,14 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
     "nbsphinx",
     "autoapi.extension",
 ]
 
-napoleon_numpy_docstring = False
-autodoc_default_options = {"ignore-module-all": False}
-autodoc_member_order = "bysource"
-autodoc_typehints = "signature"
-python_use_unqualified_type_names = True
 add_module_names = False
+napoleon_numpy_docstring = False
+python_use_unqualified_type_names = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -63,6 +61,12 @@ language = "en"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# -- Options for autodoc ----------------------------------------------------
+autodoc_default_options = {"ignore-module-all": False}
+autodoc_member_order = "bysource"
+autodoc_typehints = "signature"
+autodoc_inherit_docstrings = True
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -74,7 +78,7 @@ html_title = f"{release}"
 html_logo = "_static/Logo_Roseau_Technologies_Without_Baseline.png"
 html_favicon = "_static/Favicon_Roseau_Technologies.ico"
 html_theme_options = {
-    # "source_repository": "https://github.com/RoseauTechnologies/SIRAO_Documentation/",
+    "source_repository": "https://github.com/RoseauTechnologies/Roseau_Load_Flow/",
     # "source_branch": "main",
     # "source_directory": "source/",
     # "sidebar_hide_name": True,
@@ -96,11 +100,23 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-# AutoAPI
-autoapi_dirs = ["../roseau"]
-autoapi_ignore = ["**/tests/**", "**/conftest.py"]
-autoapi_options = ["members", "undoc-members", "show-inheritance", "show-module-summary", "imported-members"]
-autoapi_python_class_content = "both"  # without this, the __init__ docstring is not shown
-
 # Extra CSS files
 html_css_files = ["css/custom.css"]
+
+# -- Options for AutoAPI -------------------------------------------------
+autoapi_dirs = ["../roseau"]
+autoapi_ignore = ["**/tests/**", "**/conftest.py", "__about__.py"]
+autoapi_options = ["members", "show-inheritance", "show-module-summary", "imported-members"]
+autoapi_python_class_content = "both"  # without this, the __init__ docstring is not shown
+autoapi_python_use_implicit_namespaces = True
+
+# -- Options for intersphinx -------------------------------------------------
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "shapely": ("https://shapely.readthedocs.io/en/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "geopandas": ("https://geopandas.org/en/stable/", None),
+    "requests": ("https://requests.readthedocs.io/en/latest/", None),
+    "pint": ("https://pint.readthedocs.io/en/stable/", None),
+}

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,7 @@
 # Roseau Load Flow
 
-`Roseau Load Flow` is a load flow solver, capable of modeling 3 phases unbalanced networks with a wide variety of
-line, transformer, load and flexible load models.
+`Roseau Load Flow` is a load flow solver, capable of modeling 3 phases unbalanced networks with a
+wide variety of line, transformer, load and flexible load models.
 
 ## Installation
 
@@ -39,10 +39,4 @@ maxdepth: 3
 caption: API
 ---
 autoapi/roseau/load_flow/index
-```
-
-<!-- to suppress the warning from sphinx -->
-```{toctree}
-:hidden:
-autoapi/index
 ```

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,3 +1,46 @@
+# Using `pip` #
+
+`roseau_load_flow` is available on [PyPI](https://pypi.org/project/roseau-load-flow/). If you are
+using pip, you can install it with:
+```sh
+python -m pip install roseau-load-flow
+```
+
+```{tip}
+   It is recommended to work in a virtual environment. You can create one with:
+
+   `python -m venv venv`
+
+   and activate it with:
+
+   * `source venv/bin/activate` on Linux and macOS;
+   * and `venv\Scripts\activate.bat` on Windows.
+```
+
+To upgrade to the latest version (recommended), use:
+```sh
+python -m pip install --upgrade roseau-load-flow
+```
+
+# Using `conda` #
+
+If you use *conda* to manage your project, **it is recommended to use the `conda` package manager
+instead of *pip***. To install `roseau_load_flow` via `conda`, please go the release page of the
+GitHub repository [here](https://github.com/RoseauTechnologies/Roseau_Load_Flow/releases/) and
+download the latest available *Conda archive* (Click on the file that ends with `.tar.bz2`). It can
+then be installed via the following command (in this example, the installed version is 0.2.1):
+
+```sh
+conda install <PATH TO THE FILE roseau-load-flow-0.2.1-py310_0.tar.bz2>
+```
+
+```{note}
+Always install the latest version available which is conveniently marked *latest* by GitHub as
+shown here:
+
+![GitHub Latest Release](_static/2022_11_23_GH_Latest_Release.png)
+```
+
 # Using `docker` #
 
 `roseau_load_flow` provides a *docker* image with all required dependencies to run the software, including *Python*,
@@ -73,44 +116,6 @@ your docker environment, follow the steps that correspond to your operating syst
 6. Open your web browser and go to [http://localhost:8080](http://localhost:8080) to find the interface of the
    JupyterLab of the container.  A basic python environment is already installed with the `roseau_load_flow` package
    already installed.
-
-# Using `pip` #
-
-If you desire to install the `roseau_load_flow` package via `pip`, please go the release page of the GitHub repository
-[here](https://github.com/RoseauTechnologies/Roseau_Load_Flow/releases/) and download the latest available *Wheel*
-(Click on the file that ends with `.whl`). It can then be installed via the following command (here, the installed
-version is 0.2.1):
-
-```console
-$ python -m pip install <PATH TO THE FILE roseau_load_flow-0.2.1-py3-none-any.whl>
-```
-
-```{note}
-Always install the latest version available which is conveniently marked *latest* by GitHub as
-shown here:
-
-![GitHub Latest Release](_static/2022_11_23_GH_Latest_Release.png)
-```
-
-
-# Using `conda` #
-
-`roseau_load_flow` can also be installed via `conda`. Please go the release page of the GitHub repository
-[here](https://github.com/RoseauTechnologies/Roseau_Load_Flow/releases/) and download the latest available *Conda
-archive* (Click on the file that ends with `.tar.bz2`). It can then be installed via the following command (here, the
-installed version is 0.2.1):
-
-```console
-$ conda install <PATH TO THE FILE roseau-load-flow-0.2.1-py310_0.tar.bz2>
-```
-
-```{note}
-Always install the latest version available which is conveniently marked *latest* by GitHub as
-shown here:
-
-![GitHub Latest Release](_static/2022_11_23_GH_Latest_Release.png)
-```
-
 
 <!-- Local Variables: -->
 <!-- mode: markdown -->

--- a/roseau/load_flow/__init__.py
+++ b/roseau/load_flow/__init__.py
@@ -1,3 +1,10 @@
+"""
+Welcome to the API reference of Roseau Load Flow.
+
+For the most part, public classes and functions can be imported directly from this module.
+
+See Package Contents below for a list of available classes and functions.
+"""
 import importlib.metadata
 
 from roseau.load_flow.__about__ import (

--- a/roseau/load_flow/converters.py
+++ b/roseau/load_flow/converters.py
@@ -1,3 +1,11 @@
+"""
+This module provides helper functions to convert from one representation to another.
+
+Available functions:
+
+* convert between phasor and symmetrical components
+* convert potentials to voltages
+"""
 from collections.abc import Sequence
 
 import numpy as np

--- a/roseau/load_flow/exceptions.py
+++ b/roseau/load_flow/exceptions.py
@@ -1,3 +1,6 @@
+"""
+This module contains the exceptions used by Roseau Load Flow.
+"""
 import unicodedata
 from enum import auto, Enum
 from typing import Union

--- a/roseau/load_flow/io/__init__.py
+++ b/roseau/load_flow/io/__init__.py
@@ -1,3 +1,9 @@
+"""
+This module provides functions to read and write networks from and to different formats.
+
+You do not need to use this module directly, you can read and write networks using the
+corresponding methods of the :class:`~roseau.load_flow.ElectricalNetwork` object.
+"""
 from roseau.load_flow.io.dgs import network_from_dgs
 from roseau.load_flow.io.dict import network_from_dict, network_to_dict
 

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from shapely.geometry import Point
+from shapely import Point
 
 from roseau.load_flow import Line
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode

--- a/roseau/load_flow/models/__init__.py
+++ b/roseau/load_flow/models/__init__.py
@@ -1,3 +1,7 @@
+"""
+This module contains the models used to represent the network elements. The
+models are used to build the network and to perform the load flow analysis.
+"""
 from roseau.load_flow.models.branches import AbstractBranch
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -1,8 +1,8 @@
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import numpy as np
-from shapely.geometry.base import BaseGeometry
+from shapely import LineString, Point
 
 from roseau.load_flow.converters import calculate_voltages
 from roseau.load_flow.models.buses import Bus
@@ -26,7 +26,7 @@ class AbstractBranch(Element):
         *,
         phases1: str,
         phases2: str,
-        geometry: Optional[BaseGeometry] = None,
+        geometry: Optional[Union[Point, LineString]] = None,
         **kwargs: Any,
     ) -> None:
         """AbstractBranch constructor.

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from typing import Any, Optional
 
 import numpy as np
-from shapely.geometry import Point
+from shapely import Point
 
 from roseau.load_flow.converters import calculate_voltage_phases, calculate_voltages
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
@@ -18,6 +18,12 @@ class Bus(Element):
     """An electrical bus."""
 
     allowed_phases = frozenset({"ab", "bc", "ca", "an", "bn", "cn", "abn", "bcn", "can", "abc", "abcn"})
+    """The allowed phases for a bus are:
+
+    - P-P-P or P-P-P-N: ``"abc"``, ``"abcn"``
+    - P-P or P-P-N: ``"ab"``, ``"bc"``, ``"ca"``, ``"abn"``, ``"bcn"``, ``"can"``
+    - P-N: ``"an"``, ``"bn"``, ``"cn"``
+    """
 
     def __init__(
         self,
@@ -40,10 +46,11 @@ class Bus(Element):
                 :attr:`Bus.allowed_phases`.
 
             geometry:
-                The geometry of the bus.
+                An optional geometry of the bus; a :class:`~shapely.Point` that represents the
+                x-y coordinates of the bus.
 
             potentials:
-                List of initial potentials of each phase.
+                An optional list of initial potentials of each phase of the bus.
 
             ground:
                 The ground of the bus.

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -127,18 +127,19 @@ class Line(AbstractBranch):
     """An electrical line PI model with series impedance and optional shunt admittance.
 
     .. math::
-        V_1 &= a \\cdot V_2 - b \\cdot I_2 + g \\cdot V_g \\\\
-        I_1 &= c \\cdot V_2 - d \\cdot I_2 + h \\cdot V_g \\\\
-        I_g &= f^t \\cdot \\left(V_1 + V_2 - 2\\cdot V_g\\right)
+        V_1 &= a \\cdot V_2 - b \\cdot I_2 + g \\cdot V_{\\mathrm{g}} \\\\
+        I_1 &= c \\cdot V_2 - d \\cdot I_2 + h \\cdot V_{\\mathrm{g}} \\\\
+        I_{\\mathrm{g}} &= f^t \\cdot \\left(V_1 + V_2 - 2\\cdot V_{\\mathrm{g}}\\right)
 
     where
 
     .. math::
-        a &= \\mathcal{I}_5 + \\dfrac{1}{2} \\cdot Z \\cdot Y  \\\\
+        a &= \\mathcal{I}_4 + \\dfrac{1}{2} \\cdot Z \\cdot Y  \\\\
         b &= Z  \\\\
         c &= Y + \\dfrac{1}{4}\\cdot Y \\cdot Z \\cdot Y  \\\\
-        d &= \\mathcal{I}_5 + \\dfrac{1}{2} \\cdot Y \\cdot Z  \\\\
-        f &= -\\dfrac{1}{2} \\cdot \\begin{pmatrix} y_{ag} & y_{bg} & y_{cg} &y_{ng} \\end{pmatrix} ^t  \\\\
+        d &= \\mathcal{I}_4 + \\dfrac{1}{2} \\cdot Y \\cdot Z  \\\\
+        f &= -\\dfrac{1}{2} \\cdot \\begin{pmatrix} y_{\\mathrm{ag}} & y_{\\mathrm{bg}} & y_{\\mathrm{cg}} &
+        y_{\\mathrm{ng}} \\end{pmatrix} ^t  \\\\
         g &= Z \\cdot f  \\\\
         h &= 2 \\cdot f + \\frac{1}{2}\\cdot Y \\cdot Z \\cdot f  \\\\
 

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 import numpy as np
 from pint import Quantity
-from shapely.geometry import LineString, Point
+from shapely import LineString, Point
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.branches import AbstractBranch
@@ -24,6 +24,13 @@ class Switch(AbstractBranch):
     branch_type = BranchType.SWITCH
 
     allowed_phases = frozenset(Bus.allowed_phases | {"a", "b", "c", "n"})
+    """The allowed phases for a switch are:
+
+    - P-P-P or P-P-P-N: ``"abc"``, ``"abcn"``
+    - P-P or P-P-N: ``"ab"``, ``"bc"``, ``"ca"``, "abn"``, ``"bcn"``, ``"can"``
+    - P or P-N: ``"a"``, ``"b"``, ``"c"``, ``"an"``, ``"bn"``, ``"cn"``
+    - N: ``"n"``
+    """
 
     def __init__(
         self,
@@ -146,6 +153,13 @@ class Line(AbstractBranch):
     branch_type = BranchType.LINE
 
     allowed_phases = frozenset(Bus.allowed_phases | {"a", "b", "c", "n"})
+    """The allowed phases for a line are:
+
+    - P-P-P or P-P-P-N: ``"abc"``, ``"abcn"``
+    - P-P or P-P-N: ``"ab"``, ``"bc"``, ``"ca"``, "abn"``, ``"bcn"``, ``"can"``
+    - P or P-N: ``"a"``, ``"b"``, ``"c"``, ``"an"``, ``"bn"``, ``"cn"``
+    - N: ``"n"``
+    """
 
     def __init__(
         self,

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -29,6 +29,7 @@ class AbstractLoad(Element, ABC):
     _floating_neutral_allowed: bool = False
 
     allowed_phases = Bus.allowed_phases
+    """The allowed phases for a load are the same as for a :attr:`bus<Bus.allowed_phases>`."""
 
     def __init__(self, id: Id, bus: Bus, *, phases: Optional[str] = None, **kwargs: Any) -> None:
         """AbstractLoad constructor.

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -306,15 +306,15 @@ class CurrentLoad(AbstractLoad):
     The equations are the following (star loads):
 
     .. math::
-        I_{\mathrm{abc}} &= constant \\
+        I_{\mathrm{abc}} &= \mathrm{constant} \\
         I_{\mathrm{n}} &= -\sum_{p\in\{\mathrm{a},\mathrm{b},\mathrm{c}\}}I_{p}
 
     and the following (delta loads):
 
     .. math::
-        I_{\mathrm{ab}} &= constant \\
-        I_{\mathrm{bc}} &= constant \\
-        I_{\mathrm{ca}} &= constant
+        I_{\mathrm{ab}} &= \mathrm{constant} \\
+        I_{\mathrm{bc}} &= \mathrm{constant} \\
+        I_{\mathrm{ca}} &= \mathrm{constant}
     """
 
     _type = "current"

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -28,6 +28,7 @@ class VoltageSource(Element):
     """
 
     allowed_phases = Bus.allowed_phases
+    """The allowed phases for a voltage source are the same as for a :attr:`bus<Bus.allowed_phases>`."""
     _floating_neutral_allowed: bool = False
 
     def __init__(

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-from shapely.geometry import Point
+from shapely import Point
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.branches import AbstractBranch
@@ -22,6 +22,13 @@ class Transformer(AbstractBranch):
     branch_type = BranchType.TRANSFORMER
 
     allowed_phases = frozenset({"abc", "abcn"})  # Only these for now
+    """The allowed phases for a transformer are:
+
+    - P-P-P or P-P-P-N: ``"abc"``, ``"abcn"``
+
+    .. note::
+        Only 3-phase transformers are supported for now.
+    """
 
     def __init__(
         self,

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -88,8 +88,10 @@ class ElectricalNetwork:
 
     Attributes:
         DEFAULT_PRECISION (float):
-            The default precision needed for the convergence of the load flow algorithm. The solver
-            stops when the error between two iterations is below this value. Default is 1e-6.
+            The default precision needed for the convergence of the load flow algorithm. At each
+            iteration, the solver computes the residuals of the equations of the problem. When the
+            maximum of the absolute values of the residuals vector is lower than the provided
+            precision, the solver stops. Default is 1e-6.
 
         DEFAULT_MAX_ITERATIONS (int):
             Maximum number of iterations to perform the load flow analysis. The solver stops when
@@ -823,7 +825,8 @@ class ElectricalNetwork:
         The results are returned as a dataframe with the following index:
             - `potential_ref_id`: The id of the potential reference.
         and the following columns:
-            - `current`: The complex current of the potential reference (in Amps).
+            - `current`: The complex current of the potential reference (in Amps). If the load flow
+                converged, this should be zero.
         """
         self._warn_invalid_results()
         res_dict = {"potential_ref_id": [], "current": []}

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 import requests_mock
 from pandas.testing import assert_frame_equal
-from shapely.geometry import LineString, Point
+from shapely import LineString, Point
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models import (

--- a/roseau/load_flow/typing.py
+++ b/roseau/load_flow/typing.py
@@ -1,19 +1,36 @@
-"""Aliases for types used in the load flow module.
+"""
+Type Aliases used by Roseau Load Flow.
 
-These will help users to get better IDE support.
+.. class:: Id
+
+    The type of the identifier of an element.
+
+.. class:: JsonDict
+
+    A dictionary that can be serialized to JSON.
+
+.. class:: StrPath
+
+    The accepted type for files of roseau.load_flow.io.
+
+.. class:: Self
+
+    The type of the class itself.
 """
 import os
 import sys
 from typing import Any, TYPE_CHECKING, TypeVar, Union
 
-Id = Union[int, str]
-"""The type of the identifier of an element."""
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias as TypeAlias
+elif TYPE_CHECKING:
+    from typing_extensions import TypeAlias as TypeAlias
+else:
+    TypeAlias = Any
 
-JsonDict = dict[str, Any]
-"""A dictionary that can be serialized to JSON."""
-
-StrPath = Union[str, os.PathLike[str]]
-"""The accepted type for files of roseau.load_flow.io."""
+Id: TypeAlias = Union[int, str]
+JsonDict: TypeAlias = dict[str, Any]
+StrPath: TypeAlias = Union[str, os.PathLike[str]]
 
 
 if sys.version_info >= (3, 11):

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -1,7 +1,12 @@
+"""
+Units registry used by Roseau Load Flow using the `pint`_ package.
+
+.. _pint: https://pint.readthedocs.io/en/stable/getting/overview.html
+"""
 from pint import UnitRegistry
 
 ureg = UnitRegistry()
-"""The unit registry to use in this project"""
+"""The :class:`~pint.UnitRegistry` to use in this project"""
 
 Q_ = ureg.Quantity
-"""The quantity class to use in this project"""
+"""The :class:`~pint.Quantity` class to use in this project"""

--- a/roseau/load_flow/utils/__init__.py
+++ b/roseau/load_flow/utils/__init__.py
@@ -1,3 +1,6 @@
+"""
+This module contains utility classes and functions for Roseau Load Flow.
+"""
 from roseau.load_flow.utils.constants import (
     CX,
     DELTA_P,


### PR DESCRIPTION
* Update the installation docs to use PyPI; mention how to upgrade (TODO: conda upgrade and conda-forge); mention virtual environment as a tip for beginners.
* Improve the API reference
  * Add missing docstrings
  * Add links to used libraries. In functions signatures, the link is automatically created using the type hint (e.g. `def loads_frames(self) -> pd.DataFrame` links to DataFrame docs, etc.)
  * Avoid confusing nesting of the API (e.g. loads are documented as defined in `roseau.load_flow.models` instead of `roseau.load_flow.models.loads.loads`, etc)
* Remove incomplete methods `set_load_point` and `set_source_voltages` (@Saelyos if you need these methods you may want to add them to engine). The tutorials will document how to update the network elements in a more generic way)