### PR TITLE
Solver update

### DIFF
--- a/doc/solvers.md
+++ b/doc/solvers.md
@@ -52,9 +52,7 @@ fails.
 
 ### Parameters
 
-The *Newton-Raphson* solver accepts one parameter:
-- `"linear_solver"`: the linear solver used to compute $J_F^{-1}(x)F(x)$. Currently only the
-  `"SparseLU"` option is available.
+The *Newton-Raphson* solver doesn't accept any parameter.
 
 ## Goldstein and Price
 
@@ -111,5 +109,3 @@ The *Goldstein and Price* solver accepts the following parameters:
 - `"m1"` the first constant of the *Goldstein and Price* variant. By default: `0.1`.
 - `"m2"` the second constant of the *Goldstein and Price* variant. By default: `0.9`.
   Note that the constraint $m_1 < m_2$ must be met.
-- `"linear_solver"`: the linear solver used to compute $J_F^{-1}(x)F(x)$. Currently only the
-  `"SparseLU"` option is available.

--- a/roseau/load_flow/exceptions.py
+++ b/roseau/load_flow/exceptions.py
@@ -88,7 +88,6 @@ class RoseauLoadFlowExceptionCode(Enum):
     # Solver
     BAD_SOLVER_NAME = auto()
     BAD_SOLVER_PARAMS = auto()
-    BAD_LINEAR_SOLVER = auto()
     NETWORK_SOLVER_MISMATCH = auto()
 
     # DGS export

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -45,7 +45,7 @@ class Control(JsonMixin):
               :align: center
     """
 
-    DEFAULT_ALPHA: float = 200.0
+    DEFAULT_ALPHA: float = 1000.0
 
     @ureg.wraps(None, (None, None, "V", "V", "V", "V", None), strict=False)
     def __init__(
@@ -365,7 +365,7 @@ class Projection(JsonMixin):
             :align: center
     """
 
-    DEFAULT_ALPHA: float = 100.0
+    DEFAULT_ALPHA: float = 1000.0
     DEFAULT_EPSILON: float = 0.01
 
     def __init__(self, type: ProjectionType, alpha: float = DEFAULT_ALPHA, epsilon: float = DEFAULT_EPSILON) -> None:

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -412,16 +412,23 @@ class ElectricalNetwork(JsonMixin):
             self._create_network()
 
         # Get the data
-        data = {"network": self.to_dict(), "solver": {"name": solver, "params": solver_params}}
+        data = {
+            "network": self.to_dict(),
+            "solver": {
+                "name": solver,
+                "params": solver_params,
+                "max_iterations": max_iterations,
+                "tolerance": tolerance,
+                "warm_start": warm_start,
+            },
+        }
         if warm_start and self.res_info.get("status", "failure") == "success":
             # Ignore warnings because results may be invalid (a load power has been changed, etc.)
             data["results"] = self._results_to_dict(False)
 
         # Request the server
-        params = {"max_iterations": max_iterations, "tolerance": tolerance, "warm_start": warm_start}
         response = requests.post(
             url=urljoin(base_url, "solve/"),
-            params=params,
             json=data,
             auth=auth,
             headers={"accept": "application/json", "rlf-version": __version__},

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -361,8 +361,8 @@ class ElectricalNetwork(JsonMixin):
         self,
         auth: Union[tuple[str, str], HTTPBasicAuth],
         base_url: str = DEFAULT_BASE_URL,
-        tolerance: float = DEFAULT_TOLERANCE,
         max_iterations: int = DEFAULT_MAX_ITERATIONS,
+        tolerance: float = DEFAULT_TOLERANCE,
         warm_start: bool = DEFAULT_WARM_START,
         solver: Solver = DEFAULT_SOLVER,
         solver_params: Optional[JsonDict] = None,
@@ -380,11 +380,11 @@ class ElectricalNetwork(JsonMixin):
             base_url:
                 The base url to request the load flow solver.
 
-            tolerance:
-                Tolerance needed for the convergence.
-
             max_iterations:
                 The maximum number of allowed iterations.
+
+            tolerance:
+                Tolerance needed for the convergence.
 
             warm_start:
                 If true, initialize the solver with the potentials of the last successful load flow

--- a/roseau/load_flow/solvers.py
+++ b/roseau/load_flow/solvers.py
@@ -6,11 +6,9 @@ from roseau.load_flow.typing import JsonDict, Solver
 
 logger = logging.getLogger(__name__)
 
-LINEAR_SOLVERS = ["SparseLU"]
-
 _SOLVERS_PARAMS: dict[Solver, list[str]] = {
-    "newton": ["linear_solver"],
-    "newton_goldstein": ["linear_solver", "m1", "m2"],
+    "newton": [],
+    "newton_goldstein": ["m1", "m2"],
 }
 SOLVERS = list(_SOLVERS_PARAMS)
 
@@ -49,15 +47,6 @@ def check_solver_params(solver: Solver, params: Optional[JsonDict]) -> JsonDict:
             to_delete.append(key)
     for key in to_delete:
         del params[key]
-
-    # Check the linear solver
-    if "linear_solver" in params and params["linear_solver"] not in LINEAR_SOLVERS:
-        msg = (
-            f"Linear solver {params['linear_solver']!r} is not implemented. "
-            f"The implemented solvers are: {LINEAR_SOLVERS}"
-        )
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINEAR_SOLVER)
 
     # Extra checks per solver
     if solver == "newton":

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -1,7 +1,7 @@
 import itertools as it
 import warnings
 from contextlib import contextmanager
-from urllib.parse import parse_qs, urljoin, urlsplit
+from urllib.parse import urljoin
 
 import geopandas as gpd
 import numpy as np
@@ -1220,8 +1220,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, good_json_results):
 
     def json_callback(request, context):
         request_json_data = request.json()
-        query = parse_qs(urlsplit(request.url).query)
-        warm_start = query["warm_start"][0].casefold() == "true"
+        warm_start = request_json_data["solver"]["warm_start"]
         assert isinstance(request_json_data, dict)
         assert "network" in request_json_data
         if should_warm_start:

--- a/roseau/load_flow/tests/test_solvers.py
+++ b/roseau/load_flow/tests/test_solvers.py
@@ -6,22 +6,15 @@ from roseau.load_flow.solvers import check_solver_params
 
 def test_solver():
     # Additional key
-    solver_params = check_solver_params(solver="newton", params={"linear_solver": "SparseLU", "m1": 0.1, "toto": ""})
+    solver_params = check_solver_params(solver="newton", params={"m1": 0.1, "toto": ""})
     assert "m1" not in solver_params
     assert "toto" not in solver_params
-    assert "linear_solver" in solver_params
 
     # Bad solver
     with pytest.raises(RoseauLoadFlowException) as e:
-        check_solver_params(solver="toto", params={"linear_solver": "SparseLU"})
+        check_solver_params(solver="toto", params={})
     assert "Solver 'toto' is not implemented" in e.value.msg
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_SOLVER_NAME
-
-    # Bad linear solver
-    with pytest.raises(RoseauLoadFlowException) as e:
-        check_solver_params(solver="newton", params={"linear_solver": "toto"})
-    assert "Linear solver 'toto' is not implemented" in e.value.msg
-    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LINEAR_SOLVER
 
     # Bad Goldstein and Price parameters
     with pytest.raises(RoseauLoadFlowException) as e:


### PR DESCRIPTION
- Remove linear solver option, as it was too complicated for the `engine` part. 
- Increase default alpha values for flexible parameters.
- All the solver arguments (`max_iterations`, `tolerance` and `warm_start`) are now passed in the body of the request.