### PR TITLE
Do not hide function signature when using `ureg.wraps`

### DIFF
--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -9,7 +9,7 @@ from roseau.load_flow.converters import calculate_voltages
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import BranchType
 
 logger = logging.getLogger(__name__)
@@ -75,8 +75,8 @@ class AbstractBranch(Element):
         return self._res_getter(value=self._res_currents, warning=warning)
 
     @property
-    @ureg.wraps(("A", "A"), (None,), strict=False)
-    def res_currents(self) -> tuple[Q_, Q_]:
+    @ureg_wraps(("A", "A"), (None,), strict=False)
+    def res_currents(self) -> tuple[Q_[np.ndarray], Q_[np.ndarray]]:
         """The load flow result of the branch currents (A)."""
         return self._res_currents_getter(warning=True)
 
@@ -88,8 +88,8 @@ class AbstractBranch(Element):
         return powers1, powers2
 
     @property
-    @ureg.wraps(("VA", "VA"), (None,), strict=False)
-    def res_powers(self) -> tuple[Q_, Q_]:
+    @ureg_wraps(("VA", "VA"), (None,), strict=False)
+    def res_powers(self) -> tuple[Q_[np.ndarray], Q_[np.ndarray]]:
         """The load flow result of the branch powers (VA)."""
         return self._res_powers_getter(warning=True)
 
@@ -99,8 +99,8 @@ class AbstractBranch(Element):
         return pot1, pot2
 
     @property
-    @ureg.wraps(("V", "V"), (None,), strict=False)
-    def res_potentials(self) -> tuple[Q_, Q_]:
+    @ureg_wraps(("V", "V"), (None,), strict=False)
+    def res_potentials(self) -> tuple[Q_[np.ndarray], Q_[np.ndarray]]:
         """The load flow result of the branch potentials (V)."""
         return self._res_potentials_getter(warning=True)
 
@@ -109,8 +109,8 @@ class AbstractBranch(Element):
         return calculate_voltages(pot1, self.phases1), calculate_voltages(pot2, self.phases2)
 
     @property
-    @ureg.wraps(("V", "V"), (None,), strict=False)
-    def res_voltages(self) -> tuple[Q_, Q_]:
+    @ureg_wraps(("V", "V"), (None,), strict=False)
+    def res_voltages(self) -> tuple[Q_[np.ndarray], Q_[np.ndarray]]:
         """The load flow result of the branch voltages (V)."""
         return self._res_voltages_getter(warning=True)
 

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -10,7 +10,7 @@ from roseau.load_flow.converters import calculate_voltage_phases, calculate_volt
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 
 logger = logging.getLogger(__name__)
 
