### PR TITLE
Improve the typing of pint wrapped method

### DIFF
--- a/roseau/load_flow/converters.py
+++ b/roseau/load_flow/converters.py
@@ -23,7 +23,7 @@ A = np.array(
         [1, ALPHA**2, ALPHA],
         [1, ALPHA, ALPHA**2],
     ],
-    dtype=complex,
+    dtype=np.complex128,
 )
 """numpy.ndarray[complex]: "A" matrix: transformation matrix from phasor to symmetrical components."""
 
@@ -32,7 +32,7 @@ _A_INV = np.linalg.inv(A)
 
 def phasor_to_sym(v_abc: Sequence[complex]) -> ComplexArray:
     """Compute the symmetrical components `(0, +, -)` from the phasor components `(a, b, c)`."""
-    v_abc_array = np.asarray(v_abc)
+    v_abc_array = np.array(v_abc)
     orig_shape = v_abc_array.shape
     v_012 = _A_INV @ v_abc_array.reshape((3, 1))
     return v_012.reshape(orig_shape)
@@ -40,7 +40,7 @@ def phasor_to_sym(v_abc: Sequence[complex]) -> ComplexArray:
 
 def sym_to_phasor(v_012: Sequence[complex]) -> ComplexArray:
     """Compute the phasor components `(a, b, c)` from the symmetrical components `(0, +, -)`."""
-    v_012_array = np.asarray(v_012)
+    v_012_array = np.array(v_012)
     orig_shape = v_012_array.shape
     v_abc = A @ v_012_array.reshape((3, 1))
     return v_abc.reshape(orig_shape)
@@ -124,13 +124,13 @@ def calculate_voltages(potentials: ComplexArray, phases: str) -> ComplexArray:
         Otherwise, the voltages are Phase-Phase.
 
     Example:
-        >>> potentials = 230 * np.array([1, np.exp(-2j*np.pi/3), np.exp(2j*np.pi/3), 0], dtype=complex)
+        >>> potentials = 230 * np.array([1, np.exp(-2j*np.pi/3), np.exp(2j*np.pi/3), 0], dtype=np.complex128)
         >>> calculate_voltages(potentials, "abcn")
         array([ 230.  +0.j        , -115.-199.18584287j, -115.+199.18584287j])
-        >>> potentials = np.array([230, 230 * np.exp(-2j*np.pi/3)], dtype=complex)
+        >>> potentials = np.array([230, 230 * np.exp(-2j*np.pi/3)], dtype=np.complex128)
         >>> calculate_voltages(potentials, "ab")
         array([345.+199.18584287j])
-        >>> calculate_voltages(np.array([230, 0], dtype=complex), "an")
+        >>> calculate_voltages(np.array([230, 0], dtype=np.complex128), "an")
         array([230.+0.j])
     """
     assert len(potentials) == len(phases), "Number of potentials must match number of phases."

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -140,8 +140,8 @@ class AbstractBranch(Element):
         return res
 
     def results_from_dict(self, data: JsonDict) -> None:
-        currents1 = np.array([complex(i[0], i[1]) for i in data["currents1"]], dtype=complex)
-        currents2 = np.array([complex(i[0], i[1]) for i in data["currents2"]], dtype=complex)
+        currents1 = np.array([complex(i[0], i[1]) for i in data["currents1"]], dtype=np.complex128)
+        currents2 = np.array([complex(i[0], i[1]) for i in data["currents2"]], dtype=np.complex128)
         self._res_currents = (currents1, currents2)
 
     def _results_to_dict(self, warning: bool) -> JsonDict:

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -59,18 +59,18 @@ class Bus(Element):
             potentials:
                 An optional array-like of initial potentials of each phase of the bus. If given,
                 these potentials are used as the starting point of the load flow computation.
-                Either complex values (V) or a :data:`Quantity <roseau.load_flow.units.Q_>` of
+                Either complex values (V) or a :class:`Quantity <roseau.load_flow.units.Q_>` of
                 complex values.
 
             min_voltage:
                 An optional minimum voltage of the bus (V). It is not used in the load flow.
                 It must be a phase-neutral voltage if the bus has a neutral, phase-phase otherwise.
-                Either a float (V) or a :data:`Quantity <roseau.load_flow.units.Q_>` of float.
+                Either a float (V) or a :class:`Quantity <roseau.load_flow.units.Q_>` of float.
 
             max_voltage:
                 An optional maximum voltage of the bus (V). It is not used in the load flow.
                 It must be a phase-neutral voltage if the bus has a neutral, phase-phase otherwise.
-                Either a float (V) or a :data:`Quantity <roseau.load_flow.units.Q_>` of float.
+                Either a float (V) or a :class:`Quantity <roseau.load_flow.units.Q_>` of float.
         """
         super().__init__(id, **kwargs)
         self._check_phases(id, phases=phases)

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import numpy as np
 from shapely import LineString, Point
@@ -144,7 +144,7 @@ class Line(AbstractBranch):
         bus2: Bus,
         *,
         parameters: LineParameters,
-        length: float,
+        length: Union[float, Q_[float]],
         phases: Optional[str] = None,
         ground: Optional[Ground] = None,
         geometry: Optional[LineString] = None,
@@ -231,7 +231,7 @@ class Line(AbstractBranch):
 
     @length.setter
     @ureg_wraps(None, (None, "km"), strict=False)
