### PR TITLE
Fix pint warnings and remove conditional import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,6 @@ benchmark/*.mtx
 *.log
 .ruff_cache/
 doc/images/*.pdf
+
+roseau/*
+!roseau/load_flow

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -455,7 +455,7 @@ class LineParameters(Identifiable, JsonMixin):
         c[mask_off_diagonal] = -lambda_inv[mask_off_diagonal]
         g = np.zeros((4, 4), dtype=float)  # conductance (S/km)
         omega = OMEGA.m_as("rad/s")
-        g[mask_diagonal] = TAN_D[insulator_type] * np.einsum("ii->i", c) * omega
+        g[mask_diagonal] = TAN_D[insulator_type].magnitude * np.einsum("ii->i", c) * omega
 
         # Build the impedance and admittance matrices
         z_line = r + inductance * omega * 1j

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -1,5 +1,6 @@
+import numbers
+
 import numpy as np
-import pandas as pd
 import pytest
 from pint import DimensionalityError
 
@@ -350,9 +351,12 @@ def test_catalogue_data():
         assert np.isclose(tp.psc.m_as("W"), catalogue_data.at[tp.id, "psc"])
         assert np.isclose(tp.vsc.m_as(""), catalogue_data.at[tp.id, "vsc"])
 
-        # Check that the transformer can be used
-        res = tp.to_zyk()
-        assert all(pd.notna(x) for x in res)
+        # Check that the parameters are valid
+        z, y, k, orientation = tp.to_zyk()
+        assert isinstance(z.m_as("ohm"), numbers.Number)
+        assert isinstance(y.m_as("S"), numbers.Number)
+        assert isinstance(k.m_as(""), numbers.Number)
+        assert orientation in (-1.0, 1.0)
 
     # At the end of the process, the found column must be full of True
     assert catalogue_data["found"].all(), error_message

--- a/roseau/load_flow/typing.py
+++ b/roseau/load_flow/typing.py
@@ -26,15 +26,9 @@ Type Aliases used by Roseau Load Flow.
     Available solvers for the load flow computation.
 """
 import os
-import sys
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import Any, Literal, Union
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias as TypeAlias
-elif TYPE_CHECKING:
-    from typing_extensions import TypeAlias as TypeAlias
-else:
-    TypeAlias = Any
+from typing_extensions import TypeAlias
 
 Id: TypeAlias = Union[int, str]
 JsonDict: TypeAlias = dict[str, Any]


### PR DESCRIPTION
This PR fixes warnings when a pint quantity is transformed into a numpy array. It also removes a conditional import from typing_extensions as we have it as a dependency now.