@@ -74,13 +74,13 @@ class Bus(Element):
         return f"{type(self).__name__}(id={self.id!r}, phases={self.phases!r})"
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def potentials(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def potentials(self) -> Q_[np.ndarray]:
         """The potentials of the bus (V)."""
         return self._potentials
 
     @potentials.setter
-    @ureg.wraps(None, (None, "V"), strict=False)
+    @ureg_wraps(None, (None, "V"), strict=False)
     def potentials(self, value: Sequence[complex]) -> None:
         if len(value) != len(self.phases):
             msg = f"Incorrect number of potentials: {len(value)} instead of {len(self.phases)}"
@@ -93,8 +93,8 @@ class Bus(Element):
         return self._res_getter(value=self._res_potentials, warning=warning)
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def res_potentials(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def res_potentials(self) -> Q_[np.ndarray]:
         """The load flow result of the bus potentials (V)."""
         return self._res_potentials_getter(warning=True)
 
@@ -103,8 +103,8 @@ class Bus(Element):
         return calculate_voltages(potentials, self.phases)
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def res_voltages(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def res_voltages(self) -> Q_[np.ndarray]:
         """The load flow result of the bus voltages (V).
 
         If the bus has a neutral, the voltages are phase-neutral voltages for existing phases in

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -7,7 +7,7 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +51,8 @@ class Ground(Element):
         return self._res_getter(self._res_potential, warning)
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def res_potential(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def res_potential(self) -> Q_[complex]:
         """The load flow result of the ground potential (V)."""
         return self._res_potential_getter(warning=True)
 

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -13,7 +13,7 @@ from roseau.load_flow.models.grounds import Ground
 from roseau.load_flow.models.lines.parameters import LineParameters
 from roseau.load_flow.models.sources import VoltageSource
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import BranchType
 
 logger = logging.getLogger(__name__)
@@ -250,12 +250,12 @@ class Line(AbstractBranch):
             self._connect(self.ground)
 
     @property
-    @ureg.wraps("km", (None,), strict=False)
-    def length(self) -> Q_:
+    @ureg_wraps("km", (None,), strict=False)
+    def length(self) -> Q_[float]:
         return self._length
 
     @length.setter
-    @ureg.wraps(None, (None, "km"), strict=False)
+    @ureg_wraps(None, (None, "km"), strict=False)
     def length(self, value: float) -> None:
         if value <= 0:
             msg = f"A line length must be greater than 0. {value:.2f} km provided."
@@ -306,8 +306,8 @@ class Line(AbstractBranch):
         return du_line * i_line.conj()  # Sₗ = ΔU.Iₗ*
 
     @property
-    @ureg.wraps("VA", (None,), strict=False)
-    def res_series_power_losses(self) -> Q_:
+    @ureg_wraps("VA", (None,), strict=False)
+    def res_series_power_losses(self) -> Q_[np.ndarray]:
         """Get the power losses in the series elements of the line (VA)."""
         return self._res_series_power_losses_getter(warning=True)
 
@@ -325,8 +325,8 @@ class Line(AbstractBranch):
         return pot1 * i1_shunt.conj() + pot2 * i2_shunt.conj()
 
     @property
-    @ureg.wraps("VA", (None,), strict=False)
-    def res_shunt_power_losses(self) -> Q_:
+    @ureg_wraps("VA", (None,), strict=False)
+    def res_shunt_power_losses(self) -> Q_[np.ndarray]:
         """Get the power losses in the shunt elements of the line (VA)."""
         return self._res_shunt_power_losses_getter(warning=True)
 
@@ -336,8 +336,8 @@ class Line(AbstractBranch):
         return series_losses + shunt_losses
 
     @property
-    @ureg.wraps("VA", (None,), strict=False)
-    def res_power_losses(self) -> Q_:
+    @ureg_wraps("VA", (None,), strict=False)
+    def res_power_losses(self) -> Q_[np.ndarray]:
         """Get the power losses in the line (VA)."""
         return self._res_power_losses_getter(warning=True)
 

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -8,7 +8,7 @@ from typing_extensions import Self
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import (
     CX,
     EPSILON_0,
@@ -39,7 +39,7 @@ class LineParameters(Identifiable, JsonMixin):
         rf"^({_type_re})_({_material_re})_{_section_re}$", flags=re.IGNORECASE
     )
 
-    @ureg.wraps(None, (None, None, "ohm/km", "S/km"), strict=False)
+    @ureg_wraps(None, (None, None, "ohm/km", "S/km"), strict=False)
     def __init__(self, id: Id, z_line: np.ndarray, y_shunt: Optional[np.ndarray] = None) -> None:
         """LineParameters constructor.
 
@@ -82,13 +82,13 @@ class LineParameters(Identifiable, JsonMixin):
         )
 
     @property
-    @ureg.wraps("ohm/km", (None,), strict=False)
-    def z_line(self) -> Q_:
+    @ureg_wraps("ohm/km", (None,), strict=False)
+    def z_line(self) -> Q_[np.ndarray]:
         return self._z_line
 
     @property
-    @ureg.wraps("S/km", (None,), strict=False)
-    def y_shunt(self) -> Q_:
+    @ureg_wraps("S/km", (None,), strict=False)
+    def y_shunt(self) -> Q_[np.ndarray]:
         return self._y_shunt
 
     @property
@@ -96,7 +96,7 @@ class LineParameters(Identifiable, JsonMixin):
         return self._with_shunt
 
     @classmethod
-    @ureg.wraps(
+    @ureg_wraps(
         None,
         (
             None,
@@ -297,7 +297,7 @@ class LineParameters(Identifiable, JsonMixin):
         return z_line, y_shunt, model
 
     @classmethod
-    @ureg.wraps(None, (None, None, None, None, None, "mm**2", "mm**2", "m", "m"), strict=False)
+    @ureg_wraps(None, (None, None, None, None, None, "mm**2", "mm**2", "m", "m"), strict=False)
     def from_lv_exact(
         cls,
         type_name: str,
@@ -510,7 +510,7 @@ class LineParameters(Identifiable, JsonMixin):
         return z_line, y_shunt, LineModel.LV_EXACT
 
     @classmethod
-    @ureg.wraps(None, (None, None, "mm²", "m", "mm"), strict=False)
+    @ureg_wraps(None, (None, None, "mm²", "m", "mm"), strict=False)
     def from_name_lv(
         cls,
         name: str,

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -8,7 +8,7 @@ from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.models.grounds import Ground
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +68,8 @@ class PotentialRef(Element):
         return self._res_getter(self._res_current, warning)
 
     @property
-    @ureg.wraps("A", (None,), strict=False)
-    def res_current(self) -> Q_:
+    @ureg_wraps("A", (None,), strict=False)
+    def res_current(self) -> Q_[complex]:
         """The sum of the currents (A) of the connection associated to the potential reference.
 
         This sum should be equal to 0 after the load flow.

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -10,7 +10,7 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 
 logger = logging.getLogger(__name__)
 
@@ -103,13 +103,13 @@ class VoltageSource(Element):
         )
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def voltages(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def voltages(self) -> Q_[np.ndarray]:
         """The voltages of the source (V)."""
         return self._voltages
 
     @voltages.setter
-    @ureg.wraps(None, (None, "V"), strict=False)
+    @ureg_wraps(None, (None, "V"), strict=False)
     def voltages(self, voltages: Sequence[complex]) -> None:
         if len(voltages) != self._size:
             msg = f"Incorrect number of voltages: {len(voltages)} instead of {self._size}"
@@ -127,8 +127,8 @@ class VoltageSource(Element):
         return self._res_getter(value=self._res_currents, warning=warning)
 
     @property
-    @ureg.wraps("A", (None,), strict=False)
-    def res_currents(self) -> Q_:
+    @ureg_wraps("A", (None,), strict=False)
+    def res_currents(self) -> Q_[np.ndarray]:
         """The load flow result of the source currents (A)."""
         return self._res_currents_getter(warning=True)
 
@@ -136,8 +136,8 @@ class VoltageSource(Element):
         return self.bus._get_potentials_of(self.phases, warning)
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def res_potentials(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def res_potentials(self) -> Q_[np.ndarray]:
         """The load flow result of the source potentials (V)."""
         return self._res_potentials_getter(warning=True)
 
@@ -147,8 +147,8 @@ class VoltageSource(Element):
         return pots * curs.conj()
 
     @property
-    @ureg.wraps("VA", (None,), strict=False)
-    def res_powers(self) -> np.ndarray:
+    @ureg_wraps("VA", (None,), strict=False)
+    def res_powers(self) -> Q_[np.ndarray]:
         """The load flow result of the source powers (VA)."""
         return self._res_powers_getter(warning=True)
 

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import Identifiable, JsonMixin
 
 logger = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ class TransformerParameters(Identifiable, JsonMixin):
     )
     """The pattern to extract the winding of the primary and of the secondary of the transformer."""
 
-    @ureg.wraps(None, (None, None, None, "V", "V", "VA", "W", "", "W", ""), strict=False)
+    @ureg_wraps(None, (None, None, None, "V", "V", "VA", "W", "", "W", ""), strict=False)
     def __init__(
         self,
         id: Id,
@@ -143,44 +143,44 @@ class TransformerParameters(Identifiable, JsonMixin):
             )
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def uhv(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def uhv(self) -> Q_[float]:
         """Phase-to-phase nominal voltages of the high voltages side (V)"""
         return self._uhv
 
     @property
-    @ureg.wraps("V", (None,), strict=False)
-    def ulv(self) -> Q_:
+    @ureg_wraps("V", (None,), strict=False)
+    def ulv(self) -> Q_[float]:
         """Phase-to-phase nominal voltages of the low voltages side (V)"""
         return self._ulv
 
     @property
-    @ureg.wraps("VA", (None,), strict=False)
-    def sn(self) -> Q_:
+    @ureg_wraps("VA", (None,), strict=False)
+    def sn(self) -> Q_[float]:
         """The nominal power of the transformer (VA)"""
         return self._sn
 
     @property
-    @ureg.wraps("W", (None,), strict=False)
-    def p0(self) -> Q_:
+    @ureg_wraps("W", (None,), strict=False)
+    def p0(self) -> Q_[float]:
         """Losses during off-load test (W)"""
         return self._p0
 
     @property
-    @ureg.wraps("", (None,), strict=False)
-    def i0(self) -> float:
+    @ureg_wraps("", (None,), strict=False)
+    def i0(self) -> Q_[float]:
         """Current during off-load test (%)"""
         return self._i0
 
     @property
-    @ureg.wraps("W", (None,), strict=False)
-    def psc(self) -> Q_:
+    @ureg_wraps("W", (None,), strict=False)
+    def psc(self) -> Q_[float]:
         """Losses during short circuit test (W)"""
         return self._psc
 
     @property
-    @ureg.wraps("", (None,), strict=False)
-    def vsc(self) -> float:
+    @ureg_wraps("", (None,), strict=False)
+    def vsc(self) -> Q_[float]:
         """Voltages on LV side during short circuit test (%)"""
         return self._vsc
 
@@ -214,8 +214,8 @@ class TransformerParameters(Identifiable, JsonMixin):
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TYPE_NAME_SYNTAX)
 
-    @ureg.wraps(("ohm", "S", "", None), (None,), strict=False)
-    def to_zyk(self) -> tuple[Q_, Q_, float, float]:
+    @ureg_wraps(("ohm", "S", "", None), (None,), strict=False)
+    def to_zyk(self) -> tuple[Q_[complex], Q_[complex], Q_[float], float]:
         """Compute the transformer parameters ``z2``, ``ym``, ``k`` and ``orientation`` mandatory
         for some models.
 

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -11,15 +11,35 @@ Units registry used by Roseau Load Flow using the `pint`_ package.
 
 .. _pint: https://pint.readthedocs.io/en/stable/getting/overview.html
 """
-from pint import UnitRegistry
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, TypeVar, Union
 
-ureg = UnitRegistry(
+from pint import Unit, UnitRegistry
+from pint.facets.plain import PlainQuantity
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+FuncT = TypeVar("FuncT", bound=Callable)
+
+ureg: UnitRegistry = UnitRegistry(
     preprocessors=[
         lambda s: s.replace("%", " percent "),
     ]
 )
 
-Q_ = ureg.Quantity
+if TYPE_CHECKING:
+    Q_: TypeAlias = PlainQuantity[T]
+else:
+    Q_ = ureg.Quantity
+    Q_.__class_getitem__ = lambda cls, *args: cls
 
 # Define the percent unit
 ureg.define("percent = 0.01 = %")
+
+
+def ureg_wraps(
+    ret: Union[str, Unit, None, Iterable[Union[str, Unit, None]]],
+    args: Union[str, Unit, None, Iterable[Union[str, Unit, None]]],
+    strict: bool = True,
+) -> Callable[[FuncT], FuncT]:
+    return ureg.wraps(ret, args, strict)


### PR DESCRIPTION
This should fix the IDE support for our `@ureg.wrap`ed functions and also fix the return type of these functions so that users can do `ground.res_potential.as_m("V")` and so on