### PR TITLE
Improve error message when network results do not exist

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- {gh-pr}`182` Improve the error message when trying to access results on the network before running the load flow.
+
 ## Version 0.7.0
 
 ```{important}
-Starting with version 0.7.0, Roseau Load Flow will no longer be supplied as a SaaS. The software will be available as
+Starting with version 0.7.0, Roseau Load Flow is no longer supplied as a SaaS. The software is now available as
 a standalone Python library.
 ```
 

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -994,6 +994,19 @@ def test_network_results_warning(small_network, small_network_with_results, recw
         _ = en.res_loads_flexible_powers
 
 
+def test_network_results_error(small_network):
+    en = small_network
+
+    # Test all results
+    for attr_name in dir(en):
+        if not attr_name.startswith("res_"):
+            continue
+        with pytest.raises(RoseauLoadFlowException) as e:
+            getattr(en, attr_name)
+        assert e.value.code == RoseauLoadFlowExceptionCode.LOAD_FLOW_NOT_RUN
+        assert e.value.msg == "The load flow results are not available because the load flow has not been run yet."
+
+
 def test_load_flow_results_frames(small_network_with_results):
     en = small_network_with_results
     en.buses["bus0"].min_voltage = 21_000


### PR DESCRIPTION
Consider this example
```python
import roseau.load_flow as lf
en = lf.ElectricalNetwork.from_catalogue("LVFeeder00939", "summer")
en.res_loads  # <- error
```

Before:
```
RoseauLoadFlowException: Results for PowerLoad 'LVBus004111_production' are not available because the load flow has not been run yet. [load_flow_not_run]
```

After:
```
RoseauLoadFlowException: The load flow results are not available because the load flow has not been run yet. [load_flow_not_run]
```