### PR TITLE
Mark internal attributes as private

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,6 +4,7 @@
 
 **In development**
 
+- {gh-pr}`130` Mark some internal attributes as private, they were previously marked as public.
 - {gh-pr}`128` Add the properties `z_line`, `y_shunt` and `with_shunt` to the `Line` class.
 - {gh-pr}`125` Speed-up build of conda workflow using mamba.
 

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -34,7 +34,7 @@ class Control(JsonMixin):
         :ref:`Control documentation <models-flexible_load-controls>`
     """
 
-    DEFAULT_ALPHA: float = 1000.0
+    _DEFAULT_ALPHA: float = 1000.0
 
     @ureg_wraps(None, (None, None, "V", "V", "V", "V", None), strict=False)
     def __init__(
@@ -44,7 +44,7 @@ class Control(JsonMixin):
         u_down: float,
         u_up: float,
         u_max: float,
-        alpha: float = DEFAULT_ALPHA,
+        alpha: float = _DEFAULT_ALPHA,
     ) -> None:
         """Control constructor.
 
@@ -180,7 +180,7 @@ class Control(JsonMixin):
 
     @classmethod
     @ureg_wraps(None, (None, "V", "V", None), strict=False)
-    def p_max_u_production(cls, u_up: float, u_max: float, alpha: float = DEFAULT_ALPHA) -> Self:
+    def p_max_u_production(cls, u_up: float, u_max: float, alpha: float = _DEFAULT_ALPHA) -> Self:
         """Create a control of the type ``"p_max_u_production"``.
 
         See Also:
@@ -209,7 +209,7 @@ class Control(JsonMixin):
 
     @classmethod
     @ureg_wraps(None, (None, "V", "V", None), strict=False)
-    def p_max_u_consumption(cls, u_min: float, u_down: float, alpha: float = DEFAULT_ALPHA) -> Self:
+    def p_max_u_consumption(cls, u_min: float, u_down: float, alpha: float = _DEFAULT_ALPHA) -> Self:
         """Create a control of the type ``"p_max_u_consumption"``.
 
         See Also:
@@ -238,7 +238,7 @@ class Control(JsonMixin):
 
     @classmethod
     @ureg_wraps(None, (None, "V", "V", "V", "V", None), strict=False)
-    def q_u(cls, u_min: float, u_down: float, u_up: float, u_max: float, alpha: float = DEFAULT_ALPHA) -> Self:
+    def q_u(cls, u_min: float, u_down: float, u_up: float, u_max: float, alpha: float = _DEFAULT_ALPHA) -> Self:
         """Create a control of the type ``"q_u"``.
 
         See Also:
@@ -280,7 +280,7 @@ class Control(JsonMixin):
     #
     @classmethod
     def from_dict(cls, data: JsonDict) -> Self:
-        alpha = data["alpha"] if "alpha" in data else cls.DEFAULT_ALPHA
+        alpha = data["alpha"] if "alpha" in data else cls._DEFAULT_ALPHA
         if data["type"] == "constant":
             return cls.constant()
         elif data["type"] == "p_max_u_production":
@@ -340,10 +340,10 @@ class Projection(JsonMixin):
         :ref:`Projection documentation <models-flexible_load-projection>`
     """
 
-    DEFAULT_ALPHA: float = 1000.0
-    DEFAULT_EPSILON: float = 1e-8
+    _DEFAULT_ALPHA: float = 1000.0
+    _DEFAULT_EPSILON: float = 1e-8
 
-    def __init__(self, type: ProjectionType, alpha: float = DEFAULT_ALPHA, epsilon: float = DEFAULT_EPSILON) -> None:
+    def __init__(self, type: ProjectionType, alpha: float = _DEFAULT_ALPHA, epsilon: float = _DEFAULT_EPSILON) -> None:
         """Projection constructor.
 
         Args:
@@ -406,8 +406,8 @@ class Projection(JsonMixin):
     #
     @classmethod
     def from_dict(cls, data: JsonDict) -> Self:
-        alpha = data["alpha"] if "alpha" in data else cls.DEFAULT_ALPHA
-        epsilon = data["epsilon"] if "epsilon" in data else cls.DEFAULT_EPSILON
+        alpha = data["alpha"] if "alpha" in data else cls._DEFAULT_ALPHA
+        epsilon = data["epsilon"] if "epsilon" in data else cls._DEFAULT_EPSILON
         return cls(type=data["type"], alpha=alpha, epsilon=epsilon)
 
     def to_dict(self, include_geometry: bool = True) -> JsonDict:
@@ -502,9 +502,9 @@ class FlexibleParameter(JsonMixin):
         u_up: float,
         u_max: float,
         s_max: float,
-        alpha_control: float = Control.DEFAULT_ALPHA,
-        alpha_proj: float = Projection.DEFAULT_ALPHA,
-        epsilon_proj: float = Projection.DEFAULT_EPSILON,
+        alpha_control: float = Control._DEFAULT_ALPHA,
+        alpha_proj: float = Projection._DEFAULT_ALPHA,
+        epsilon_proj: float = Projection._DEFAULT_EPSILON,
     ) -> Self:
         """Build flexible parameters for production ``P(U)`` control with a Euclidean projection.
 