-    def length(self, value: float) -> None:
+    def length(self, value: Union[float, Q_[float]]) -> None:
         if value <= 0:
             msg = f"A line length must be greater than 0. {value:.2f} km provided."
             logger.error(msg)
@@ -335,7 +335,7 @@ class Line(AbstractBranch):
 
     def _res_shunt_currents_getter(self, warning: bool) -> tuple[ComplexArray, ComplexArray]:
         if not self.with_shunt:
-            zeros = np.zeros(len(self.phases), dtype=complex)
+            zeros = np.zeros(len(self.phases), dtype=np.complex128)
             return zeros[:], zeros[:]
         _, _, cur1, cur2 = self._res_shunt_values_getter(warning)
         return cur1, cur2
@@ -348,7 +348,7 @@ class Line(AbstractBranch):
 
     def _res_shunt_power_losses_getter(self, warning: bool) -> ComplexArray:
         if not self.with_shunt:
-            return np.zeros(len(self.phases), dtype=complex)
+            return np.zeros(len(self.phases), dtype=np.complex128)
         pot1, pot2, cur1, cur2 = self._res_shunt_values_getter(warning)
         return pot1 * cur1.conj() + pot2 * cur2.conj()
 

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -1,13 +1,20 @@
 import logging
 import warnings
-from typing import TYPE_CHECKING, NoReturn, Optional
+from typing import TYPE_CHECKING, NoReturn, Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Self
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
-from roseau.load_flow.typing import Authentication, ComplexArray, ControlType, JsonDict, ProjectionType
+from roseau.load_flow.typing import (
+    Authentication,
+    ComplexArray,
+    ComplexArrayLike1D,
+    ControlType,
+    JsonDict,
+    ProjectionType,
+)
 from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import JsonMixin, _optional_deps
 
@@ -41,11 +48,11 @@ class Control(JsonMixin):
     def __init__(
         self,
         type: ControlType,
-        u_min: float,
-        u_down: float,
-        u_up: float,
-        u_max: float,
-        alpha: float = _DEFAULT_ALPHA,
+        u_min: Union[float, Q_[float]],
+        u_down: Union[float, Q_[float]],
+        u_up: Union[float, Q_[float]],
+        u_max: Union[float, Q_[float]],
+        alpha: Union[float, Q_[float]] = _DEFAULT_ALPHA,
     ) -> None:
         """Control constructor.
 
@@ -181,7 +188,9 @@ class Control(JsonMixin):
 
     @classmethod
     @ureg_wraps(None, (None, "V", "V", None), strict=False)
-    def p_max_u_production(cls, u_up: float, u_max: float, alpha: float = _DEFAULT_ALPHA) -> Self:
+    def p_max_u_production(
+        cls, u_up: Union[float, Q_[float]], u_max: Union[float, Q_[float]], alpha: float = _DEFAULT_ALPHA
+    ) -> Self:
         """Create a control of the type ``"p_max_u_production"``.
 
         See Also:
@@ -210,7 +219,9 @@ class Control(JsonMixin):
 
     @classmethod
     @ureg_wraps(None, (None, "V", "V", None), strict=False)
-    def p_max_u_consumption(cls, u_min: float, u_down: float, alpha: float = _DEFAULT_ALPHA) -> Self:
+    def p_max_u_consumption(
+        cls, u_min: Union[float, Q_[float]], u_down: Union[float, Q_[float]], alpha: float = _DEFAULT_ALPHA
+    ) -> Self:
         """Create a control of the type ``"p_max_u_consumption"``.
 
         See Also:
@@ -239,7 +250,14 @@ class Control(JsonMixin):
 
     @classmethod
     @ureg_wraps(None, (None, "V", "V", "V", "V", None), strict=False)
-    def q_u(cls, u_min: float, u_down: float, u_up: float, u_max: float, alpha: float = _DEFAULT_ALPHA) -> Self:
+    def q_u(
+        cls,
+        u_min: Union[float, Q_[float]],
+        u_down: Union[float, Q_[float]],
+        u_up: Union[float, Q_[float]],
+        u_max: Union[float, Q_[float]],
+        alpha: float = _DEFAULT_ALPHA,
+    ) -> Self:
         """Create a control of the type ``"q_u"``.
 
         See Also:
@@ -446,9 +464,9 @@ class FlexibleParameter(JsonMixin):
         control_p: Control,
         control_q: Control,
         projection: Projection,
