### PR TITLE
Add network constraints for load flow analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,4 @@ repos:
     hooks:
       - id: prettier
         args: ["--print-width", "120"]
+        exclude: ^.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,24 +3,21 @@
   "jupyter.notebookFileRoot": "${workspaceFolder}",
   "notebook.formatOnSave.enabled": true,
   "notebook.codeActionsOnSave": {
-    "source.organizeImports.ruff": true
+    "source.organizeImports.ruff": "explicit",
   },
 
   // Python
   "python.analysis.diagnosticSeverityOverrides": {
     "reportInvalidStringEscapeSequence": "warning",
     "reportImportCycles": "warning",
-    "reportUnusedImport": "warning"
+    "reportUnusedImport": "warning",
   },
-  "python.formatting.provider": "none",
-  "python.testing.pytestArgs": [],
-  "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports.ruff": true
-    }
-  }
+      "source.organizeImports.ruff": "explicit",
+    },
+  },
 }

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,6 +4,14 @@
 
 **In development**
 
+- {gh-pr}`138` Add network constraints for analysis of the results.
+  - Buses can define minimum and maximum voltages. Use `bus.res_violated` to see if the bus has
+    over- or under-voltage.
+  - Lines can define a maximum current. Use `line.res_violated` to see if the loading of any of the
+    line's cables is too high.
+  - Transformers can define a maximum power. Use `transformer.res_violated` to see if the transformer
+    loading is too high.
+  - The new fields also appear in the data frames of the network.
 - {gh-pr}`133` {gh-issue}`126` Add Qmin and Qmax limits of flexible parameters.
 - {gh-pr}`132` {gh-issue}`101` Document extra utilities including converters and constants.
 - {gh-pr}`131` {gh-issue}`127` Improve the documentation of the flexible loads.

--- a/doc/usage/Getting_Started.md
+++ b/doc/usage/Getting_Started.md
@@ -9,9 +9,10 @@ In this tutorial you will learn how to:
 1. [Create a simple electrical network with one source and one load](gs-creating-network);
 2. [Solve a load flow](gs-solving-load-flow);
 3. [Get the results of the load flow](gs-getting-results);
-4. [Update the elements of the network](gs-updating-elements);
-5. [Save the network and the results to the disk for later analysis](gs-saving-network);
-6. [Load the saved network and the results from the disk](gs-loading-network).
+4. [Analyze the results](gs-analysis-and-violations);
+5. [Update the elements of the network](gs-updating-elements);
+6. [Save the network and the results to the disk for later analysis](gs-saving-network);
+7. [Load the saved network and the results from the disk](gs-loading-network).
 
 (gs-creating-network)=
 
@@ -208,15 +209,16 @@ The results returned by the `res_` properties are also `Quantity` objects.
 The available results depend on the type of element. The following table summarizes the available
 results for each element type:
 
-| Element type                                | Available results                                                                                                                       |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `Bus`                                       | `res_potentials`, `res_voltages`                                                                                                        |
-| `Line`                                      | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_series_power_losses`, `res_shunt_power_losses`, `res_power_losses` |
-| `Transformer`, `Switch`                     | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`                                                                          |
-| `ImpedanceLoad`, `CurrentLoad`, `PowerLoad` | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_flexible_powers`&#8270;                                            |
-| `VoltageSource`                             | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`                                                                          |
-| `Ground`                                    | `res_potential`                                                                                                                         |
-| `PotentialRef`                              | `res_current` _(Always zero for a successful load flow)_                                                                                |
+| Element type                                | Available results                                                                                                                                       |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Bus`                                       | `res_potentials`, `res_voltages`, `res_violated`                                                                                                        |
+| `Line`                                      | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_series_power_losses`, `res_shunt_power_losses`, `res_power_losses`, `res_violated` |
+| `Transformer`                               | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_violated`                                                                          |
+| `Switch`                                    | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`                                                                                          |
+| `ImpedanceLoad`, `CurrentLoad`, `PowerLoad` | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_flexible_powers`&#8270;                                                            |
+| `VoltageSource`                             | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`                                                                                          |
+| `Ground`                                    | `res_potential`                                                                                                                                         |
+| `PotentialRef`                              | `res_current` _(Always zero for a successful load flow)_                                                                                                |
 
 &#8270;: `res_flexible_powers` is only available for flexible loads (`PowerLoad`s with `flexible_params`). You'll see
 an example on the usage of flexible loads in the _Flexible Loads_ section.
@@ -242,7 +244,8 @@ array([0.22192818, 0.22192818, 0.22192818]) <Unit('kilovolt')>
 
 ```{important}
 Everywhere in `roseau-load-flow`, the `voltages` of an element depend on the element's `phases`.
-Voltages of elements connected in a *Star (wye)* configuration (elements that have a neutral connection indicated by the presence of the `'n'` char in their `phases` attribute) are the
+Voltages of elements connected in a *Star (wye)* configuration (elements that have a neutral
+connection indicated by the presence of the `'n'` char in their `phases` attribute) are the
 **phase-to-neutral** voltages. Voltages of elements connected in a *Delta* configuration (elements
 that do not have a neutral connection indicated by the absence of the `'n'` char from their
 `phases` attribute) are the **phase-to-phase** voltages. This is true for *input* voltages, such
@@ -276,9 +279,13 @@ The results can also be retrieved for the entire network using `res_` properties
 Available results for the network are:
 
 - `res_buses`: Buses potentials indexed by _(bus id, phase)_
-- `res_buses_voltages`: Buses voltages indexed by _(bus id, voltage phase)_
+- `res_buses_voltages`: Buses voltages and voltage limits indexed by _(bus id, voltage phase)_
 - `res_branches`: Branches currents, powers, and potentials indexed by _(branch id, phase)_
-- `res_lines`: Lines currents, powers, potentials, series losses, series currents indexed by _(line id, phase)_
+- `res_transformers`: Transformers currents, powers, potentials, and power limits indexed by
+  _(transformer id, phase)_
+- `res_lines`: Lines currents, powers, potentials, series losses, series currents, and current
+  limits indexed by _(line id, phase)_
+- `res_switches`: Switches currents, powers, and potentials indexed by _(switch id, phase)_
 - `res_loads`: Loads currents, powers, and potentials indexed by _(load id, phase)_
 - `res_loads_voltages`: Loads voltages indexed by _(load id, voltage phase)_
 - `res_loads_flexible_powers`: Loads flexible powers (only for flexible loads) indexed by
@@ -317,14 +324,14 @@ All the following tables are rounded to 2 decimals to be properly displayed.
 >>> en.res_buses_voltages
 ```
 
