### PR TITLE
Add API reference to the models pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,7 @@ autodoc_default_options = {"ignore-module-all": False}
 autodoc_member_order = "bysource"
 autodoc_typehints = "signature"
 autodoc_inherit_docstrings = True
+autoclass_content = "both"  # show both class and __init__ docstrings
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -42,7 +42,8 @@ usage/index
 
 ## Models
 
-A description of the electrical models used for each component is available:
+A description of the electrical models used for each component, an example usage, and a reference
+to the API of the classes are available here:
 
 ```{toctree}
 ---

--- a/doc/models/Bus.md
+++ b/doc/models/Bus.md
@@ -101,3 +101,12 @@ en.res_branches[["current1"]].transform([np.abs, ft.partial(np.angle, deg=True)]
 # | ('line', 'c') |                      0     |                  0      |
 # | ('line', 'n') |                      0     |                  0      |
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.Bus
+   :members:
+   :show-inheritance:
+   :no-index:
+```

--- a/doc/models/Ground.md
+++ b/doc/models/Ground.md
@@ -147,3 +147,12 @@ en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
 # | ('bus3', 'bc') |                   385.429 |         -121.026       |
 # | ('bus3', 'ca') |                   399.18  |          118.807       |
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.Ground
+   :members:
+   :show-inheritance:
+   :no-index:
+```

--- a/doc/models/Line/index.md
+++ b/doc/models/Line/index.md
@@ -180,3 +180,16 @@ Parameters
 ShuntLine
 SimplifiedLine
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.LineParameters
+   :members:
+   :show-inheritance:
+   :no-index:
+.. autoclass:: roseau.load_flow.models.Line
+   :members:
+   :show-inheritance:
+   :no-index:
+```

--- a/doc/models/Load/FlexibleLoad/index.md
+++ b/doc/models/Load/FlexibleLoad/index.md
@@ -55,3 +55,20 @@ Projection
 FlexibleParameter
 FeasibleDomain
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.Control
+   :members:
+   :show-inheritance:
+   :no-index:
+.. autoclass:: roseau.load_flow.models.Projection
+   :members:
+   :show-inheritance:
+   :no-index:
+.. autoclass:: roseau.load_flow.models.FlexibleParameter
+    :members:
+    :show-inheritance:
+    :no-index:
+```

--- a/doc/models/Load/index.md
+++ b/doc/models/Load/index.md
@@ -76,3 +76,24 @@ CurrentLoad
 PowerLoad
 FlexibleLoad/index
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.AbstractLoad
+   :members:
+   :show-inheritance:
+   :no-index:
+.. autoclass:: roseau.load_flow.models.ImpedanceLoad
+   :members:
+   :show-inheritance:
+   :no-index:
+.. autoclass:: roseau.load_flow.models.CurrentLoad
+    :members:
+    :show-inheritance:
+    :no-index:
+.. autoclass:: roseau.load_flow.models.PowerLoad
+    :members:
+    :show-inheritance:
+    :no-index:
+```

--- a/doc/models/PotentialRef.md
+++ b/doc/models/PotentialRef.md
@@ -47,3 +47,12 @@ from roseau.load_flow.models import Bus, PotentialRef
 bus = Bus(id="bus", phases="abcn")
 p_ref = PotentialRef(id="pref", element=bus, phase="a")
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.PotentialRef
+   :members:
+   :show-inheritance:
+   :no-index:
+```

--- a/doc/models/Switch.md
+++ b/doc/models/Switch.md
@@ -84,7 +84,7 @@ en.res_branches[["current2"]].transform([np.abs, ft.partial(np.angle, deg=True)]
 # The two currents are equal in magnitude and opposite in phase, as expected
 
 # The two buses have the same voltages
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages[["voltage"]].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                    230.94 |                      0 |
@@ -93,4 +93,13 @@ en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
 # | ('bus2', 'an') |                    230.94 |                      0 |
 # | ('bus2', 'bn') |                    230.94 |                   -120 |
 # | ('bus2', 'cn') |                    230.94 |                    120 |
+```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.Switch
+   :members:
+   :show-inheritance:
+   :no-index:
 ```

--- a/doc/models/Transformer/index.md
+++ b/doc/models/Transformer/index.md
@@ -154,3 +154,16 @@ Single_Phase_Transformer
 Three_Phase_Transformer
 Center_Tapped_Transformer
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.TransformerParameters
+   :members:
+   :show-inheritance:
+   :no-index:
+.. autoclass:: roseau.load_flow.models.Transformer
+   :members:
+   :show-inheritance:
+   :no-index:
+```