-        s_max: float,
-        q_min: Optional[float] = None,
-        q_max: Optional[float] = None,
+        s_max: Union[float, Q_[float]],
+        q_min: Optional[Union[float, Q_[float]]] = None,
+        q_max: Optional[Union[float, Q_[float]]] = None,
     ) -> None:
         """FlexibleParameter constructor.
 
@@ -490,7 +508,7 @@ class FlexibleParameter(JsonMixin):
 
     @s_max.setter
     @ureg_wraps(None, (None, "VA"), strict=False)
-    def s_max(self, value: float) -> None:
+    def s_max(self, value: Union[float, Q_[float]]) -> None:
         if value <= 0:
             s_max = Q_(value, "VA")
             msg = f"'s_max' must be greater than 0 but {s_max:P#~} was provided."
@@ -512,7 +530,7 @@ class FlexibleParameter(JsonMixin):
 
     @q_min.setter
     @ureg_wraps(None, (None, "VAr"), strict=False)
-    def q_min(self, value: Optional[float]) -> None:
+    def q_min(self, value: Optional[Union[float, Q_[float]]]) -> None:
         if value is not None and value < -self._s_max:
             q_min = Q_(value, "VAr")
             msg = f"'q_min' must be greater than -s_max ({-self.s_max:P#~}) but {q_min:P#~} was provided."
@@ -533,7 +551,7 @@ class FlexibleParameter(JsonMixin):
 
     @q_max.setter
     @ureg_wraps(None, (None, "VAr"), strict=False)
-    def q_max(self, value: Optional[float]) -> None:
+    def q_max(self, value: Optional[Union[float, Q_[float]]]) -> None:
         if value is not None and value > self._s_max:
             q_max = Q_(value, "VAr")
             msg = f"'q_max' must be less than s_max ({self.s_max:P#~}) but {q_max:P#~} was provided."
@@ -564,9 +582,9 @@ class FlexibleParameter(JsonMixin):
     @ureg_wraps(None, (None, "V", "V", "VA", None, None, None, None), strict=False)
     def p_max_u_production(
         cls,
-        u_up: float,
-        u_max: float,
-        s_max: float,
+        u_up: Union[float, Q_[float]],
+        u_max: Union[float, Q_[float]],
+        s_max: Union[float, Q_[float]],
         alpha_control: float = Control._DEFAULT_ALPHA,
         type_proj: ProjectionType = Projection._DEFAULT_TYPE,
         alpha_proj: float = Projection._DEFAULT_ALPHA,
@@ -620,9 +638,9 @@ class FlexibleParameter(JsonMixin):
     @ureg_wraps(None, (None, "V", "V", "VA", None, None, None, None), strict=False)
     def p_max_u_consumption(
         cls,
-        u_min: float,
-        u_down: float,
-        s_max: float,
+        u_min: Union[float, Q_[float]],
+        u_down: Union[float, Q_[float]],
+        s_max: Union[float, Q_[float]],
         alpha_control: float = Control._DEFAULT_ALPHA,
         type_proj: ProjectionType = Projection._DEFAULT_TYPE,
         alpha_proj: float = Projection._DEFAULT_ALPHA,
@@ -673,13 +691,13 @@ class FlexibleParameter(JsonMixin):
     @ureg_wraps(None, (None, "V", "V", "V", "V", "VA", "Var", "Var", None, None, None, None), strict=False)
     def q_u(
         cls,
-        u_min: float,
-        u_down: float,
-        u_up: float,
-        u_max: float,
-        s_max: float,
-        q_min: Optional[float] = None,
-        q_max: Optional[float] = None,
+        u_min: Union[float, Q_[float]],
+        u_down: Union[float, Q_[float]],
+        u_up: Union[float, Q_[float]],
+        u_max: Union[float, Q_[float]],
+        s_max: Union[float, Q_[float]],
+        q_min: Optional[Union[float, Q_[float]]] = None,
+        q_max: Optional[Union[float, Q_[float]]] = None,
         alpha_control: float = Control._DEFAULT_ALPHA,
         type_proj: ProjectionType = Projection._DEFAULT_TYPE,
         alpha_proj: float = Projection._DEFAULT_ALPHA,
@@ -747,15 +765,15 @@ class FlexibleParameter(JsonMixin):
     @ureg_wraps(None, (None, "V", "V", "V", "V", "V", "V", "VA", "VAr", "VAr", None, None, None, None), strict=False)
     def pq_u_production(
         cls,
-        up_up: float,
-        up_max: float,
-        uq_min: float,
-        uq_down: float,
-        uq_up: float,
-        uq_max: float,
-        s_max: float,
-        q_min: Optional[float] = None,
-        q_max: Optional[float] = None,
+        up_up: Union[float, Q_[float]],
+        up_max: Union[float, Q_[float]],
+        uq_min: Union[float, Q_[float]],
+        uq_down: Union[float, Q_[float]],
+        uq_up: Union[float, Q_[float]],
+        uq_max: Union[float, Q_[float]],
+        s_max: Union[float, Q_[float]],
+        q_min: Optional[Union[float, Q_[float]]] = None,
+        q_max: Optional[Union[float, Q_[float]]] = None,
         alpha_control=Control._DEFAULT_ALPHA,
         type_proj: ProjectionType = Projection._DEFAULT_TYPE,
         alpha_proj=Projection._DEFAULT_ALPHA,
@@ -834,16 +852,16 @@ class FlexibleParameter(JsonMixin):
     @ureg_wraps(None, (None, "V", "V", "V", "V", "V", "V", "VA", "VAr", "VAr", None, None, None, None), strict=False)
     def pq_u_consumption(
         cls,
-        up_min: float,
-        up_down: float,
-        uq_min: float,
-        uq_down: float,
-        uq_up: float,
-        uq_max: float,
-        s_max: float,
-        q_min: Optional[float] = None,
-        q_max: Optional[float] = None,
-        alpha_control: float = Control._DEFAULT_ALPHA,
+        up_min: Union[float, Q_[float]],
+        up_down: Union[float, Q_[float]],
+        uq_min: Union[float, Q_[float]],
+        uq_down: Union[float, Q_[float]],
+        uq_up: Union[float, Q_[float]],
+        uq_max: Union[float, Q_[float]],
+        s_max: Union[float, Q_[float]],
+        q_min: Optional[Union[float, Q_[float]]] = None,
+        q_max: Optional[Union[float, Q_[float]]] = None,
+        alpha_control: Union[float, Q_[float]] = Control._DEFAULT_ALPHA,
         type_proj: ProjectionType = Projection._DEFAULT_TYPE,
         alpha_proj: float = Projection._DEFAULT_ALPHA,
         epsilon_proj: float = Projection._DEFAULT_EPSILON,
@@ -966,8 +984,8 @@ class FlexibleParameter(JsonMixin):
     def compute_powers(
         self,
         auth: Authentication,
-        voltages: NDArray[np.float_],
-        power: complex,
+        voltages: ComplexArrayLike1D,
+        power: Union[complex, Q_[complex]],
         solve_kwargs: Optional[JsonDict] = None,
     ) -> Q_[ComplexArray]:
         """Compute the flexible powers for different voltages (norms)
