### PR TITLE
Bug in `propagate_potentials` with "center" transformer types

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -7,11 +7,13 @@ Starting with version 0.7.0, Roseau Load Flow will no longer be supplied as a Sa
 a standalone Python library.
 ```
 
+- {gh-pr}`179` Solve a bug in the propagation of potentials when a center-tapped transformer is used without neutral at
+  the primary side.
 - {gh-pr}`178` {gh-issue}`176` Merge the `results_to_json`, `results_from_json`, `results_to_dict`
   and `results_from_dict` methods of the `ElectricalNetwork` and `Element`s classes into the methods
   `to_json`, `from_json`, `to_dict` and `from_dict` respectively. The old `results_` methods are
   **deprecated** and will be removed in a future release. The new methods will include the results by
-  default but you can pass `include_results=False` to exclude them.
+  default, but you can pass `include_results=False` to exclude them.
 - {gh-pr}`175` {gh-issue}`174` Fix JSON serialization of network with line parameters created from the
   catalogue.
 - {gh-pr}`173` Remove the conda installation option.

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -7,7 +7,7 @@ Starting with version 0.7.0, Roseau Load Flow will no longer be supplied as a Sa
 a standalone Python library.
 ```
 
-- {gh-pr}`179` Solve a bug in the propagation of potentials when a center-tapped transformer is used without neutral at
+- {gh-pr}`179` Fix a bug in the propagation of potentials when a center-tapped transformer is used without neutral at
   the primary side.
 - {gh-pr}`178` {gh-issue}`176` Merge the `results_to_json`, `results_from_json`, `results_to_dict`
   and `results_from_dict` methods of the `ElectricalNetwork` and `Element`s classes into the methods

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -1276,6 +1276,9 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                             phase_displacement = element.parameters.phase_displacement
                             if phase_displacement is None:
                                 phase_displacement = 0
+                            if element.parameters.type == "center" and "n" not in element.bus1.phases:
+                                # "n" is mandatory in the bus2 but not in the bus1
+                                potentials = np.append(potentials, 0.0)
                             elements.append((e, potentials * k * np.exp(phase_displacement * -1j * np.pi / 6.0)))
                         else:
                             elements.append((e, potentials))

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -1,3 +1,4 @@
+import contextlib
 import itertools as it
 import re
 import warnings
@@ -6,6 +7,7 @@ from contextlib import contextmanager
 import geopandas as gpd
 import networkx as nx
 import numpy as np
+import numpy.testing as npt
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
@@ -1741,7 +1743,7 @@ def test_serialization(small_network, small_network_with_results):
     assert_results(en_dict_with_results, included=True)
     assert_results(en_dict_without_results, included=False)
     assert en_dict_with_results != en_dict_without_results
-    # round triping
+    # round tripping
     assert ElectricalNetwork.from_dict(en_dict_with_results).to_dict() == en_dict_with_results
     assert ElectricalNetwork.from_dict(en_dict_without_results).to_dict() == en_dict_without_results
     # default is to include the results
@@ -1757,7 +1759,7 @@ def test_serialization(small_network, small_network_with_results):
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LOAD_FLOW_RESULT
     en_dict_without_results = en.to_dict(include_results=False)
-    # round triping without the results should still work
+    # round tripping without the results should still work
     assert ElectricalNetwork.from_dict(en_dict_without_results).to_dict() == en_dict_without_results
 
 
@@ -1798,3 +1800,20 @@ def test_deprecated_results_methods(small_network_with_results, tmp_path):
         "Method `results_from_json()` is deprecated. Method `from_json()` now includes the results by default."
     )
     assert new_en.to_dict() == en_dict_res
+
+
+def test_propagate_potentials_center_transformers():
+    # Source is located at the primary side of the transformer
+    bus1 = Bus(id="bus1", phases="ab")
+    PotentialRef(id="pref", element=bus1)
+    VoltageSource(id="vs", bus=bus1, voltages=[20000])
+    tp = TransformerParameters(
+        id="test", type="center", sn=160000, uhv=20000.0, ulv=400.0, i0=0.023, p0=460.0, psc=2350.0, vsc=0.04
+    )
+    bus2 = Bus(id="bus2", phases="abn")
+    PotentialRef(id="pref2", element=bus2)
+    Transformer(id="transfo", bus1=bus1, bus2=bus2, parameters=tp)
+    en = ElectricalNetwork.from_element(bus2)
+    with contextlib.suppress(RoseauLoadFlowException):  # No valid license
+        en.solve_load_flow()  # propagate the potentials
+    npt.assert_allclose(bus2.potentials.m_as("V"), np.array([200, -200, 0], dtype=np.complex128))

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -1743,7 +1743,7 @@ def test_serialization(small_network, small_network_with_results):
     assert_results(en_dict_with_results, included=True)
     assert_results(en_dict_without_results, included=False)
     assert en_dict_with_results != en_dict_without_results
-    # round tripping
+    # round triping
     assert ElectricalNetwork.from_dict(en_dict_with_results).to_dict() == en_dict_with_results
     assert ElectricalNetwork.from_dict(en_dict_without_results).to_dict() == en_dict_without_results
     # default is to include the results
@@ -1759,7 +1759,7 @@ def test_serialization(small_network, small_network_with_results):
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LOAD_FLOW_RESULT
     en_dict_without_results = en.to_dict(include_results=False)
-    # round tripping without the results should still work
+    # round triping without the results should still work
     assert ElectricalNetwork.from_dict(en_dict_without_results).to_dict() == en_dict_without_results
 
 


### PR DESCRIPTION
In case of "center" transformers, if the bus of first winding only have two phases (without neutral), the propagation of the potentials fails because three values are expected at the bus of the secondary winding.