@@ -554,9 +554,9 @@ class FlexibleParameter(JsonMixin):
         u_min: float,
         u_down: float,
         s_max: float,
-        alpha_control: float = Control.DEFAULT_ALPHA,
-        alpha_proj: float = Projection.DEFAULT_ALPHA,
-        epsilon_proj: float = Projection.DEFAULT_EPSILON,
+        alpha_control: float = Control._DEFAULT_ALPHA,
+        alpha_proj: float = Projection._DEFAULT_ALPHA,
+        epsilon_proj: float = Projection._DEFAULT_EPSILON,
     ) -> Self:
         """Build flexible parameters for consumption ``P(U)`` control with a Euclidean projection.
 
@@ -605,9 +605,9 @@ class FlexibleParameter(JsonMixin):
         u_up: float,
         u_max: float,
         s_max: float,
-        alpha_control: float = Control.DEFAULT_ALPHA,
-        alpha_proj: float = Projection.DEFAULT_ALPHA,
-        epsilon_proj: float = Projection.DEFAULT_EPSILON,
+        alpha_control: float = Control._DEFAULT_ALPHA,
+        alpha_proj: float = Projection._DEFAULT_ALPHA,
+        epsilon_proj: float = Projection._DEFAULT_EPSILON,
     ) -> Self:
         """Build flexible parameters for ``Q(U)`` control with a Euclidean projection.
 
@@ -665,9 +665,9 @@ class FlexibleParameter(JsonMixin):
         uq_up: float,
         uq_max: float,
         s_max: float,
-        alpha_control=Control.DEFAULT_ALPHA,
-        alpha_proj=Projection.DEFAULT_ALPHA,
-        epsilon_proj=Projection.DEFAULT_EPSILON,
+        alpha_control=Control._DEFAULT_ALPHA,
+        alpha_proj=Projection._DEFAULT_ALPHA,
+        epsilon_proj=Projection._DEFAULT_EPSILON,
     ) -> Self:
         """Build flexible parameters for production ``P(U)`` control and ``Q(U)`` control with a
         Euclidean projection.
@@ -736,9 +736,9 @@ class FlexibleParameter(JsonMixin):
         uq_up: float,
         uq_max: float,
         s_max: float,
-        alpha_control: float = Control.DEFAULT_ALPHA,
-        alpha_proj: float = Projection.DEFAULT_ALPHA,
-        epsilon_proj: float = Projection.DEFAULT_EPSILON,
+        alpha_control: float = Control._DEFAULT_ALPHA,
+        alpha_proj: float = Projection._DEFAULT_ALPHA,
+        epsilon_proj: float = Projection._DEFAULT_EPSILON,
     ) -> Self:
         """Build flexible parameters for consumption ``P(U)`` control and ``Q(U)`` control with a
         Euclidean projection.

--- a/roseau/load_flow/models/tests/test_loads.py
+++ b/roseau/load_flow/models/tests/test_loads.py
@@ -305,8 +305,8 @@ def test_loads_to_dict():
                 "control_q": {"type": "constant"},
                 "projection": {
                     "type": "euclidean",
-                    "alpha": Projection.DEFAULT_ALPHA,
-                    "epsilon": Projection.DEFAULT_EPSILON,
+                    "alpha": Projection._DEFAULT_ALPHA,
+                    "epsilon": Projection._DEFAULT_EPSILON,
                 },
                 "s_max": 1.0,
             },

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -92,22 +92,6 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
             be connected to a bus or to a ground.
 
     Attributes:
-        DEFAULT_TOLERANCE (float):
-            The default tolerance needed for the convergence of the load flow solver. At each
-            iteration, the solver computes the residuals of the equations of the problem. When the
-            maximum of the absolute values of the residuals vector is lower than the provided
-            tolerance, the solver stops. Default is 1e-6.
-
-        DEFAULT_MAX_ITERATIONS (int):
-            Maximum number of iterations to perform the load flow analysis. The solver stops when
-            this number of iterations is reached. Default is 20.
-
-        DEFAULT_BASE_URL (str):
-            Base URL of the Roseau Load Flow API endpoint.
-
-        DEFAULT_SOLVER (str):
-            The default solver to compute the load flow.
-
         buses (dict[Id, roseau.load_flow.Bus]):
             Dictionary of buses of the network indexed by their IDs. Also available as a
             :attr:`GeoDataFrame<buses_frame>`.