@@ -991,14 +1009,14 @@ class FlexibleParameter(JsonMixin):
         return self._compute_powers(auth=auth, voltages=voltages, power=power, solve_kwargs=solve_kwargs)
 
     def _compute_powers(
-        self, auth: Authentication, voltages: NDArray[np.float_], power: complex, solve_kwargs: Optional[JsonDict]
+        self, auth: Authentication, voltages: ComplexArrayLike1D, power: complex, solve_kwargs: Optional[JsonDict]
     ) -> ComplexArray:
         from roseau.load_flow import Bus, ElectricalNetwork, PotentialRef, PowerLoad, VoltageSource
 
         # Format the input
         if solve_kwargs is None:
             solve_kwargs = {}
-        voltages = np.array(np.abs(voltages), dtype=float)
+        voltages = np.array(np.abs(voltages), dtype=np.float64)
 
         # Simple network
         bus = Bus(id="bus", phases="an")
@@ -1015,14 +1033,14 @@ class FlexibleParameter(JsonMixin):
             en.solve_load_flow(auth=auth, **solve_kwargs)
             res_flexible_powers.append(load.res_flexible_powers.m_as("VA")[0])
 
-        return np.array(res_flexible_powers, dtype=complex)
+        return np.array(res_flexible_powers, dtype=np.complex128)
 
     @ureg_wraps((None, "VA"), (None, None, "V", "VA", None, None, None, "VA"), strict=False)
     def plot_pq(
         self,
         auth: Authentication,
-        voltages: NDArray[np.float_],
-        power: complex,
+        voltages: Union[NDArray[np.float64], Q_[NDArray[np.float64]]],
+        power: Union[complex, Q_[complex]],
         ax: Optional["Axes"] = None,
         solve_kwargs: Optional[JsonDict] = None,
         voltages_labels_mask: Optional[NDArray[np.bool_]] = None,
@@ -1051,7 +1069,7 @@ class FlexibleParameter(JsonMixin):
                 A mask to activate the plot of voltages labels. By default, no voltages annotations.
 
             res_flexible_powers:
-                If None, is provided, the `res_flexible_powers` are computed. Other
+                If None is provided, the `res_flexible_powers` are computed. Otherwise, the provided values are used.
 
         Returns:
             The axis on which the plot has been drawn and the resulting flexible powers (the input if not `None` else
@@ -1066,9 +1084,9 @@ class FlexibleParameter(JsonMixin):
 
         # Initialise some variables
         if voltages_labels_mask is None:
-            voltages_labels_mask = np.zeros_like(voltages, dtype=bool)
+            voltages_labels_mask = np.zeros_like(voltages, dtype=np.bool_)
         else:
-            voltages_labels_mask = np.array(voltages_labels_mask, dtype=bool)
+            voltages_labels_mask = np.array(voltages_labels_mask, dtype=np.bool_)
         s_max = self._s_max
         v_min = voltages.min()
         v_max = voltages.max()
@@ -1134,8 +1152,8 @@ class FlexibleParameter(JsonMixin):
     def plot_control_p(
         self,
         auth: Authentication,
-        voltages: NDArray[np.float_],
-        power: complex,
+        voltages: Union[NDArray[np.float64], Q_[NDArray[np.float64]]],
+        power: Union[complex, Q_[complex]],
         ax: Optional["Axes"] = None,
         solve_kwargs: Optional[JsonDict] = None,
         res_flexible_powers: Optional[ComplexArray] = None,
@@ -1159,7 +1177,7 @@ class FlexibleParameter(JsonMixin):
                 The keywords arguments of the :meth:`~roseau.load_flow.ElectricalNetwork.solve_load_flow` method.
 
             res_flexible_powers:
-                If None, is provided, the `res_flexible_powers` are computed. Other
+                If None is provided, the `res_flexible_powers` are computed. Otherwise, the provided values are used.
 
         Returns:
             The axis on which the plot has been drawn and the resulting flexible powers (the input if not `None` else
@@ -1200,8 +1218,8 @@ class FlexibleParameter(JsonMixin):
     def plot_control_q(
         self,
         auth: Authentication,
-        voltages: NDArray[np.float_],
-        power: complex,
+        voltages: Union[NDArray[np.float64], Q_[NDArray[np.float64]]],
+        power: Union[complex, Q_[complex]],
         ax: Optional["Axes"] = None,
         solve_kwargs: Optional[JsonDict] = None,
         res_flexible_powers: Optional[ComplexArray] = None,
@@ -1225,7 +1243,7 @@ class FlexibleParameter(JsonMixin):
                 The keywords arguments of the :meth:`~roseau.load_flow.ElectricalNetwork.solve_load_flow` method
 
             res_flexible_powers:
-                If None, is provided, the `res_flexible_powers` are computed. Other
+                If None is provided, the `res_flexible_powers` are computed. Otherwise, the provided values are used.
 
         Returns:
             The axis on which the plot has been drawn and the resulting flexible powers (the input if not `None` else
@@ -1268,7 +1286,7 @@ class FlexibleParameter(JsonMixin):
     @staticmethod
     def _theoretical_control_data(
         control: Control, v_min: float, v_max: float, power: float, s_max: float
-    ) -> tuple[NDArray[np.float_], NDArray[np.float_], NDArray[np.object_]]:
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.object_]]:
         """Helper to get data for the different plots of the class. It provides the theoretical control curve
         abscissas and ordinates values. It also provides ticks for the abscissa axis.
 
@@ -1293,27 +1311,27 @@ class FlexibleParameter(JsonMixin):
         """
         # Depending on the type of the control, several options
         if control.type == "constant":
-            x = np.array([v_min, v_max], dtype=float)
-            y = np.array([power, power], dtype=float)
-            x_ticks = np.array([f"{v_min:.1f}", f"{v_max:.1f}"], dtype=object)
+            x = np.array([v_min, v_max], dtype=np.float64)
+            y = np.array([power, power], dtype=np.float64)
+            x_ticks = np.array([f"{v_min:.1f}", f"{v_max:.1f}"], dtype=np.object_)
         elif control.type == "p_max_u_production":
             u_up = control._u_up
             u_max = control._u_max
-            x = np.array([u_up, u_max, v_min, v_max], dtype=float)
-            y = np.zeros_like(x, dtype=float)
+            x = np.array([u_up, u_max, v_min, v_max], dtype=np.float64)
+            y = np.zeros_like(x, dtype=np.float64)
             y[x < u_up] = -s_max
             mask = np.logical_and(u_up <= x, x < u_max)
             y[mask] = -s_max * (x[mask] - u_max) / (u_up - u_max)
             y[x >= u_max] = 0
             x_ticks = np.array(
                 [f"{u_up:.1f}\n$U^{{\\mathrm{{up}}}}$", f"{u_max:.1f}\n$U^{{\\max}}$", f"{v_min:.1f}", f"{v_max:.1f}"],
-                dtype=object,
+                dtype=np.object_,
             )
         elif control.type == "p_max_u_consumption":
             u_min = control._u_min
             u_down = control._u_down
-            x = np.array([u_min, u_down, v_min, v_max], dtype=float)
-            y = np.zeros_like(x, dtype=float)
+            x = np.array([u_min, u_down, v_min, v_max], dtype=np.float64)
+            y = np.zeros_like(x, dtype=np.float64)
             y[x < u_min] = 0
             y[x >= u_down] = s_max
             mask = np.logical_and(u_min <= x, x < u_down)
@@ -1325,15 +1343,15 @@ class FlexibleParameter(JsonMixin):
                     f"{v_min:.1f}",
                     f"{v_max:.1f}",
                 ],
-                dtype=object,
+                dtype=np.object_,
             )
         elif control.type == "q_u":
             u_min = control._u_min
             u_down = control._u_down
             u_up = control._u_up
             u_max = control._u_max
-            x = np.array([u_min, u_down, u_up, u_max, v_min, v_max], dtype=float)
-            y = np.zeros_like(x, dtype=float)
+            x = np.array([u_min, u_down, u_up, u_max, v_min, v_max], dtype=np.float64)
+            y = np.zeros_like(x, dtype=np.float64)
             y[x < u_min] = -s_max
             mask = np.logical_and(u_min <= x, x < u_down)
             y[mask] = -s_max * (x[mask] - u_down) / (u_min - u_down)
@@ -1350,7 +1368,7 @@ class FlexibleParameter(JsonMixin):
                     f"{v_min:.1f}",
                     f"{v_max:.1f}",
                 ],
-                dtype=object,
+                dtype=np.object_,
             )
         else:  # pragma: no-cover
             msg = f"Unsupported control type {control.type!r}"

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -225,7 +225,7 @@ class PowerLoad(AbstractLoad):
 
             powers:
                 An array-like of the powers for each phase component. Either complex values (VA)