-| bus_id | phase |        voltage |
-| :----- | :---- | -------------: |
-| sb     | an    |      230.94+0j |
-| sb     | bn    |   -115.47-200j |
-| sb     | cn    |   -115.47+200j |
-| lb     | an    |      221.93+0j |
-| lb     | bn    | -110.96-192.2j |
-| lb     | cn    | -110.96+192.2j |
+| bus_id | phase |        voltage | min_voltage | max_voltage | violated |
+| :----- | :---- | -------------: | ----------: | ----------: | :------- |
+| sb     | an    |      230.94+0j |     207.846 |     254.034 | False    |
+| sb     | bn    |   -115.47-200j |     207.846 |     254.034 | False    |
+| sb     | cn    |   -115.47+200j |     207.846 |     254.034 | False    |
+| lb     | an    |      221.93-0j |     207.846 |     254.034 | False    |
+| lb     | bn    | -110.96-192.2j |     207.846 |     254.034 | False    |
+| lb     | cn    | -110.96+192.2j |     207.846 |     254.034 | False    |
 
 ```pycon
 >>> en.res_branches
@@ -341,12 +348,26 @@ All the following tables are rounded to 2 decimals to be properly displayed.
 >>> en.res_lines
 ```
 
-| branch_id | phase |      current1 |     current2 |      power1 |    power2 |   potential1 |     potential2 | series_losses | series_current |
-| :-------- | :---- | ------------: | -----------: | ----------: | --------: | -----------: | -------------: | ------------: | -------------: |
-| line      | a     |      45.06+0j |    -45.06-0j | 10406.07-0j | -10000+0j |    230.94+0j |      221.93-0j |     406.07-0j |       45.06+0j |
-| line      | b     | -22.53-39.02j | 22.53+39.02j | 10406.07+0j | -10000-0j | -115.47-200j | -110.96-192.2j |     406.07-0j |  -22.53-39.02j |
-| line      | c     | -22.53+39.02j | 22.53-39.02j | 10406.07-0j | -10000+0j | -115.47+200j | -110.96+192.2j |     406.07+0j |  -22.53+39.02j |
-| line      | n     |            0j |          -0j |         -0j |       -0j |           0j |            -0j |           -0j |          -0+0j |
+| line_id | phase |      current1 |     current2 |      power1 |    power2 |   potential1 |     potential2 | series_losses | series_current | max_current | violated |
+| :------ | :---- | ------------: | -----------: | ----------: | --------: | -----------: | -------------: | ------------: | -------------: | ----------: | :------- |
+| line    | a     |      45.06-0j |    -45.06+0j | 10406.07+0j | -10000-0j |    230.94+0j |      221.93+0j |     406.07-0j |       45.06-0j |         500 | False    |
+| line    | b     | -22.53-39.02j | 22.53+39.02j | 10406.07+0j | -10000-0j | -115.47-200j | -110.96-192.2j |     406.07-0j |  -22.53-39.02j |         500 | False    |
+| line    | c     | -22.53+39.02j | 22.53-39.02j | 10406.07-0j | -10000+0j | -115.47+200j | -110.96+192.2j |     406.07+0j |  -22.53+39.02j |         500 | False    |
+| line    | n     |         -0-0j |           0j |       -0+0j |       -0j |           0j |             0j |           -0j |          -0-0j |         500 | False    |
+
+```pycon
+>>> en.res_transformers
+```
+
+| transformer_id | phase | current1 | current2 | power1 | power2 | potential1 | potential2 | max_power | violated |
+| -------------- | ----- | -------- | -------- | ------ | ------ | ---------- | ---------- | --------- | -------- |
+
+```pycon
+>>> en.res_switches
+```
+
+| switch_id | phase | current1 | current2 | power1 | power2 | potential1 | potential2 |
+| --------- | ----- | -------- | -------- | ------ | ------ | ---------- | ---------- |
 
 ```pycon
 >>> en.res_loads
@@ -400,7 +421,7 @@ Using the `transform` method of data frames, the results can easily be converted
 to magnitude and angle values.
 
 ```pycon
->>> en.res_buses_voltages.transform([np.abs, np.angle])
+>>> en.res_buses_voltages["voltage"].transform([np.abs, np.angle])
 ```
 
 | bus_id | phase | ('voltage', 'absolute') | ('voltage', 'angle') |
@@ -416,7 +437,7 @@ Or, if you prefer degrees:
 
 ```pycon
 >>> import functools as ft
-... en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+... en.res_buses_voltages["voltage"].transform([np.abs, ft.partial(np.angle, deg=True)])
 ```
 
 | bus_id | phase | ('voltage', 'absolute') | ('voltage', 'angle') |
@@ -427,6 +448,44 @@ Or, if you prefer degrees:
 | lb     | an    |                 221.928 |          1.65643e-17 |
 | lb     | bn    |                 221.928 |                 -120 |
 | lb     | cn    |                 221.928 |                  120 |
+
+(gs-analysis-and-violations)=
+
+## Analyzing the results and detecting violations
+
+In the example network above, `min_voltage` and `max_voltage` arguments were passed to the `Bus`
+constructor and `max_current` was passed to the `LineParameters` constructor. These arguments
+define the limits of the network that can be used to check if the network is in a valid state
+or not. Note that these limits have no effect on the load flow calculation.
+
+If you set `min_voltage` or `max_voltage` on a bus, the `res_violated` property will tell you if
+the voltage limits are violated or not at this bus. Here, the voltage limits are not violated.
+
+```pycon
+>>> load_bus.res_violated
+False
+```
+
+Similarly, if you set `max_current` on a line, the `res_violated` property will tell you if the
+current loading of the line in any phase exceeds the limit. Here, the current limit is not violated.
+
+```pycon
+>>> line.res_violated
+False
+```
+
+The power limit of the transformer can be defined using the `max_power` argument of the
+`TransformerParameters`. Transformers also have a `res_violated` property that indicates if the
+power loading of the transformer exceeds the limit.
+
+The data frame results on the electrical network also include a `violated` column that indicates if
+the limits are violated or not for the corresponding element.
+
+```{tip}
+You can use the {meth}`Bus.propagate_limits() <roseau.load_flow.Bus.propagate_limits>` method to
+propagate the limits from a bus to its neighboring buses, that is, buses on the same side of a
+transformer.
+```
 
 (gs-updating-elements)=
 

--- a/doc/usage/Getting_Started.md
+++ b/doc/usage/Getting_Started.md
@@ -71,9 +71,17 @@ It leads to the following code
 >>> import numpy as np
 ... from roseau.load_flow import *
 
+>>> # Nominal phase-to-neutral voltage
+... un = 400 / np.sqrt(3)  # In Volts
+
+>>> # Optional network limits (for results analysis only)
+... u_min = 0.9 * un  # V
+... u_max = 1.1 * un  # V
+... i_max = 500.0  # A
+
 >>> # Create two buses
-... source_bus = Bus(id="sb", phases="abcn")
-... load_bus = Bus(id="lb", phases="abcn")
+... source_bus = Bus(id="sb", phases="abcn", min_voltage=u_min, max_voltage=u_max)
+... load_bus = Bus(id="lb", phases="abcn", min_voltage=u_min, max_voltage=u_max)
 
 >>> # Define the reference of potentials to be the neutral of the source bus
 ... ground = Ground(id="gnd")
@@ -82,17 +90,20 @@ It leads to the following code
 ... ground.connect(source_bus, phase="n")
 
 >>> # Create a LV source at the first bus
-... # Volts (phase-to-neutral because the source is connected to the neutral)
-... un = 400 / np.sqrt(3)
-... source_voltages = [un, un * np.exp(-2j * np.pi / 3), un * np.exp(2j * np.pi / 3)]
-... vs = VoltageSource(id="vs", bus=source_bus, voltages=source_voltages)
+... # (phase-to-neutral voltage because the source is connected to the neutral)
+... source_voltages = un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
+... vs = VoltageSource(
+...     id="vs", bus=source_bus, voltages=source_voltages
+... )  # phases="abcn" inferred from the bus
 
 >>> # Add a load at the second bus
 ... load = PowerLoad(id="load", bus=load_bus, powers=[10e3 + 0j, 10e3, 10e3])  # VA
 
 >>> # Add a LV line between the source bus and the load bus
 ... # R = 0.1 Ohm/km, X = 0
-... lp = LineParameters("lp", z_line=(0.1 + 0.0j) * np.eye(4, dtype=complex))
+... lp = LineParameters(
+...     "lp", z_line=(0.1 + 0.0j) * np.eye(4, dtype=complex), max_current=i_max
+... )
 ... line = Line(id="line", bus1=source_bus, bus2=load_bus, parameters=lp, length=2.0)
 ```
 