@@ -148,11 +132,11 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                 }
     """
 
-    DEFAULT_TOLERANCE: float = 1e-6
-    DEFAULT_MAX_ITERATIONS: int = 20
-    DEFAULT_BASE_URL: str = "https://load-flow-api-dev.roseautechnologies.com/"
-    DEFAULT_WARM_START: bool = True
-    DEFAULT_SOLVER: Solver = "newton_goldstein"
+    _DEFAULT_TOLERANCE: float = 1e-6
+    _DEFAULT_MAX_ITERATIONS: int = 20
+    _DEFAULT_BASE_URL: str = "https://load-flow-api-dev.roseautechnologies.com/"
+    _DEFAULT_WARM_START: bool = True
+    _DEFAULT_SOLVER: Solver = "newton_goldstein"
 
     # Elements classes (for internal use only)
     _branch_class = AbstractBranch
@@ -374,11 +358,11 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
     def solve_load_flow(
         self,
         auth: Union[tuple[str, str], HTTPBasicAuth],
-        base_url: str = DEFAULT_BASE_URL,
-        max_iterations: int = DEFAULT_MAX_ITERATIONS,
-        tolerance: float = DEFAULT_TOLERANCE,
-        warm_start: bool = DEFAULT_WARM_START,
-        solver: Solver = DEFAULT_SOLVER,
+        base_url: str = _DEFAULT_BASE_URL,
+        max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+        tolerance: float = _DEFAULT_TOLERANCE,
+        warm_start: bool = _DEFAULT_WARM_START,
+        solver: Solver = _DEFAULT_SOLVER,
         solver_params: Optional[JsonDict] = None,
     ) -> int:
         """Solve the load flow for this network (Requires internet access).

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -520,7 +520,7 @@ def test_solve_load_flow(small_network, good_json_results):
 
     # Good result
     # Request the server
-    solve_url = urljoin(ElectricalNetwork.DEFAULT_BASE_URL, "solve/")
+    solve_url = urljoin(ElectricalNetwork._DEFAULT_BASE_URL, "solve/")
     with requests_mock.Mocker() as m:
         m.post(solve_url, status_code=200, json=good_json_results, headers={"content-type": "application/json"})
         small_network.solve_load_flow(auth=("", ""))
@@ -607,7 +607,7 @@ def test_solve_load_flow(small_network, good_json_results):
 
 def test_solve_load_flow_error(small_network):
     # Solve url
-    solve_url = urljoin(ElectricalNetwork.DEFAULT_BASE_URL, "solve/")
+    solve_url = urljoin(ElectricalNetwork._DEFAULT_BASE_URL, "solve/")
 
     # Parse RLF error
     json_result = {"msg": "toto", "code": "roseau.load_flow.bad_branch_type"}
@@ -778,7 +778,7 @@ def test_single_phase_network(single_phase_network: ElectricalNetwork):
             {"id": "pref", "current": [-1.2500243895541274e-13, 0.0]},
         ],
     }
-    solve_url = urljoin(ElectricalNetwork.DEFAULT_BASE_URL, "solve/")
+    solve_url = urljoin(ElectricalNetwork._DEFAULT_BASE_URL, "solve/")
     with requests_mock.Mocker() as m:
         m.post(solve_url, status_code=200, json=json_results, headers={"content-type": "application/json"})
         single_phase_network.solve_load_flow(auth=("", ""))
@@ -1036,7 +1036,7 @@ def test_network_results_warning(small_network: ElectricalNetwork, good_json_res
         assert e.value.args[1] == RoseauLoadFlowExceptionCode.LOAD_FLOW_NOT_RUN
 
     # Solve a load flow
-    solve_url = urljoin(ElectricalNetwork.DEFAULT_BASE_URL, "solve/")
+    solve_url = urljoin(ElectricalNetwork._DEFAULT_BASE_URL, "solve/")
     with requests_mock.Mocker() as m:
         m.post(solve_url, status_code=200, json=good_json_results, headers={"content-type": "application/json"})
         small_network.solve_load_flow(auth=("", ""))
@@ -1310,7 +1310,7 @@ def test_load_flow_results_frames(small_network: ElectricalNetwork, good_json_re
 def test_solver_warm_start(small_network: ElectricalNetwork, good_json_results):
     load: PowerLoad = small_network.loads["load"]
     load_bus = small_network.buses["bus1"]
-    solve_url = urljoin(ElectricalNetwork.DEFAULT_BASE_URL, "solve/")
+    solve_url = urljoin(ElectricalNetwork._DEFAULT_BASE_URL, "solve/")
     headers = {"Content-Type": "application/json"}
 
     def json_callback(request, context):


### PR DESCRIPTION
To avoid someone typing:
```python
Control.DEFAULT_ALPHA = 2000
control = Control("constant", 220, 225, 235, 240)  # no alpha provided
```
and expecting to see the new default value.

I'll update the engine as well.