-                or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
+                or a :class:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the load. A string like ``"abc"`` or ``"an"`` etc. The order of the
@@ -363,7 +363,7 @@ class CurrentLoad(AbstractLoad):
 
             currents:
                 An array-like of the currents for each phase component. Either complex values (A)
-                or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
+                or a :class:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the load. A string like ``"abc"`` or ``"an"`` etc. The order of the
@@ -415,7 +415,7 @@ class ImpedanceLoad(AbstractLoad):
 
             impedances:
                 An array-like of the impedances for each phase component. Either complex values
-                (Ohms) or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
+                (Ohms) or a :class:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the load. A string like ``"abc"`` or ``"an"`` etc. The order of the

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -1,6 +1,5 @@
 import logging
 from abc import ABC
-from collections.abc import Sequence
 from typing import Any, Literal, Optional
 
 import numpy as np
@@ -10,7 +9,7 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.models.loads.flexible_parameters import FlexibleParameter
-from roseau.load_flow.typing import ComplexArray, Id, JsonDict
+from roseau.load_flow.typing import ComplexArray, ComplexArrayLike1D, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
 
 logger = logging.getLogger(__name__)
@@ -104,7 +103,7 @@ class AbstractLoad(Element, ABC):
         """The load flow result of the load currents (A)."""
         return self._res_currents_getter(warning=True)
 