--- a/doc/usage/Getting_Started.md
+++ b/doc/usage/Getting_Started.md
@@ -435,14 +435,14 @@ to magnitude and angle values.
 >>> en.res_buses_voltages["voltage"].transform([np.abs, np.angle])
 ```
 
-| bus_id | phase | ('voltage', 'absolute') | ('voltage', 'angle') |
-| :----- | :---- | ----------------------: | -------------------: |
-| sb     | an    |                  230.94 |                    0 |
-| sb     | bn    |                  230.94 |              -2.0944 |
-| sb     | cn    |                  230.94 |               2.0944 |
-| lb     | an    |                 221.928 |          2.89102e-19 |
-| lb     | bn    |                 221.928 |              -2.0944 |
-| lb     | cn    |                 221.928 |               2.0944 |
+| bus_id | phase | absolute |       angle |
+| :----- | :---- | -------: | ----------: |
+| sb     | an    |   230.94 |           0 |
+| sb     | bn    |   230.94 |     -2.0944 |
+| sb     | cn    |   230.94 |      2.0944 |
+| lb     | an    |  221.928 | 2.89102e-19 |
+| lb     | bn    |  221.928 |     -2.0944 |
+| lb     | cn    |  221.928 |      2.0944 |
 
 Or, if you prefer degrees:
 
@@ -451,14 +451,14 @@ Or, if you prefer degrees:
 ... en.res_buses_voltages["voltage"].transform([np.abs, ft.partial(np.angle, deg=True)])
 ```
 
-| bus_id | phase | ('voltage', 'absolute') | ('voltage', 'angle') |
-| :----- | :---- | ----------------------: | -------------------: |
-| sb     | an    |                  230.94 |                    0 |
-| sb     | bn    |                  230.94 |                 -120 |
-| sb     | cn    |                  230.94 |                  120 |
-| lb     | an    |                 221.928 |          1.65643e-17 |
-| lb     | bn    |                 221.928 |                 -120 |
-| lb     | cn    |                 221.928 |                  120 |
+| bus_id | phase | absolute |       angle |
+| :----- | :---- | -------: | ----------: |
+| sb     | an    |   230.94 |           0 |
+| sb     | bn    |   230.94 |        -120 |
+| sb     | cn    |   230.94 |         120 |
+| lb     | an    |  221.928 | 1.65643e-17 |
+| lb     | bn    |  221.928 |        -120 |
+| lb     | cn    |  221.928 |         120 |
 
 (gs-analysis-and-violations)=
 

--- a/doc/usage/Getting_Started.md
+++ b/doc/usage/Getting_Started.md
@@ -373,12 +373,12 @@ All the following tables are rounded to 2 decimals to be properly displayed.
 >>> en.res_sources
 ```
 
-| source_id | phase |      current |         power |    potential |
-| :-------- | :---- | -----------: | ------------: | -----------: |
-| vs        | a     |    -45.06-0j | -10406.07+0j) |    230.94+0j |
-| vs        | b     | 22.53+39.02j | -10406.07-0j) | -115.47-200j |
-| vs        | c     | 22.53-39.02j | -10406.07+0j) | -115.47+200j |
-| vs        | n     |           0j |            0j |           0j |
+| source_id | phase |      current |        power |    potential |
+| :-------- | :---- | -----------: | -----------: | -----------: |
+| vs        | a     |    -45.06-0j | -10406.07+0j |    230.94+0j |
+| vs        | b     | 22.53+39.02j | -10406.07-0j | -115.47-200j |
+| vs        | c     | 22.53-39.02j | -10406.07+0j | -115.47+200j |
+| vs        | n     |           0j |           0j |           0j |
 
 ```pycon
 >>> en.res_grounds

--- a/roseau/load_flow/exceptions.py
+++ b/roseau/load_flow/exceptions.py
@@ -24,6 +24,7 @@ class RoseauLoadFlowExceptionCode(Enum):
     BAD_BUS_ID = auto()
     BAD_BUS_TYPE = auto()
     BAD_POTENTIALS_SIZE = auto()
