### PR TITLE
Update non-euclidean projections

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,7 +4,7 @@
 
 **In development**
 
-* [PR106](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/105) Improvements for non-euclidean projections.
+* [PR106](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/106) Improvements for non-euclidean projections.
 * [PR104](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/104) Remove `roseau.load_flow.utils.BranchType`
 * [GH99](https://github.com/RoseauTechnologies/Roseau_Load_Flow/issues/99) Add `Line.res_series_currents`
   and `Line.res_shunt_currents` properties to get the currents in the series and shunt components

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,6 +4,7 @@
 
 **In development**
 
+* [PR106](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/105) Improvements for non-euclidean projections.
 * [PR104](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/104) Remove `roseau.load_flow.utils.BranchType`
 * [GH99](https://github.com/RoseauTechnologies/Roseau_Load_Flow/issues/99) Add `Line.res_series_currents`
   and `Line.res_shunt_currents` properties to get the currents in the series and shunt components

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -341,7 +341,7 @@ class Projection(JsonMixin):
     """
 
     DEFAULT_ALPHA: float = 1000.0
-    DEFAULT_EPSILON: float = 0.01
+    DEFAULT_EPSILON: float = 1e-8
 
     def __init__(self, type: ProjectionType, alpha: float = DEFAULT_ALPHA, epsilon: float = DEFAULT_EPSILON) -> None:
         """Projection constructor.
@@ -357,7 +357,7 @@ class Projection(JsonMixin):
                 This value is used to make soft sign function and to build a soft projection function.
 
             epsilon:
-                This value is used to make a smooth sqrt function. It is only used in the Euclidean projection.
+                This value is used to make a smooth sqrt function.
         """
         self.type = type
         self._alpha = alpha


### PR DESCRIPTION
- The `keep_p` and `keep_q` projections have been reworked in the engine part to accept higher `alpha` values. Now the `DEFAULT_ALPHA=1000` is fine.
- The default epsilon has been decreased to `1e-8`