### PR TITLE
Fix handling of quantities in input sequences

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,6 +4,7 @@
 
 **In development**
 
+- {gh-pr}`146` {gh-issue}`145` Fix handling of quantities in input sequences
 - {gh-pr}`142` {gh-issue}`136` Add `Bus.res_voltage_unbalance()` method to get the Voltage Unbalance
   Factor (VUF) as defined by the IEC standard IEC 61000-3-14.
 - {gh-pr}`141` {gh-issue}`137` Add `ElectricalNetwork.to_graph()` to get a `networkx.Graph` object

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -92,13 +92,12 @@ class Bus(Element):
         return self._potentials
 
     @potentials.setter
-    @ureg_wraps(None, (None, "V"), strict=False)
     def potentials(self, value: Sequence[complex]) -> None:
         if len(value) != len(self.phases):
             msg = f"Incorrect number of potentials: {len(value)} instead of {len(self.phases)}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_POTENTIALS_SIZE)
-        self._potentials = np.asarray(value, dtype=complex)
+        self._potentials = np.array([Q_(v, "V").m for v in value], dtype=complex)
         self._invalidate_network_results()
 
     def _res_potentials_getter(self, warning: bool) -> ComplexArray:

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -90,13 +90,12 @@ class VoltageSource(Element):
         return self._voltages
 
     @voltages.setter
-    @ureg_wraps(None, (None, "V"), strict=False)
     def voltages(self, voltages: Sequence[complex]) -> None:
         if len(voltages) != self._size:
             msg = f"Incorrect number of voltages: {len(voltages)} instead of {self._size}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES_SIZE)
-        self._voltages = np.asarray(voltages, dtype=complex)
+        self._voltages = np.array([Q_(v, "V").m for v in voltages], dtype=complex)
         self._invalidate_network_results()
 
     @property

--- a/roseau/load_flow/models/tests/test_loads.py
+++ b/roseau/load_flow/models/tests/test_loads.py
@@ -354,13 +354,25 @@ def test_loads_units():
     load.powers = Q_([1, 1, 1], "kVA")
     assert np.allclose(load._powers, [1000, 1000, 1000])
 
+    # Also works as a quantity array
+    load = PowerLoad("load", bus, powers=Q_(10, "kVA") * np.ones(3), phases="abcn")
+    assert np.allclose(load._powers, [10000, 10000, 10000])
+
+    # Units in a list
+    load = PowerLoad("load", bus, powers=[Q_(1_000, "VA"), Q_(1, "kVA"), Q_(0.001, "MVA")], phases="abcn")
+    assert np.allclose(load._powers, [1000, 1000, 1000])
+    load = CurrentLoad("load", bus, currents=[Q_(1_000, "A"), Q_(1, "kA"), Q_(0.001, "MA")], phases="abcn")
+    assert np.allclose(load._currents, [1000, 1000, 1000])
+    load = ImpedanceLoad("load", bus, impedances=[Q_(1_000, "ohm"), Q_(1, "kohm"), Q_(0.001, "Mohm")], phases="abcn")
+    assert np.allclose(load._impedances, [1000, 1000, 1000])
+
     # Bad unit constructor
-    with pytest.raises(DimensionalityError, match=r"Cannot convert from 'ampere' \(\[current\]\) to 'VA'"):
+    with pytest.raises(DimensionalityError, match=r"Cannot convert from 'ampere' \(\[current\]\) to 'volt_ampere'"):
         PowerLoad("load", bus, powers=Q_([100, 100, 100], "A"), phases="abcn")
 
     # Bad unit setter
     load = PowerLoad("load", bus, powers=[100, 100, 100], phases="abcn")
-    with pytest.raises(DimensionalityError, match=r"Cannot convert from 'ampere' \(\[current\]\) to 'VA'"):
+    with pytest.raises(DimensionalityError, match=r"Cannot convert from 'ampere' \(\[current\]\) to 'volt_ampere'"):
         load.powers = Q_([100, 100, 100], "A")
 
 

--- a/roseau/load_flow/models/tests/test_sources.py
+++ b/roseau/load_flow/models/tests/test_sources.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+from pint.errors import DimensionalityError
+
+from roseau.load_flow import Q_, Bus, VoltageSource
+
+
+def test_source_units():
+    bus = Bus("bus", phases="abcn")
+
+    # Good unit constructor
+    vs = VoltageSource("vs", bus, voltages=Q_([1, 1, 1], "kV"), phases="abcn")
+    assert np.allclose(vs._voltages, [1000, 1000, 1000])
+
+    # Good unit setter
+    vs = VoltageSource("vs", bus, voltages=[100, 100, 100], phases="abcn")
+    assert np.allclose(vs._voltages, [100, 100, 100])
+    vs.voltages = Q_([1, 1, 1], "kV")
+    assert np.allclose(vs._voltages, [1000, 1000, 1000])
+
+    # Units in a list
+    vs = VoltageSource("vs", bus, voltages=[Q_(1_000, "V"), Q_(1, "kV"), Q_(0.001, "MV")], phases="abcn")
+    assert np.allclose(vs._voltages, [1000, 1000, 1000])
+
+    # Bad unit constructor
+    with pytest.raises(DimensionalityError, match=r"Cannot convert from 'ampere' \(\[current\]\) to 'volt'"):
+        VoltageSource("vs", bus, voltages=Q_([100, 100, 100], "A"), phases="abcn")
+
+    # Bad unit setter
+    vs = VoltageSource("vs", bus, voltages=[100, 100, 100], phases="abcn")
+    with pytest.raises(DimensionalityError, match=r"Cannot convert from 'ampere' \(\[current\]\) to 'volt'"):
+        vs.voltages = Q_([100, 100, 100], "A")


### PR DESCRIPTION
Fixes #145

This required a few setters to abandon the `ureg.wraps` decorator but the alternative is very simple so I don't see a problem. I also tested other alternative like `Q_.from_sequence` but these don't always work as expected.