+    BAD_VOLTAGES = auto()
     BAD_VOLTAGES_SIZE = auto()
     BAD_SHORT_CIRCUIT = auto()
 

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -132,15 +132,15 @@ def network_from_dict(
     return buses, branches_dict, loads, sources, grounds, potential_refs
 
 
-def network_to_dict(en: "ElectricalNetwork", include_geometry: bool) -> JsonDict:
+def network_to_dict(en: "ElectricalNetwork", *, _lf_only: bool) -> JsonDict:
     """Return a dictionary of the current network data.
 
     Args:
         en:
             The electrical network.
 
-        include_geometry:
-            If False, the geometry will not be added to the network dictionary.
+        _lf_only:
+            Internal argument, please do not use.
 
     Returns:
         The created dictionary.
@@ -155,7 +155,7 @@ def network_to_dict(en: "ElectricalNetwork", include_geometry: bool) -> JsonDict
     sources: list[JsonDict] = []
     short_circuits: list[JsonDict] = []
     for bus in en.buses.values():
-        buses.append(bus.to_dict(include_geometry=include_geometry))
+        buses.append(bus.to_dict(_lf_only=_lf_only))
         for element in bus._connected_elements:
             if isinstance(element, AbstractLoad):
                 assert element.bus is bus
@@ -171,7 +171,7 @@ def network_to_dict(en: "ElectricalNetwork", include_geometry: bool) -> JsonDict
     lines_params_dict: dict[Id, LineParameters] = {}
     transformers_params_dict: dict[Id, TransformerParameters] = {}
     for branch in en.branches.values():
-        branches.append(branch.to_dict(include_geometry=include_geometry))
+        branches.append(branch.to_dict(_lf_only=_lf_only))
         if isinstance(branch, Line):
             params_id = branch.parameters.id
             if params_id in lines_params_dict and branch.parameters != lines_params_dict[params_id]:
@@ -192,13 +192,13 @@ def network_to_dict(en: "ElectricalNetwork", include_geometry: bool) -> JsonDict
     # Line parameters
     line_params: list[JsonDict] = []
     for lp in lines_params_dict.values():
-        line_params.append(lp.to_dict())
+        line_params.append(lp.to_dict(_lf_only=_lf_only))
     line_params.sort(key=lambda x: x["id"])  # Always keep the same order
 
     # Transformer parameters
     transformer_params: list[JsonDict] = []
     for tp in transformers_params_dict.values():
-        transformer_params.append(tp.to_dict())
+        transformer_params.append(tp.to_dict(_lf_only=_lf_only))
     transformer_params.sort(key=lambda x: x["id"])  # Always keep the same order
 
     res = {

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -126,7 +126,7 @@ class AbstractBranch(Element):
     def from_dict(cls, data: JsonDict) -> Self:
         return cls(**data)  # not used anymore
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         res = {
             "id": self.id,
             "type": self.branch_type,
@@ -135,7 +135,7 @@ class AbstractBranch(Element):
             "bus1": self.bus1.id,
             "bus2": self.bus2.id,
         }
-        if self.geometry is not None and include_geometry:
+        if not _lf_only and self.geometry is not None:
             res["geometry"] = self.geometry.__geo_interface__
         return res
 

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -178,7 +178,7 @@ class Bus(Element):
         self._max_voltage = value
 
     @property
-    def res_violated(self) -> bool | None:
+    def res_violated(self) -> Optional[bool]:
         """Whether the bus has voltage limits violations.
 
         Returns ``None`` if the bus has no voltage limits are not set.

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
+import pandas as pd
 from shapely import Point
 from typing_extensions import Self
 
@@ -40,6 +41,8 @@ class Bus(Element):
         phases: str,
         geometry: Optional[Point] = None,
         potentials: Optional[Sequence[complex]] = None,
+        min_voltage: Optional[float] = None,
+        max_voltage: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
         """Bus constructor.
@@ -60,8 +63,13 @@ class Bus(Element):
             potentials:
                 An optional list of initial potentials of each phase of the bus.
 
-            ground:
-                The ground of the bus.
+            min_voltage:
+                An optional minimum voltage of the bus (V). It is not used in the load flow.
+                It must be a phase-neutral voltage if the bus has a neutral, phase-phase otherwise.
+
+            max_voltage:
+                An optional maximum voltage of the bus (V). It is not used in the load flow.
+                It must be a phase-neutral voltage if the bus has a neutral, phase-phase otherwise.
         """
         super().__init__(id, **kwargs)
         self._check_phases(id, phases=phases)
@@ -70,6 +78,10 @@ class Bus(Element):
             potentials = [0] * len(phases)
         self.potentials = potentials
         self.geometry = geometry
+        self._min_voltage: Optional[float] = None
+        self._max_voltage: Optional[float] = None
+        self.min_voltage = min_voltage
+        self.max_voltage = max_voltage
 
         self._res_potentials: Optional[np.ndarray] = None
         self._short_circuits: list[dict[str, Any]] = []
@@ -127,6 +139,124 @@ class Bus(Element):
         potentials = self._res_potentials_getter(warning)
         return np.array([potentials[self.phases.index(p)] for p in phases])
 
+    @property
+    def min_voltage(self) -> Optional[Q_[float]]:
+        """The minimum voltage of the bus (V) if it is set."""
+        return None if self._min_voltage is None else Q_(self._min_voltage, "V")
+
+    @min_voltage.setter
+    @ureg_wraps(None, (None, "V"), strict=False)
+    def min_voltage(self, value: Optional[float]) -> None:
+        if value is not None and self._max_voltage is not None and value > self._max_voltage:
+            msg = (
+                f"Cannot set min voltage of bus {self.id!r} to {value} V as it is higher than its "
+                f"max voltage ({self._max_voltage} V)."
+            )
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES)
+        if pd.isna(value):
+            value = None
+        self._min_voltage = value
+
+    @property
+    def max_voltage(self) -> Optional[Q_[float]]:
+        """The maximum voltage of the bus (V) if it is set."""
+        return None if self._max_voltage is None else Q_(self._max_voltage, "V")
+
+    @max_voltage.setter
+    @ureg_wraps(None, (None, "V"), strict=False)
+    def max_voltage(self, value: Optional[float]) -> None:
+        if value is not None and self._min_voltage is not None and value < self._min_voltage:
+            msg = (
+                f"Cannot set max voltage of bus {self.id!r} to {value} V as it is lower than its "
+                f"min voltage ({self._min_voltage} V)."
+            )
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES)
+        if pd.isna(value):
+            value = None
+        self._max_voltage = value
+
+    @property
+    def res_violated(self) -> bool | None:
+        """Whether the bus has voltage limits violations.
+
+        Returns ``None`` if the bus has no voltage limits are not set.
+        """
+        if self._min_voltage is None and self._max_voltage is None:
+            return None
+        voltages = abs(self._res_voltages_getter(warning=True))
+        if self._min_voltage is None:
+            assert self._max_voltage is not None
+            return float(max(voltages)) > self._max_voltage
+        elif self._max_voltage is None:
+            return float(min(voltages)) < self._min_voltage
+        else:
+            return float(min(voltages)) < self._min_voltage or float(max(voltages)) > self._max_voltage
+
+    def propagate_limits(self, force: bool = False) -> None:
+        """Propagate the voltage limits to neighbor buses.
+
+        Neighbor buses here refers to buses connected to this bus through lines or switches. This
+        ensures that these voltage limits are only applied to buses with the same voltage level. If
+        a bus is connected to this bus through a transformer, the voltage limits are not propagated
+        to that bus.
+
+        If this bus does not define any voltage limits, calling this method will unset the limits
+        of the neighbor buses.
+
+        Args:
+            force:
+                If ``False`` (default), an exception is raised if connected buses already have
+                limits different from this bus. If ``True``, the limits are propagated even if
+                connected buses have different limits.
+        """
+        from roseau.load_flow.models.lines import Line, Switch
+
+        buses: set[Bus] = set()
+        visited: set[Element] = set()
+        remaining = set(self._connected_elements)
+
+        while remaining:
+            branch = remaining.pop()
+            visited.add(branch)
+            if not isinstance(branch, (Line, Switch)):
+                continue
+            for element in branch._connected_elements:
+                if not isinstance(element, Bus) or element is self or element in buses:
+                    continue
+                buses.add(element)
+                to_add = set(element._connected_elements).difference(visited)
+                remaining.update(to_add)
+                if not (
+                    force
+                    or self._min_voltage is None
+                    or element._min_voltage is None
+                    or np.isclose(element._min_voltage, self._min_voltage)
+                ):
+                    msg = (
+                        f"Cannot propagate the minimum voltage ({self._min_voltage} V) of bus {self.id!r} "
+                        f"to bus {element.id!r} with different minimum voltage ({element._min_voltage} V)."
+                    )
+                    logger.error(msg)
+                    raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES)
+                if not (
+                    force
+                    or self._max_voltage is None
+                    or element._max_voltage is None
+                    or np.isclose(element._max_voltage, self._max_voltage)
+                ):
+                    msg = (
+                        f"Cannot propagate the maximum voltage ({self._max_voltage} V) of bus {self.id!r} "
+                        f"to bus {element.id!r} with different maximum voltage ({element._max_voltage} V)."
+                    )
+                    logger.error(msg)
+                    raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES)
+
+        for bus in buses:
+            bus._min_voltage = self._min_voltage
+            bus._max_voltage = self._max_voltage
+
     #
     # Json Mixin interface
     #
