### PR TITLE
Add some shortcuts to the Line class

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,6 +4,7 @@
 
 **In development**
 
+- {gh-pr}`128` Add the properties `z_line`, `y_shunt` and `with_shunt` to the `Line` class.
 - {gh-pr}`125` Speed-up build of conda workflow using mamba.
 
 ## Version 0.5.0

--- a/doc/models/Line/ShuntLine.md
+++ b/doc/models/Line/ShuntLine.md
@@ -128,6 +128,28 @@ load = PowerLoad(
     id="load", bus=bus2, powers=Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
 )
 
+# The impedance matrix (in Ohm) can be accessed from the line instance
+line.z_line
+# array(
+#     [[0.3+0.35j, 0. +0.25j, 0. +0.25j, 0. +0.25j],
+#      [0. +0.25j, 0.3+0.35j, 0. +0.25j, 0. +0.25j],
+#      [0. +0.25j, 0. +0.25j, 0.3+0.35j, 0. +0.25j],
+#      [0. +0.25j, 0. +0.25j, 0. +0.25j, 0.3+0.35j]]
+# ) <Unit('ohm')>
+
+# The shunt admittance matrix (in Siemens) can be accessed from the line instance
+line.y_shunt
+# array(
+#     [[2.e-05+4.75e-04j, 0.e+00-6.80e-05j, 0.e+00-1.00e-05j, 0.e+00-6.80e-05j],
+#      [0.e+00-6.80e-05j, 2.e-05+4.75e-04j, 0.e+00-6.80e-05j, 0.e+00-1.00e-05j],
+#      [0.e+00-1.00e-05j, 0.e+00-6.80e-05j, 2.e-05+4.75e-04j, 0.e+00-6.80e-05j],
+#      [0.e+00-6.80e-05j, 0.e+00-1.00e-05j, 0.e+00-6.80e-05j, 2.e-05+4.75e-04j]]
+# ) <Unit('siemens')>
+
+# For a shunt line, the property `with_shunt` is True
+line.with_shunt
+# True
+
 # Create a network and solve a load flow
 en = ElectricalNetwork.from_element(bus1)
 auth = ("username", "password")

--- a/doc/models/Line/SimplifiedLine.md
+++ b/doc/models/Line/SimplifiedLine.md
@@ -74,6 +74,27 @@ load = PowerLoad(
     id="load", bus=bus2, powers=Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
 )
 
+# The impedance matrix (in Ohm) can be accessed from the line instance
+line.z_line
+# array(
+#     [[0.35+0.j, 0.  +0.j, 0.  +0.j, 0.  +0.j],
+#      [0.  +0.j, 0.35+0.j, 0.  +0.j, 0.  +0.j],
+#      [0.  +0.j, 0.  +0.j, 0.35+0.j, 0.  +0.j],
+#      [0.  +0.j, 0.  +0.j, 0.  +0.j, 0.35+0.j]]
+# ) <Unit('ohm')>
+
+# For a simplified line, the property `with_shunt` is False and the `y_shunt` matrix is zero
+line.with_shunt
+# False
+
+line.y_shunt
+# array(
+#     [[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+#      [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+#      [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+#      [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]]
+# ) <Unit('siemens')>
+
 # Create a network and solve a load flow
 en = ElectricalNetwork.from_element(bus1)
 auth = ("username", "password")

--- a/doc/models/Line/index.md
+++ b/doc/models/Line/index.md
@@ -8,8 +8,8 @@ $\underline{Y}$.
 
 ## Matrices definition
 
-Before diving into the different line models, lets define the series impedance matrix $Z$, and the
-shunt admittance matrix $Y$ used to model the lines.
+Before diving into the different line models, lets define the series impedance matrix $\underline{Z}$, and the
+shunt admittance matrix $\underline{Y}$ used to model the lines.
 
 ### Series impedance matrix
 
@@ -156,6 +156,11 @@ simple_line_parameters = LineParameters(id="simple_line_parameters", z_line=z_li
 shunt_line_parameters = LineParameters(
     id="shunt_line_parameters", z_line=z_line, y_shunt=y_shunt
 )
+```
+
+```{tip}
+The `Line` instance itself has the `z_line` and `y_shunt` properties. They retrieve the line impedance in $\Omega$
+and the line shunt admittance in Siemens (taking into account the length of the line).
 ```
 
 There are several alternative constructors for `LineParameters` objects. The description of them can be found in the

--- a/roseau/load_flow/solvers.py
+++ b/roseau/load_flow/solvers.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from roseau.load_flow import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
+from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.typing import JsonDict, Solver
 
 logger = logging.getLogger(__name__)

--- a/roseau/load_flow/tests/test_solvers.py
+++ b/roseau/load_flow/tests/test_solvers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from roseau.load_flow import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
+from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.solvers import check_solver_params
 
 


### PR DESCRIPTION
A proposal of @YassineAbdelouadoud who wanted to have access to the impedance and shunt admittance of the line from a Line instance directly (in Ohm and in S). To avoid confusion between ohm/km (resp. S/km) and ohm (resp. ohm/km), the name of the methods should maybe be changed...