### PR TITLE
Error when accessing results of disconnected elements

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,6 +4,8 @@
 
 **In development**
 
+* [PR113](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/113) Raise an error when accessing the results of
+  disconnected elements.
 * [PR112](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/112) Make the geometry serialization optional.
 * [PR106](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/106) Improvements for non-euclidean projections.
 * [PR104](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/104) Remove `roseau.load_flow.utils.BranchType`
@@ -14,14 +16,14 @@
 * [GH100](https://github.com/RoseauTechnologies/Roseau_Load_Flow/issues/100) Fix the `Yz` transformers
 * [PR97](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/97) Add the model section to the documentation
 * [PR96](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/96)
-  * Add single-phase transformer
-  * Add center-tapped transformer
-  * Remove the `TransformerType` enumeration
+    * Add single-phase transformer
+    * Add center-tapped transformer
+    * Remove the `TransformerType` enumeration
 * [PR93](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/93) Add short circuit computation
 * [PR92](https://github.com/RoseauTechnologies/Roseau_Load_Flow/pull/92)
-  * Add the changelog in the documentation
-  *  Use NodeJs 20 in the Dockerfile
-  *  Correction of a dead link in the README
+    * Add the changelog in the documentation
+    * Use NodeJs 20 in the Dockerfile
+    * Correction of a dead link in the README
 
 ## Version 0.4.0
 

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -122,6 +122,7 @@ class AbstractLoad(Element, ABC):
         return np.asarray(value, dtype=complex)
 
     def _res_potentials_getter(self, warning: bool) -> np.ndarray:
+        self._raise_disconnected_error()
         return self.bus._get_potentials_of(self.phases, warning)
 
     @property
@@ -158,6 +159,13 @@ class AbstractLoad(Element, ABC):
         """Disconnect this load from the network. It cannot be used afterwards."""
         self._disconnect()
         self.bus = None
+
+    def _raise_disconnected_error(self) -> None:
+        """Raise an error if the load is disconnected."""
+        if self.bus is None:
+            msg = f"The load {self.id!r} is disconnected and cannot be used anymore."
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT)
 
     #
     # Json Mixin interface
@@ -309,10 +317,7 @@ class PowerLoad(AbstractLoad):
     # Json Mixin interface
     #
     def to_dict(self, include_geometry: bool = True) -> JsonDict:
-        if self.bus is None:
-            msg = f"The load {self.id!r} is disconnected and cannot be used anymore."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT)
+        self._raise_disconnected_error()
         res = {
             "id": self.id,
             "bus": self.bus.id,
@@ -384,10 +389,7 @@ class CurrentLoad(AbstractLoad):
         self._invalidate_network_results()
 
     def to_dict(self, include_geometry: bool = True) -> JsonDict:
-        if self.bus is None:
-            msg = f"The load {self.id!r} is disconnected and cannot be used anymore."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT)
+        self._raise_disconnected_error()
         return {
             "id": self.id,
             "bus": self.bus.id,
@@ -442,10 +444,7 @@ class ImpedanceLoad(AbstractLoad):
         self._invalidate_network_results()
 
     def to_dict(self, include_geometry: bool = True) -> JsonDict:
-        if self.bus is None:
-            msg = f"The load {self.id!r} is disconnected and cannot be used anymore."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT)
+        self._raise_disconnected_error()
         return {
             "id": self.id,
             "bus": self.bus.id,


### PR DESCRIPTION
Some results in loads and voltage sources requires the element to be connected to a bus which is not the case when the element is manually disconnected.