@@ -136,14 +266,26 @@ class Bus(Element):
         potentials = data.get("potentials")
         if potentials is not None:
             potentials = [complex(v[0], v[1]) for v in potentials]
-        return cls(id=data["id"], phases=data["phases"], geometry=geometry, potentials=potentials)
+        return cls(
+            id=data["id"],
+            phases=data["phases"],
+            geometry=geometry,
+            potentials=potentials,
+            min_voltage=data.get("min_voltage"),
+            max_voltage=data.get("max_voltage"),
+        )
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         res = {"id": self.id, "phases": self.phases}
         if not np.allclose(self.potentials, 0):
             res["potentials"] = [[v.real, v.imag] for v in self._potentials]
-        if self.geometry is not None and include_geometry:
-            res["geometry"] = self.geometry.__geo_interface__
+        if not _lf_only:
+            if self.geometry is not None:
+                res["geometry"] = self.geometry.__geo_interface__
+            if self.min_voltage is not None:
+                res["min_voltage"] = self.min_voltage.magnitude
+            if self.max_voltage is not None:
+                res["max_voltage"] = self.max_voltage.magnitude
         return res
 
     def results_from_dict(self, data: JsonDict) -> None:
@@ -204,6 +346,6 @@ class Bus(Element):
         """Return the list of short-circuits of this bus."""
         return self._short_circuits[:]  # return a copy as users should not modify the list directly
 
-    def clear_short_circuits(self):
+    def clear_short_circuits(self) -> None:
         """Remove the short-circuits."""
         self._short_circuits = []

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -1,13 +1,15 @@
 import logging
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from typing_extensions import Self
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
-from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
+
+if TYPE_CHECKING:
+    from roseau.load_flow.models.buses import Bus
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +67,7 @@ class Ground(Element):
         """The bus ID and phase of the buses connected to this ground."""
         return self._connected_buses.copy()  # copy so that the user does not change it
 
-    def connect(self, bus: Bus, phase: str = "n") -> None:
+    def connect(self, bus: "Bus", phase: str = "n") -> None:
         """Connect the ground to a bus on the given phase.
 
         Args:
@@ -97,7 +99,7 @@ class Ground(Element):
         self._connected_buses = data["buses"]
         return self
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         # Shunt lines and potential references will have the ground in their dict not here.
         return {
             "id": self.id,

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -293,6 +293,13 @@ class Line(AbstractBranch):
         return self.parameters._y_shunt * self._length
 
     @property
+    def max_current(self) -> Optional[Q_[float]]:
+        """The maximum current loading of the line in A."""
+        # Do not add a setter. The user must know that if they change the max_current, it changes
+        # for all lines that share the parameters. It is better to set it on the parameters.
+        return self.parameters.max_current
+
+    @property
     def with_shunt(self) -> bool:
         return self.parameters.with_shunt
 
@@ -369,12 +376,25 @@ class Line(AbstractBranch):
         """Get the power losses in the line (VA)."""
         return self._res_power_losses_getter(warning=True)
 
+    @property
+    def res_violated(self) -> bool | None:
+        """Whether the line current exceeds the maximum current (loading > 100%).
+
+        Returns ``None`` if the maximum current is not set.
+        """
+        i_max = self.parameters._max_current
+        if i_max is None:
+            return None
+        currents1, currents2 = self._res_currents_getter(warning=True)
+        # True if any phase is overloaded
+        return float(np.max([abs(currents1), abs(currents2)])) > i_max
+
     #
     # Json Mixin interface
     #
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         res = {
-            **super().to_dict(include_geometry=include_geometry),
+            **super().to_dict(_lf_only=_lf_only),
             "length": self._length,
             "params_id": self.parameters.id,
         }

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -377,7 +377,7 @@ class Line(AbstractBranch):
         return self._res_power_losses_getter(warning=True)
 
     @property
-    def res_violated(self) -> bool | None:
+    def res_violated(self) -> Optional[bool]:
         """Whether the line current exceeds the maximum current (loading > 100%).
 
         Returns ``None`` if the maximum current is not set.

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -312,7 +312,7 @@ class Control(JsonMixin):
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_CONTROL_TYPE)
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         if self.type == "constant":
             return {"type": "constant"}
         elif self.type == "p_max_u_production":
@@ -427,7 +427,7 @@ class Projection(JsonMixin):
         epsilon = data["epsilon"] if "epsilon" in data else cls._DEFAULT_EPSILON
         return cls(type=data["type"], alpha=alpha, epsilon=epsilon)
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         return {"type": self.type, "alpha": self._alpha, "epsilon": self._epsilon}
 
     def _results_to_dict(self, warning: bool) -> NoReturn:
@@ -957,7 +957,7 @@ class FlexibleParameter(JsonMixin):
             q_max=q_max,
         )
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         res = {
             "control_p": self.control_p.to_dict(),
             "control_q": self.control_q.to_dict(),
@@ -1021,7 +1021,7 @@ class FlexibleParameter(JsonMixin):
         bus = Bus(id="bus", phases="an")
         vs = VoltageSource(id="source", bus=bus, voltages=[voltages[0]])
         PotentialRef(id="pref", element=bus, phase="n")
-        fp = FlexibleParameter.from_dict(data=self.to_dict(include_geometry=False))
+        fp = FlexibleParameter.from_dict(data=self.to_dict(_lf_only=True))
         load = PowerLoad(id="load", bus=bus, powers=[power], flexible_params=[fp])
         en = ElectricalNetwork.from_element(bus)
 

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -324,7 +324,7 @@ class PowerLoad(AbstractLoad):
     #
     # Json Mixin interface
     #
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         self._raise_disconnected_error()
         res = {
             "id": self.id,
@@ -396,7 +396,7 @@ class CurrentLoad(AbstractLoad):
         self._currents = self._validate_value(value)
         self._invalidate_network_results()
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         self._raise_disconnected_error()
         return {
             "id": self.id,
@@ -451,7 +451,7 @@ class ImpedanceLoad(AbstractLoad):
         self._impedances = self._validate_value(impedances)
         self._invalidate_network_results()
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         self._raise_disconnected_error()
         return {
             "id": self.id,

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -86,7 +86,7 @@ class PotentialRef(Element):
     def from_dict(cls, data: JsonDict) -> Self:
         return cls(data["id"], data["element"], phase=data.get("phases"))
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         res = {"id": self.id}
         e = self.element
         if isinstance(e, Bus):

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -161,7 +161,7 @@ class VoltageSource(Element):
         voltages = [complex(v[0], v[1]) for v in data["voltages"]]
         return cls(data["id"], data["bus"], voltages=voltages, phases=data["phases"])
 
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
         self._raise_disconnected_error()
         return {
             "id": self.id,

--- a/roseau/load_flow/models/tests/test_buses.py
+++ b/roseau/load_flow/models/tests/test_buses.py
@@ -1,14 +1,21 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from roseau.load_flow import (
+    Q_,
     Bus,
     ElectricalNetwork,
     Ground,
+    Line,
+    LineParameters,
     PotentialRef,
     PowerLoad,
     RoseauLoadFlowException,
     RoseauLoadFlowExceptionCode,
+    Switch,
+    Transformer,
+    TransformerParameters,
     VoltageSource,
 )
 
@@ -74,3 +81,203 @@ def test_short_circuit():
         bus.add_short_circuit("a", "b")
     assert "is already connected on bus" in e.value.msg
     assert e.value.args[1] == RoseauLoadFlowExceptionCode.BAD_SHORT_CIRCUIT
+
+
+def test_voltage_limits():
+    # Default values
+    bus = Bus("bus", phases="abc")
+    assert bus.min_voltage is None
+    assert bus.max_voltage is None
+
+    # Passed as arguments
+    bus = Bus("bus", phases="abc", min_voltage=350, max_voltage=420)
+    assert bus.min_voltage == Q_(350, "V")
+    assert bus.max_voltage == Q_(420, "V")
+
+    # Can be set to a real number
+    bus.min_voltage = 350.0
+    bus.max_voltage = 420.0
+    assert bus.min_voltage == Q_(350.0, "V")
+    assert bus.max_voltage == Q_(420.0, "V")
+
+    # Can be reset to None
+    bus.min_voltage = None
+    bus.max_voltage = None
+    assert bus.min_voltage is None
+    assert bus.max_voltage is None
+
+    # Can be set to a Quantity
+    bus.min_voltage = Q_(19, "kV")
+    bus.max_voltage = Q_(21, "kV")
+    assert bus.min_voltage == Q_(19_000, "V")
+    assert bus.max_voltage == Q_(21_000, "V")
+
+    # NaNs are converted to None
+    for na in (np.nan, float("nan"), pd.NA):
+        bus.min_voltage = na
+        bus.max_voltage = na
+        assert bus.min_voltage is None
+        assert bus.max_voltage is None
+
+    # Bad values
+    bus.min_voltage = 220
+    with pytest.raises(RoseauLoadFlowException) as e:
+        bus.max_voltage = 200
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_VOLTAGES
+    assert e.value.msg == "Cannot set max voltage of bus 'bus' to 200 V as it is lower than its min voltage (220 V)."
+    bus.max_voltage = 240
+    with pytest.raises(RoseauLoadFlowException) as e:
+        bus.min_voltage = 250
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_VOLTAGES
+    assert e.value.msg == "Cannot set min voltage of bus 'bus' to 250 V as it is higher than its max voltage (240 V)."
+
+
+def test_res_violated():
+    bus = Bus("bus", phases="abc")
+    direct_seq = np.exp([0, -2 / 3 * np.pi * 1j, 2 / 3 * np.pi * 1j])
+    bus._res_potentials = 230 * direct_seq
+
+    # No limits
+    assert bus.res_violated is None
+
+    # Only min voltage
+    bus.min_voltage = 350
+    assert bus.res_violated is False
+    bus.min_voltage = 450
+    assert bus.res_violated is True
+
+    # Only max voltage
+    bus.min_voltage = None
+    bus.max_voltage = 450
+    assert bus.res_violated is False
+    bus.max_voltage = 350
+    assert bus.res_violated is True
+
+    # Both min and max voltage
+    # min <= v <= max
+    bus.min_voltage = 350
+    bus.max_voltage = 450
+    assert bus.res_violated is False
+    # v < min
+    bus.min_voltage = 450
+    assert bus.res_violated is True
+    # v > max
+    bus.min_voltage = 350
+    bus.max_voltage = 350
+    assert bus.res_violated is True
+
+
+def test_propagate_limits():  # noqa: C901
+    b1_mv = Bus("b1_mv", phases="abc")
+    b2_mv = Bus("b2_mv", phases="abc")
+    b3_mv = Bus("b3_mv", phases="abc")
+    b1_lv = Bus("b1_lv", phases="abcn")
+    b2_lv = Bus("b2_lv", phases="abcn")
+
+    PotentialRef("pref_mv", element=b1_mv)
+    g = Ground("g")
+    PotentialRef("pref_lv", element=g)
+
+    lp_mv = LineParameters("lp_mv", z_line=np.eye(3), y_shunt=0.1 * np.eye(3))
+    lp_lv = LineParameters("lp_lv", z_line=np.eye(4))
+    tp = TransformerParameters.from_catalogue(id="SE_Minera_A0Ak_100kVA", manufacturer="SE")
+
+    Line("l1_mv", b1_mv, b2_mv, length=1.5, parameters=lp_mv, ground=g)
+    Line("l2_mv", b2_mv, b3_mv, length=2, parameters=lp_mv, ground=g)
+    Transformer("tr", b3_mv, b1_lv, parameters=tp)
+    Line("l1_lv", b1_lv, b2_lv, length=1, parameters=lp_lv)
+
+    voltages = 20_000 * np.exp([0, -2 / 3 * np.pi * 1j, 2 / 3 * np.pi * 1j])
+    VoltageSource("s_mv", bus=b1_mv, voltages=voltages)
+
+    PowerLoad("pl1_mv", bus=b2_mv, powers=[10e3, 10e3, 10e3])
+    PowerLoad("pl2_mv", bus=b3_mv, powers=[10e3, 10e3, 10e3])
+    PowerLoad("pl1_lv", bus=b1_lv, powers=[1e3, 1e3, 1e3])
+    PowerLoad("pl2_lv", bus=b2_lv, powers=[1e3, 1e3, 1e3])
+
+    # All buses have None as min and max voltage
+    for bus in (b1_mv, b2_mv, b3_mv, b1_lv, b2_lv):
+        assert bus.min_voltage is None
+        assert bus.max_voltage is None
+
+    # Set min and max voltage of b1_mv
+    b1_mv.min_voltage = 19_000
+    b1_mv.max_voltage = 21_000
+    # propagate MV voltage limits
+    b1_mv.propagate_limits()
+    for bus in (b1_mv, b2_mv, b3_mv):
+        assert bus.min_voltage == Q_(19_000, "V")
+        assert bus.max_voltage == Q_(21_000, "V")
+    for bus in (b1_lv, b2_lv):
+        assert bus.min_voltage is None
+        assert bus.max_voltage is None
+
+    # Set min and max voltage of b1_lv
+    b1_lv.min_voltage = 217
+    b1_lv.max_voltage = 253
+    b1_lv.propagate_limits()
+    for bus in (b1_mv, b2_mv, b3_mv):
+        assert bus.min_voltage == Q_(19_000, "V")
+        assert bus.max_voltage == Q_(21_000, "V")
+    for bus in (b1_lv, b2_lv):
+        assert bus.min_voltage == Q_(217, "V")
+        assert bus.max_voltage == Q_(253, "V")
+
+    # Reset min MV voltage limits only
+    b1_mv.min_voltage = None
+    b1_mv.propagate_limits()
+    for bus in (b1_mv, b2_mv, b3_mv):
+        assert bus.min_voltage is None
+        assert bus.max_voltage == Q_(21_000, "V")
+    for bus in (b1_lv, b2_lv):
+        assert bus.min_voltage == Q_(217, "V")
+        assert bus.max_voltage == Q_(253, "V")
+
+    # Error, different max voltage limits
+    b1_mv.max_voltage = 21_005
+    with pytest.raises(RoseauLoadFlowException) as e:
+        b1_mv.propagate_limits()
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_VOLTAGES
+    assert e.value.msg == (
+        "Cannot propagate the maximum voltage (21005 V) of bus 'b1_mv' to bus 'b2_mv' with "
+        "different maximum voltage (21000 V)."
+    )
+
+    # The limits are not changed after the error
+    for bus in (b2_mv, b3_mv):
+        assert bus.min_voltage is None
+        assert bus.max_voltage == Q_(21_000, "V")
+    for bus in (b1_lv, b2_lv):
+        assert bus.min_voltage == Q_(217, "V")
+        assert bus.max_voltage == Q_(253, "V")
+
+    # It is okay to propagate with different limits if force=True
+    b1_mv.propagate_limits(force=True)
+    for bus in (b1_mv, b2_mv, b3_mv):
+        assert bus.min_voltage is None
+        assert bus.max_voltage == Q_(21_005, "V")
+    for bus in (b1_lv, b2_lv):
+        assert bus.min_voltage == Q_(217, "V")
+        assert bus.max_voltage == Q_(253, "V")
+
+    # What if there is a switch?
+    b4_mv = Bus("b4_mv", phases="abc")
+    Switch("sw", b2_mv, b4_mv)
+    b1_mv.propagate_limits()
+    for bus in (b1_mv, b2_mv, b3_mv, b4_mv):
+        assert bus.min_voltage is None
+        assert bus.max_voltage == Q_(21_005, "V")
+    for bus in (b1_lv, b2_lv):
+        assert bus.min_voltage == Q_(217, "V")
+        assert bus.max_voltage == Q_(253, "V")
+
+    # Let's add a MV loop; does it still work?
+    Line("l3_mv", b1_mv, b3_mv, length=1, parameters=lp_mv, ground=g)
+    b1_mv.min_voltage = 19_000
+    b1_mv.propagate_limits()
+    for bus in (b1_mv, b2_mv, b3_mv, b4_mv):
+        assert bus.min_voltage == Q_(19_000, "V")
+        assert bus.max_voltage == Q_(21_005, "V")
+    for bus in (b1_lv, b2_lv):
+        assert bus.min_voltage == Q_(217, "V")
+        assert bus.max_voltage == Q_(253, "V")

--- a/roseau/load_flow/models/tests/test_line_parameters.py
+++ b/roseau/load_flow/models/tests/test_line_parameters.py
@@ -5,6 +5,7 @@ import pytest
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models import Bus, Ground, Line, LineParameters
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import ConductorType, InsulatorType, LineType
 
 
@@ -345,3 +346,20 @@ def test_from_name_mv():
     lp = LineParameters.from_name_mv("U_AL_150")
     npt.assert_allclose(lp.z_line.m_as("ohm/km"), z_line_expected)
     npt.assert_allclose(lp.y_shunt.m_as("S/km"), y_shunt_expected, rtol=1e-4)
+
+
+def test_max_current():
+    lp = LineParameters("test", z_line=np.eye(3))
+    assert lp.max_current is None
+
+    lp = LineParameters("test", z_line=np.eye(3), max_current=100)
+    assert lp.max_current == Q_(100, "A")
+
+    lp.max_current = 200
+    assert lp.max_current == Q_(200, "A")
+
+    lp.max_current = None
+    assert lp.max_current is None
+
+    lp.max_current = Q_(3, "kA")
+    assert lp.max_current == Q_(3_000, "A")

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -460,3 +460,30 @@ def test_print_catalogue():
     with console.capture() as capture:
         TransformerParameters.print_catalogue(ulv=250)
     assert len(capture.get().split("\n")) == 2
+
+
+def test_max_power():
+    kwds = {
+        "type": "yzn11",
+        "psc": 1350.0,
+        "p0": 145.0,
+        "i0": 1.8 / 100,
+        "ulv": 400,
+        "uhv": 20000,
+        "sn": 50 * 1e3,
+        "vsc": 4 / 100,
+    }
+    tp = TransformerParameters("test", **kwds)
+    assert tp.max_power is None
+
+    tp = TransformerParameters("test", **kwds, max_power=60_000)
+    assert tp.max_power == Q_(60_000, "VA")
+
+    tp.max_power = 55_000
+    assert tp.max_power == Q_(55_000, "VA")
+
+    tp.max_power = None
+    assert tp.max_power is None
+
+    tp.max_power = Q_(65, "kVA")
+    assert tp.max_power == Q_(65_000, "VA")

--- a/roseau/load_flow/models/tests/test_transformers.py
+++ b/roseau/load_flow/models/tests/test_transformers.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from roseau.load_flow.models import Bus, Transformer, TransformerParameters
+
+
+def test_res_violated():
+    bus1 = Bus("bus1", phases="abc")
+    bus2 = Bus("bus1", phases="abcn")
+    tp = TransformerParameters(
+        id="tp", psc=1350.0, p0=145.0, i0=1.8 / 100, ulv=400, uhv=20000, sn=50 * 1e3, vsc=4 / 100, type="yzn11"
+    )
+    transformer = Transformer("transformer", bus1=bus1, bus2=bus2, parameters=tp)
+    direct_seq = np.exp([0, -2 / 3 * np.pi * 1j, 2 / 3 * np.pi * 1j])
+    direct_seq_neutral = np.concatenate([direct_seq, [0]])
+
+    bus1._res_potentials = 20_000 * direct_seq
+    bus2._res_potentials = 230 * direct_seq_neutral
+    transformer._res_currents = 0.8 * direct_seq, -65 * direct_seq_neutral
+
+    # No limits
+    assert transformer.res_violated is None
+
+    # No constraint violated
+    tp.max_power = 50_000
+    assert transformer.res_violated is False
+
+    # Two violations
+    tp.max_power = 40_000
+    assert transformer.res_violated is True
+
+    # Primary side violation
+    tp.max_power = 47_900
+    assert transformer.res_violated is True
+
+    # Secondary side violation
+    tp.max_power = 50_000
+    transformer._res_currents = 0.8 * direct_seq, -80 * direct_seq_neutral
+    assert transformer.res_violated is True

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -255,7 +255,7 @@ class Transformer(AbstractBranch):
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
 
     @property
-    def res_violated(self) -> bool | None:
+    def res_violated(self) -> Optional[bool]:
         """Whether the transformer power exceeds the maximum power (loading > 100%).
 
         Returns ``None`` if the maximum power is not set.

--- a/roseau/load_flow/tests/test_converters.py
+++ b/roseau/load_flow/tests/test_converters.py
@@ -3,7 +3,7 @@ import pandas as pd
 from pandas.testing import assert_series_equal
 
 from roseau.load_flow.converters import phasor_to_sym, series_phasor_to_sym, sym_to_phasor
-from roseau.load_flow.network import _PHASE_DTYPE
+from roseau.load_flow.utils import PhaseDtype
 
 
 def test_phasor_to_sym():
@@ -88,7 +88,7 @@ def test_series_phasor_to_sym():
         [("bus1", "a"), ("bus1", "b"), ("bus1", "c"), ("bus2", "a"), ("bus2", "b"), ("bus2", "c")],
         names=["bus_id", "phase"],
     )
-    index = index.set_levels(index.levels[-1].astype(_PHASE_DTYPE), level=-1)
+    index = index.set_levels(index.levels[-1].astype(PhaseDtype), level=-1)
     voltage = pd.Series([va, vb, vc, va / 2, vb / 2, vc / 2], index=index, name="voltage")
 
     seq_dtype = pd.CategoricalDtype(categories=["zero", "pos", "neg"], ordered=True)

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -12,6 +12,7 @@ Units registry used by Roseau Load Flow using the `pint`_ package.
 .. _pint: https://pint.readthedocs.io/en/stable/getting/overview.html
 """
 from collections.abc import Callable, Iterable
+from types import GenericAlias
 from typing import TYPE_CHECKING, TypeVar, Union
 
 from pint import Unit, UnitRegistry
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
     Q_: TypeAlias = PlainQuantity[T]
 else:
     Q_ = ureg.Quantity
-    Q_.__class_getitem__ = lambda cls, *args: cls
+    Q_.__class_getitem__ = classmethod(GenericAlias)
 
 
 def ureg_wraps(
@@ -40,4 +41,16 @@ def ureg_wraps(
     args: Union[str, Unit, None, Iterable[Union[str, Unit, None]]],
     strict: bool = True,
 ) -> Callable[[FuncT], FuncT]:
+    """Wraps a function to become pint-aware.
+
+    Args:
+        ureg:
+            a UnitRegistry instance.
+        ret:
+            Units of each of the return values. Use `None` to skip argument conversion.
+        args:
+            Units of each of the input arguments. Use `None` to skip argument conversion.
+        strict:
+            Indicates that only quantities are accepted. (Default value = True)
+    """
     return ureg.wraps(ret, args, strict)

--- a/roseau/load_flow/utils/__init__.py
+++ b/roseau/load_flow/utils/__init__.py
@@ -4,7 +4,14 @@ This module contains utility classes and functions for Roseau Load Flow.
 from roseau.load_flow.utils.console import console, palette
 from roseau.load_flow.utils.constants import CX, DELTA_P, EPSILON_0, EPSILON_R, MU_0, MU_R, OMEGA, PI, RHO, TAN_D, F
 from roseau.load_flow.utils.mixins import CatalogueMixin, Identifiable, JsonMixin
-from roseau.load_flow.utils.types import ConductorType, InsulatorType, LineType
+from roseau.load_flow.utils.types import (
+    BranchTypeDtype,
+    ConductorType,
+    InsulatorType,
+    LineType,
+    PhaseDtype,
+    VoltagePhaseDtype,
+)
 
 __all__ = [
     # Constants
@@ -27,6 +34,10 @@ __all__ = [
     "LineType",
     "ConductorType",
     "InsulatorType",
+    # Dtypes
+    "PhaseDtype",
+    "VoltagePhaseDtype",
+    "BranchTypeDtype",
     # Console
     "console",
     "palette",

--- a/roseau/load_flow/utils/mixins.py
+++ b/roseau/load_flow/utils/mixins.py
@@ -53,13 +53,9 @@ class JsonMixin(metaclass=ABCMeta):
         return cls.from_dict(data=data)
 
     @abstractmethod
-    def to_dict(self, include_geometry: bool = True) -> JsonDict:
-        """Return the element information as a dictionary format.
-
-        Args:
-            include_geometry:
-                If False, the geometry will not be added to the result dictionary.
-        """
+    def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
+        """Return the element information as a dictionary format."""
+        # _lf_only is used internally by Roseau Load Flow. Please do not use.
         raise NotImplementedError
 
     def to_json(self, path: StrPath) -> Path:

--- a/roseau/load_flow/utils/types.py
+++ b/roseau/load_flow/utils/types.py
@@ -1,12 +1,55 @@
 import logging
 from enum import Enum, auto, unique
 
+import pandas as pd
 from typing_extensions import Self
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 
 # The local logger
 logger = logging.getLogger(__name__)
+
+
+# pandas dtypes used in the data frames
+PhaseDtype = pd.CategoricalDtype(categories=["a", "b", "c", "n"], ordered=True)
+"""Categorical data type used for the phase of potentials, currents, powers, etc."""
+VoltagePhaseDtype = pd.CategoricalDtype(categories=["an", "bn", "cn", "ab", "bc", "ca"], ordered=True)
+"""Categorical data type used for the phase of voltages and flexible powers only."""
+BranchTypeDtype = pd.CategoricalDtype(categories=["line", "transformer", "switch"], ordered=True)
+"""Categorical data type used for branch types."""
+_DTYPES = {
+    "bus_id": object,
+    "branch_id": object,
+    "transformer_id": object,
+    "line_id": object,
+    "switch_id": object,
+    "load_id": object,
+    "source_id": object,
+    "ground_id": object,
+    "potential_ref_id": object,
+    "branch_type": BranchTypeDtype,
+    "phase": PhaseDtype,
+    "current": complex,
+    "current1": complex,
+    "current2": complex,
+    "power": complex,
+    "power1": complex,
+    "power2": complex,
+    "potential": complex,
+    "potential1": complex,
+    "potential2": complex,
+    "voltage": complex,
+    "voltage1": complex,
+    "voltage2": complex,
+    "max_power": float,
+    "series_losses": complex,
+    "shunt_losses": complex,
+    "series_current": complex,
+    "max_current": float,
+    "min_voltage": float,
+    "max_voltage": float,
+    "violated": pd.BooleanDtype(),
+}
 
 
 @unique


### PR DESCRIPTION
The constraints are not used by the load flow solver. They are only used to analyze the results.

The constraints that can be defined include:
- For buses: minimum and maximum voltages. Use `bus.res_violated` to see if the bus has over- or under-voltage.
- For lines: a maximum current. Use `line.res_violated` to see if the loading of any of the line's cables is too high.
- For transformers: a maximum power. Use `transformer.res_violated` to see if the transformer loading is too high.
- The new fields also appear in the data frames of the network.

I still need to change the documentation.