--- a/doc/models/VoltageSource.md
+++ b/doc/models/VoltageSource.md
@@ -111,3 +111,12 @@ un = 400
 voltages = un * np.exp([0, -2j * np.pi / 3])  # Only two elements!!
 VoltageSource(id="vs", bus=bus, phases="abc", voltages=voltages)  # Error
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autoclass:: roseau.load_flow.models.VoltageSource
+   :members:
+   :show-inheritance:
+   :no-index:
+```

--- a/doc/usage/Getting_Started.md
+++ b/doc/usage/Getting_Started.md
@@ -58,8 +58,6 @@ The following is a summary of the available elements:
   - `PotentialRef`: A potential reference sets the reference of potentials in the network. It can be connected to
     buses or grounds.
 
-For a more detailed description of the elements, please refer to the [API reference](../autoapi/roseau/load_flow/models/index).
-
 Let's use some of these elements to build the following network with a voltage source, a simple
 line and a constant power load. This network is a low voltage network (three-phase + neutral wire).
 

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -20,11 +20,7 @@ if TYPE_CHECKING:
 
 
 class Bus(Element):
-    """An electrical bus.
-
-    See Also:
-        :doc:`Bus model documentation </models/Bus>`
-    """
+    """A multi-phase electrical bus."""
 
     allowed_phases = frozenset({"ab", "bc", "ca", "an", "bn", "cn", "abn", "bcn", "can", "abc", "abcn"})
     """The allowed phases for a bus are:
@@ -54,7 +50,7 @@ class Bus(Element):
             phases:
                 The phases of the bus. A string like ``"abc"`` or ``"an"`` etc. The order of the
                 phases is important. For a full list of supported phases, see the class attribute
-                :attr:`Bus.allowed_phases`.
+                :attr:`.allowed_phases`.
 
             geometry:
                 An optional geometry of the bus; a :class:`~shapely.Point` that represents the
@@ -347,5 +343,5 @@ class Bus(Element):
         return self._short_circuits[:]  # return a copy as users should not modify the list directly
 
     def clear_short_circuits(self) -> None:
-        """Remove the short-circuits."""
+        """Remove the short-circuits of this bus."""
         self._short_circuits = []

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -30,10 +30,6 @@ class Ground(Element):
 
        To connect a ground to a line with shunt components, pass the ground object to the
        :class:`Line` constructor. Note that the ground connection is mandatory for shunt lines.
-
-
-    See Also:
-        :doc:`Ground model documentation </models/Ground>`
     """
 
     allowed_phases = frozenset({"a", "b", "c", "n"})

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -19,11 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class Switch(AbstractBranch):
-    """A general purpose switch branch.
-
-    See Also:
-        :doc:`Switch model documentation </models/Switch>`
-    """
+    """A general purpose switch branch."""
 
     branch_type = "switch"
 
@@ -128,11 +124,7 @@ class Switch(AbstractBranch):
 
 
 class Line(AbstractBranch):
-    """An electrical line PI model with series impedance and optional shunt admittance.
-
-    See Also:
-        :doc:`Line documentation </models/Line/index>`
-    """
+    """An electrical line PI model with series impedance and optional shunt admittance."""
 
     branch_type = "line"
 
@@ -171,7 +163,8 @@ class Line(AbstractBranch):
                 The second bus (aka `"to_bus"`) to connect to the line.
 
             parameters:
-                The parameters of the line, an instance of :class:`LineParameters`.
+                Parameters defining the electrical model of the line. This is an instance of the
+                :class:`LineParameters` class and can be used by multiple lines.
 
             length:
                 The length of the line in km.

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -30,11 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class LineParameters(Identifiable, JsonMixin):
-    """A class to store the line parameters of lines
-
-    See Also:
-        :ref:`Line parameters documentation <models-line_parameters>`
-    """
+    """Parameters that define electrical models of lines."""
 
     _type_re = "|".join("|".join(x) for x in LineType.CODES.values())
     _material_re = "|".join(x.code() for x in ConductorType)

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -45,9 +45,6 @@ class Control(JsonMixin):
           :math:`P^{\\max}_{\\mathrm{cons}}(U)`.
 
         * ``"q_u"``: control the reactive power based on the voltage :math:`Q(U)`.
-
-    See Also:
-        :ref:`Control documentation <models-flexible_load-controls>`
     """
 
     _DEFAULT_ALPHA: float = 1000.0
@@ -351,9 +348,6 @@ class Projection(JsonMixin):
         * ``"euclidean"``: for a Euclidean projection on the feasible space;
         * ``"keep_p"``: for maintaining a constant P;
         * ``"keep_q"``: for maintaining a constant Q.
-
-    See Also:
-        :ref:`Projection documentation <models-flexible_load-projections>`
     """
 
     _DEFAULT_ALPHA: float = 1000.0
@@ -453,9 +447,6 @@ class FlexibleParameter(JsonMixin):
             the radius of the feasible circle used by the projection
 
     For multi-phase loads, you need to use a `FlexibleParameter` instance per phase.
-
-    See Also:
-        :ref:`Flexible Parameters documentation <models-flexible_load-flexible_parameters>`
     """
 
     _control_class: type[Control] = Control

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -20,11 +20,8 @@ class AbstractLoad(Element, ABC):
     """An abstract class of an electric load.
 
     The subclasses of this class can be used to depict:
-        * star-connected loads using a `phases` constructor argument containing a `"n"`
-        * delta-connected loads using a `phases` constructor argument which doesn't contain `"n"`
-
-    See Also:
-        :doc:`Load documentation </models/Load/index>`
+        * star-connected loads using a `phases` constructor argument containing `"n"`
+        * delta-connected loads using a `phases` constructor argument not containing `"n"`
     """
 
     _power_load_class: type["PowerLoad"]
@@ -204,11 +201,7 @@ class AbstractLoad(Element, ABC):
 
 
 class PowerLoad(AbstractLoad):
-    """A constant power load.
-
-    See Also:
-        :doc:`Power Load documentation </models/Load/PowerLoad>`
-    """
+    """A constant power load."""
 
     _type = "power"
 
@@ -352,11 +345,7 @@ class PowerLoad(AbstractLoad):
 
 
 class CurrentLoad(AbstractLoad):
-    """A constant current load.
-
-    See Also:
-        :doc:`Current Load documentation </models/Load/CurrentLoad>`
-    """
+    """A constant current load."""
 
     _type = "current"
 
@@ -407,11 +396,7 @@ class CurrentLoad(AbstractLoad):
 
 
 class ImpedanceLoad(AbstractLoad):
-    """A constant impedance load.
-
-    See Also:
-        :doc:`Impedance Load documentation </models/Load/ImpedanceLoad>`
-    """
+    """A constant impedance load."""
 
     _type = "impedance"
 

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -21,9 +21,6 @@ class PotentialRef(Element):
     can be set on any bus or ground elements. If set on a bus with no neutral and without
     specifying the phase, the reference will be set as ``Va + Vb + Vc = 0``. For other buses, the
     default is ``Vn = 0``.
-
-    See Also:
-        :doc:`Potential reference model documentation </models/PotentialRef>`
     """
 
     allowed_phases = frozenset({"a", "b", "c", "n"})

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -16,11 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class VoltageSource(Element):
-    """A voltage source.
-
-    See Also:
-        :doc:`Voltage source model documentation </models/VoltageSource>`
-    """
+    """A voltage source."""
 
     allowed_phases = Bus.allowed_phases
     """The allowed phases for a voltage source are the same as for a :attr:`bus<Bus.allowed_phases>`."""

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -21,11 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
-    """A class to store the parameters of the transformers.
-
-    See Also:
-        :ref:`Transformer parameters documentation <models-transformer_parameters>`
-    """
+    """Parameters that define electrical models of transformers."""
 
     _EXTRACT_WINDINGS_RE = regex.compile(
         "(?(DEFINE)(?P<y_winding>yn?)(?P<d_winding>d)(?P<z_winding>zn?)(?P<p_set_1>[06])"

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -16,10 +16,7 @@ logger = logging.getLogger(__name__)
 class Transformer(AbstractBranch):
     """A generic transformer model.
 
-    The model parameters are defined in the ``parameters``.
-
-    See Also:
-        :doc:`Transformer models documentation </models/Transformer/index>`
+    The model parameters are defined using the ``parameters`` argument.
     """
 
     branch_type = "transformer"
@@ -65,7 +62,8 @@ class Transformer(AbstractBranch):
                 The tap of the transformer, for example 1.02.
 
             parameters:
-                The parameters of the transformer.
+                Parameters defining the electrical model of the transformer. This is an instance of
+                the :class:`TransformerParameters` class and can be used by multiple transformers.
 
             phases1:
                 The phases of the first extremity of the transformer. A string like ``"abc"`` or

--- a/roseau/load_flow/utils/mixins.py
+++ b/roseau/load_flow/utils/mixins.py
@@ -54,8 +54,12 @@ class JsonMixin(metaclass=ABCMeta):
 
     @abstractmethod
     def to_dict(self, *, _lf_only: bool = False) -> JsonDict:
-        """Return the element information as a dictionary format."""
-        # _lf_only is used internally by Roseau Load Flow. Please do not use.
+        """Return the element information as a dictionary format.
+
+        Args:
+            _lf_only:
+                Internal argument, please do not use.
+        """
         raise NotImplementedError
 
     def to_json(self, path: StrPath) -> Path:


### PR DESCRIPTION
So this improves the docs of the elements by bringing the documentation of the API of an element closer to the the definition of its model.
I left the comprehensive API alone which means each element class now have two pages describing its API. This is OK because the pages are auto-generated so they never get out of sync.

<details>

<summary>The API is now easy to access from the models index page. Click here for a preview</summary>

![Screenshot from 2023-10-09 17-27-50](https://github.com/RoseauTechnologies/Roseau_Load_Flow/assets/33871648/effe1b21-a0c2-4f63-ba80-dbd01fe279e1)

Here is an example showing both the model and API of the potential reference element

![Screenshot from 2023-10-09 17-26-05](https://github.com/RoseauTechnologies/Roseau_Load_Flow/assets/33871648/6028ab95-3dd7-4698-97c6-0fec66a240d6)

</details>

I removed the "See Also" links from the doscstring as they point to the same page the text is displayed in now.