-    def _validate_value(self, value: Sequence[complex]) -> ComplexArray:
+    def _validate_value(self, value: ComplexArrayLike1D) -> ComplexArray:
         if len(value) != self._size:
             msg = f"Incorrect number of {self._type}s: {len(value)} instead of {self._size}"
             logger.error(msg)
@@ -116,7 +115,7 @@ class AbstractLoad(Element, ABC):
             msg = f"An impedance of the load {self.id!r} is null"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_Z_VALUE)
-        return np.asarray(value, dtype=complex)
+        return np.array(value, dtype=np.complex128)
 
     def _res_potentials_getter(self, warning: bool) -> ComplexArray:
         self._raise_disconnected_error()
@@ -190,7 +189,7 @@ class AbstractLoad(Element, ABC):
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LOAD_TYPE)
 
     def results_from_dict(self, data: JsonDict) -> None:
-        self._res_currents = np.array([complex(i[0], i[1]) for i in data["currents"]], dtype=complex)
+        self._res_currents = np.array([complex(i[0], i[1]) for i in data["currents"]], dtype=np.complex128)
 
     def _results_to_dict(self, warning: bool) -> JsonDict:
         return {
@@ -210,7 +209,7 @@ class PowerLoad(AbstractLoad):
         id: Id,
         bus: Bus,
         *,
-        powers: Sequence[complex],
+        powers: ComplexArrayLike1D,
         phases: Optional[str] = None,
         flexible_params: Optional[list[FlexibleParameter]] = None,
         **kwargs: Any,
@@ -225,7 +224,8 @@ class PowerLoad(AbstractLoad):
                 The bus to connect the load to.
 
             powers:
-                List of power for each phase (VA).
+                An array-like of the powers for each phase component. Either complex values (VA)
+                or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the load. A string like ``"abc"`` or ``"an"`` etc. The order of the
@@ -272,7 +272,7 @@ class PowerLoad(AbstractLoad):
 
     @powers.setter
     @ureg_wraps(None, (None, "VA"), strict=False)
-    def powers(self, value: Sequence[complex]) -> None:
+    def powers(self, value: ComplexArrayLike1D) -> None:
         value = self._validate_value(value)
         if self.is_flexible:
             for power, fp in zip(value, self._flexible_params):
@@ -332,7 +332,7 @@ class PowerLoad(AbstractLoad):
     def results_from_dict(self, data: JsonDict) -> None:
         super().results_from_dict(data=data)
         if self.is_flexible:
-            self._res_flexible_powers = np.array([complex(p[0], p[1]) for p in data["powers"]], dtype=complex)
+            self._res_flexible_powers = np.array([complex(p[0], p[1]) for p in data["powers"]], dtype=np.complex128)
 
     def _results_to_dict(self, warning: bool) -> JsonDict:
         if self.is_flexible:
@@ -350,7 +350,7 @@ class CurrentLoad(AbstractLoad):
     _type = "current"
 
     def __init__(
-        self, id: Id, bus: Bus, *, currents: Sequence[complex], phases: Optional[str] = None, **kwargs: Any
+        self, id: Id, bus: Bus, *, currents: ComplexArrayLike1D, phases: Optional[str] = None, **kwargs: Any
     ) -> None:
         """CurrentLoad constructor.
 
@@ -362,7 +362,8 @@ class CurrentLoad(AbstractLoad):
                 The bus to connect the load to.
 
             currents:
-                List of currents for each phase (Amps).
+                An array-like of the currents for each phase component. Either complex values (A)
+                or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the load. A string like ``"abc"`` or ``"an"`` etc. The order of the
@@ -381,7 +382,7 @@ class CurrentLoad(AbstractLoad):
 
     @currents.setter
     @ureg_wraps(None, (None, "A"), strict=False)
-    def currents(self, value: Sequence[complex]) -> None:
+    def currents(self, value: ComplexArrayLike1D) -> None:
         self._currents = self._validate_value(value)
         self._invalidate_network_results()
 
@@ -401,7 +402,7 @@ class ImpedanceLoad(AbstractLoad):
     _type = "impedance"
 
     def __init__(
-        self, id: Id, bus: Bus, *, impedances: Sequence[complex], phases: Optional[str] = None, **kwargs: Any
+        self, id: Id, bus: Bus, *, impedances: ComplexArrayLike1D, phases: Optional[str] = None, **kwargs: Any
     ) -> None:
         """ImpedanceLoad constructor.
 
@@ -413,7 +414,8 @@ class ImpedanceLoad(AbstractLoad):
                 The bus to connect the load to.
 
             impedances:
-                List of impedances for each phase (Ohms).
+                An array-like of the impedances for each phase component. Either complex values
+                (Ohms) or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the load. A string like ``"abc"`` or ``"an"`` etc. The order of the
@@ -432,7 +434,7 @@ class ImpedanceLoad(AbstractLoad):
 
     @impedances.setter
     @ureg_wraps(None, (None, "ohm"), strict=False)
-    def impedances(self, impedances: Sequence[complex]) -> None:
+    def impedances(self, impedances: ComplexArrayLike1D) -> None:
         self._impedances = self._validate_value(impedances)
         self._invalidate_network_results()
 

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -37,7 +37,7 @@ class VoltageSource(Element):
                 An array-like of the voltages of the source. They will be set on the connected bus.
                 If the source has a neutral connection, the voltages are considered phase-to-neutral
                 voltages, otherwise they are the phase-to-phase voltages. Either complex values (V)
-                or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
+                or a :class:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the source. A string like ``"abc"`` or ``"an"`` etc. The order of the

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Sequence
 from typing import Any, Optional
 
 import numpy as np
@@ -9,7 +8,7 @@ from roseau.load_flow.converters import calculate_voltage_phases
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
-from roseau.load_flow.typing import ComplexArray, Id, JsonDict
+from roseau.load_flow.typing import ComplexArray, ComplexArrayLike1D, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
 
 logger = logging.getLogger(__name__)
@@ -23,7 +22,7 @@ class VoltageSource(Element):
     _floating_neutral_allowed: bool = False
 
     def __init__(
-        self, id: Id, bus: Bus, *, voltages: Sequence[complex], phases: Optional[str] = None, **kwargs: Any
+        self, id: Id, bus: Bus, *, voltages: ComplexArrayLike1D, phases: Optional[str] = None, **kwargs: Any
     ) -> None:
         """Voltage source constructor.
 
@@ -35,9 +34,10 @@ class VoltageSource(Element):
                 The bus of the voltage source.
 
             voltages:
-                The voltages of the source. They will be fixed on the connected bus. If the source
-                has a neutral connection, the voltages are the phase-to-neutral voltages, otherwise
-                they are the phase-to-phase voltages.
+                An array-like of the voltages of the source. They will be set on the connected bus.
+                If the source has a neutral connection, the voltages are considered phase-to-neutral
+                voltages, otherwise they are the phase-to-phase voltages. Either complex values (V)
+                or a :data:`Quantity <roseau.load_flow.units.Q_>` of complex values.
 
             phases:
                 The phases of the source. A string like ``"abc"`` or ``"an"`` etc. The order of the
@@ -91,12 +91,12 @@ class VoltageSource(Element):
 
     @voltages.setter
     @ureg_wraps(None, (None, "V"), strict=False)
-    def voltages(self, voltages: Sequence[complex]) -> None:
+    def voltages(self, voltages: ComplexArrayLike1D) -> None:
         if len(voltages) != self._size:
             msg = f"Incorrect number of voltages: {len(voltages)} instead of {self._size}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES_SIZE)
-        self._voltages = np.asarray(voltages, dtype=complex)
+        self._voltages = np.array(voltages, dtype=np.complex128)
         self._invalidate_network_results()
 
     @property
@@ -167,7 +167,7 @@ class VoltageSource(Element):
         }
 
     def results_from_dict(self, data: JsonDict) -> None:
-        self._res_currents = np.array([complex(i[0], i[1]) for i in data["currents"]], dtype=complex)
+        self._res_currents = np.array([complex(i[0], i[1]) for i in data["currents"]], dtype=np.complex128)
 
     def _results_to_dict(self, warning: bool) -> JsonDict:
         return {

--- a/roseau/load_flow/models/tests/test_branches.py
+++ b/roseau/load_flow/models/tests/test_branches.py
@@ -225,9 +225,9 @@ def test_powers_equal(network_with_results):
 def test_lines_results(phases, z_line, y_shunt, len_line, bus_pot, line_cur, ground_pot, expected_pow):
     bus1 = Bus("bus1", phases=phases["bus1"])
     bus2 = Bus("bus2", phases=phases["bus2"])
-    y_shunt = np.asarray(y_shunt, dtype=complex) if y_shunt is not None else None
+    y_shunt = np.array(y_shunt, dtype=np.complex128) if y_shunt is not None else None
     ground = Ground("gnd")
-    lp = LineParameters("lp", z_line=np.asarray(z_line, dtype=complex), y_shunt=y_shunt)
+    lp = LineParameters("lp", z_line=np.array(z_line, dtype=np.complex128), y_shunt=y_shunt)
     line = Line(
         "line",
         bus1,

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -42,14 +42,14 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         self,
         id: Id,
         type: str,
-        uhv: float,
-        ulv: float,
-        sn: float,
-        p0: float,
-        i0: float,
-        psc: float,
-        vsc: float,
-        max_power: Optional[float] = None,
+        uhv: Union[float, Q_[float]],
+        ulv: Union[float, Q_[float]],
+        sn: Union[float, Q_[float]],
+        p0: Union[float, Q_[float]],
+        i0: Union[float, Q_[float]],
+        psc: Union[float, Q_[float]],
+        vsc: Union[float, Q_[float]],
+        max_power: Optional[Union[float, Q_[float]]] = None,
     ) -> None:
         """TransformerParameters constructor.
 
@@ -204,7 +204,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
 
     @max_power.setter
     @ureg_wraps(None, (None, "VA"), strict=False)
-    def max_power(self, value: Optional[float]) -> None:
+    def max_power(self, value: Optional[Union[float, Q_[float]]]) -> None:
         self._max_power = value
 
     @ureg_wraps(("ohm", "S", "", None), (None,), strict=False)

--- a/roseau/load_flow/typing.py
+++ b/roseau/load_flow/typing.py
@@ -1,9 +1,14 @@
 """
 Type Aliases used by Roseau Load Flow.
 
+.. warning::
+
+    Types defined in this module are not part of the public API. You can use these types in your
+    code, but they are not guaranteed to be stable.
+
 .. class:: Id
 
-    The type of the identifier of an element.
+    The type of the identifier of an element. An element's ID can be an integer or a string.
 
 .. class:: JsonDict
 
@@ -11,15 +16,15 @@ Type Aliases used by Roseau Load Flow.
 
 .. class:: StrPath
 
-    The accepted type for files of roseau.load_flow.io.
+    The accepted type for file paths in roseau.load_flow. This is a string or a path-like object.
 
 .. class:: ControlType
 
-    Available types of control for flexible loads.
+    Available control types for flexible loads.
 
 .. class:: ProjectionType
 
-    Available types of projections for flexible loads control.
+    Available projections types for flexible loads control.
 
 .. class:: Solver
 
@@ -27,19 +32,38 @@ Type Aliases used by Roseau Load Flow.
 
 .. class:: Authentication
 
-    Valid authentication types.
+    Valid authentication types used to connect to the Roseau Load Flow solver API.
+
+.. class:: MapOrSeq
+
+    A mapping from element IDs to elements or a sequence of elements of unique IDs.
 
 .. class:: ComplexArray
 
     A numpy array of complex numbers.
+
+.. class:: ComplexArrayLike1D
+
+    A 1D array-like of complex numbers or a quantity of complex numbers. An array-like is a
+    sequence or a numpy array.
+
+.. class:: ComplexArrayLike2D
+
+    A 2D array-like of complex numbers or a quantity of complex numbers. An array-like is a
+    sequence or a numpy array.
 """
 import os
-from typing import Any, Literal, Union
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, TypeVar, Union
 
 import numpy as np
 from numpy.typing import NDArray
 from requests.auth import HTTPBasicAuth
 from typing_extensions import TypeAlias
+
+from roseau.load_flow.units import Q_
+
+T = TypeVar("T")
 
 Id: TypeAlias = Union[int, str]
 JsonDict: TypeAlias = dict[str, Any]
@@ -48,7 +72,21 @@ ControlType: TypeAlias = Literal["constant", "p_max_u_production", "p_max_u_cons
 ProjectionType: TypeAlias = Literal["euclidean", "keep_p", "keep_q"]
 Solver: TypeAlias = Literal["newton", "newton_goldstein"]
 Authentication: TypeAlias = Union[tuple[str, str], HTTPBasicAuth]
-ComplexArray: TypeAlias = NDArray[np.complex_]
+MapOrSeq: TypeAlias = Union[Mapping[Id, T], Sequence[T]]
+ComplexArray: TypeAlias = NDArray[np.complex128]
+# TODO: improve the types below when shape-typing becomes supported
+ComplexArrayLike1D: TypeAlias = Union[
+    ComplexArray,
+    Q_[ComplexArray],
+    Q_[Sequence[complex]],
+    Sequence[Union[complex, Q_[complex]]],
+]
+ComplexArrayLike2D: TypeAlias = Union[
+    ComplexArray,
+    Q_[ComplexArray],
+    Q_[Sequence[Sequence[complex]]],
+    Sequence[Sequence[Union[complex, Q_[complex]]]],
+]
 
 
 __all__ = [
@@ -59,5 +97,8 @@ __all__ = [
     "ProjectionType",
     "Solver",
     "Authentication",
+    "MapOrSeq",
     "ComplexArray",
+    "ComplexArrayLike1D",
+    "ComplexArrayLike2D",
 ]

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -9,7 +9,7 @@ Units registry used by Roseau Load Flow using the `pint`_ package.
 .. class:: Q_
 
     The :class:`pint.Quantity` class to use in this project. You can use it to provide quantities
-    in units different than the default ones. For example, to create a constant power load of 1 MVA,
+    in units different from the default ones. For example, to create a constant power load of 1 MVA,
     you can do:
 
     >>> load = lf.PowerLoad("load", bus=bus, powers=Q_([1, 1, 1], "MVA"))

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -3,11 +3,20 @@ Units registry used by Roseau Load Flow using the `pint`_ package.
 
 .. class:: ureg
 
-    The :class:`~pint.UnitRegistry` object to use in this project.
+    The :class:`pint.UnitRegistry` object to use in this project. You should not need to use it
+    directly.
 
 .. class:: Q_
 
-    The :class:`~pint.Quantity` class to use in this project.
+    The :class:`pint.Quantity` class to use in this project. You can use it to provide quantities
+    in units different than the default ones. For example, to create a constant power load of 1 MVA,
+    you can do:
+
+    >>> load = lf.PowerLoad("load", bus=bus, powers=Q_([1, 1, 1], "MVA"))
+
+    which is equivalent to:
+
+    >>> load = lf.PowerLoad("load", bus=bus, powers=[1000000, 1000000, 1000000])  # in VA
 
 .. _pint: https://pint.readthedocs.io/en/stable/getting/overview.html
 """


### PR DESCRIPTION
This PR improves the user facing types of parameters of methods wrapped with pint wrappers. Inside the methods, the types of parameters that accept either a quantity or a unitless value become incorrect but users of these methods now get the correct types. This means we accept a little bit of wrong types in our internal code for the benefit of our users. Until the Python type system have a "Map" type support, this is our best option.