### PR TITLE
Optimize results

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -15,7 +15,7 @@ myst:
 
 ## Unreleased
 
-- {gh-pr}`191` Speed up results access by up to 3x using several optimization techniques. This is especially
+- {gh-pr}`192` Speed up results access by up to 3x using several optimization techniques. This is especially
   noticeable in timeseries simulations and when accessing results of large networks.
 - {gh-pr}`184` Improve the documentation to have a better SEO (sitemap, metadata and canonical URLs). The navigation
   menu has also been improved.

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -15,6 +15,8 @@ myst:
 
 ## Unreleased
 
+- {gh-pr}`191` Speed up results access by up to 3x using several optimization techniques. This is especially
+  noticeable in timeseries simulations and when accessing results of large networks.
 - {gh-pr}`184` Improve the documentation to have a better SEO (sitemap, metadata and canonical URLs). The navigation
   menu has also been improved.
 - {gh-pr}`183` {gh-issue}`181` Update the networks catalogue to better represent the real networks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ extend-include = ["*.ipynb"]
 namespace-packages = ["roseau"]
 lint.select = ["E", "F", "C90", "W", "B", "UP", "I", "RUF100", "TID", "SIM", "PT", "PIE", "N", "C4", "NPY", "T10"]
 lint.unfixable = ["B"]
-lint.ignore = ["E501", "B024", "N818"]
+lint.ignore = ["E501", "B024", "N818", "UP038"]
 lint.flake8-tidy-imports.ban-relative-imports = "all"
 lint.flake8-pytest-style.parametrize-values-type = "tuple"
 lint.mccabe.max-complexity = 15
@@ -136,7 +136,4 @@ directory = "htmlcov"
 [tool.pytest.ini_options]
 addopts = "--color=yes -n=0 --import-mode=importlib"
 testpaths = ["roseau/load_flow/"]
-filterwarnings = [
-    'ignore:.*utcfromtimestamp:DeprecationWarning:dateutil.*', # dateutil is imported by pandas, not us
-    'ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning:.*',
-]
+filterwarnings = []

--- a/roseau/load_flow/_wrapper.py
+++ b/roseau/load_flow/_wrapper.py
@@ -55,9 +55,8 @@ def _apply_defaults(sig: Signature, args: tuple[Any], kwargs: dict[str, Any]) ->
     values so that every argument is defined.
     """
     n = len(args)
-    empty = Parameter.empty
     for i, param in enumerate(sig.parameters.values()):
-        if i >= n and param.default != empty and param.name not in kwargs:
+        if i >= n and param.default != Parameter.empty and param.name not in kwargs:
             kwargs[param.name] = param.default
     return list(args), kwargs
 

--- a/roseau/load_flow/_wrapper.py
+++ b/roseau/load_flow/_wrapper.py
@@ -20,7 +20,7 @@ def _parse_wrap_args(args: Iterable[str | Unit | None]) -> Callable:
     # Check for references in args, remove None values
     unit_args_ndx = {ndx for ndx, arg in enumerate(args_as_uc) if arg is not None}
 
-    def _converter(ureg: UnitRegistry, sig: Signature, values: list[Any], kw: dict[Any]):
+    def _converter(ureg: "UnitRegistry", sig: "Signature", values: "list[Any]", kw: "dict[Any]"):
         len_initial_values = len(values)
 
         # pack kwargs
@@ -55,8 +55,9 @@ def _apply_defaults(sig: Signature, args: tuple[Any], kwargs: dict[str, Any]) ->
     values so that every argument is defined.
     """
     n = len(args)
+    empty = Parameter.empty
     for i, param in enumerate(sig.parameters.values()):
-        if i >= n and param.default != Parameter.empty and param.name not in kwargs:
+        if i >= n and param.default != empty and param.name not in kwargs:
             kwargs[param.name] = param.default
     return list(args), kwargs
 
@@ -94,27 +95,27 @@ def wraps(
             if the number of given arguments does not match the number of function parameters.
             if any of the provided arguments is not a unit a string or Quantity
     """
-    if not isinstance(args, list | tuple):
+    if not isinstance(args, (list, tuple)):
         args = (args,)
 
     for arg in args:
-        if arg is not None and not isinstance(arg, ureg.Unit | str):
+        if arg is not None and not isinstance(arg, (ureg.Unit, str)):
             raise TypeError(f"wraps arguments must by of type str or Unit, not {type(arg)} ({arg})")
 
     converter = _parse_wrap_args(args)
 
-    is_ret_container = isinstance(ret, list | tuple)
+    is_ret_container = isinstance(ret, (list, tuple))
     if is_ret_container:
         for arg in ret:
-            if arg is not None and not isinstance(arg, ureg.Unit | str):
+            if arg is not None and not isinstance(arg, (ureg.Unit, str)):
                 raise TypeError(f"wraps 'ret' argument must by of type str or Unit, not {type(arg)} ({arg})")
         ret = ret.__class__([to_units_container(arg, ureg) for arg in ret])
     else:
-        if ret is not None and not isinstance(ret, ureg.Unit | str):
+        if ret is not None and not isinstance(ret, (ureg.Unit, str)):
             raise TypeError(f"wraps 'ret' argument must by of type str or Unit, not {type(ret)} ({ret})")
         ret = to_units_container(ret, ureg)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Quantity]:
+    def decorator(func: "Callable[..., Any]") -> "Callable[..., Quantity]":
         sig = signature(func)
         count_params = len(sig.parameters)
         if len(args) != count_params:
@@ -124,7 +125,7 @@ def wraps(
         updated = tuple(attr for attr in functools.WRAPPER_UPDATES if hasattr(func, attr))
 
         @functools.wraps(func, assigned=assigned, updated=updated)
-        def wrapper(*values, **kw) -> Quantity:
+        def wrapper(*values, **kw) -> "Quantity":
             values, kw = _apply_defaults(sig, values, kw)
 
             # In principle, the values are used as is

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -79,12 +79,12 @@ class AbstractBranch(Element):
         s += ")"
         return s
 
-    @cached_property
+    @property
     def phases1(self) -> str:
         """The phases of the branch at the first bus."""
         return self._phases1
 
-    @cached_property
+    @property
     def phases2(self) -> str:
         """The phases of the branch at the second bus."""
         return self._phases2

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cached_property
 from typing import Any
 
 import numpy as np
@@ -60,6 +61,8 @@ class AbstractBranch(Element):
         super().__init__(id, **kwargs)
         self._check_phases(id, phases1=phases1)
         self._check_phases(id, phases2=phases2)
+        self._n1 = len(phases1)
+        self._n2 = len(phases2)
         self._phases1 = phases1
         self._phases2 = phases2
         self._bus1 = bus1
@@ -76,15 +79,19 @@ class AbstractBranch(Element):
         s += ")"
         return s
 
-    @property
+    @cached_property
     def phases1(self) -> str:
         """The phases of the branch at the first bus."""
         return self._phases1
 
-    @property
+    @cached_property
     def phases2(self) -> str:
         """The phases of the branch at the second bus."""
         return self._phases2
+
+    @cached_property
+    def _all_phases(self) -> str:
+        return "".join(sorted(set(self._phases1) | set(self._phases2)))
 
     @property
     def bus1(self) -> Bus:
@@ -98,7 +105,7 @@ class AbstractBranch(Element):
 
     def _res_currents_getter(self, warning: bool) -> tuple[ComplexArray, ComplexArray]:
         if self._fetch_results:
-            self._res_currents = self._cy_element.get_currents(len(self.phases1), len(self.phases2))
+            self._res_currents = self._cy_element.get_currents(self._n1, self._n2)
         return self._res_getter(value=self._res_currents, warning=warning)
 
     @property

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -100,7 +100,7 @@ class Bus(Element):
     def __repr__(self) -> str:
         return f"{type(self).__name__}(id={self.id!r}, phases={self.phases!r})"
 
-    @cached_property
+    @property
     def phases(self) -> str:
         """The phases of the bus."""
         return self._phases

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterator
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -99,7 +100,7 @@ class Bus(Element):
     def __repr__(self) -> str:
         return f"{type(self).__name__}(id={self.id!r}, phases={self.phases!r})"
 
-    @property
+    @cached_property
     def phases(self) -> str:
         """The phases of the bus."""
         return self._phases
@@ -150,7 +151,7 @@ class Bus(Element):
         """
         return self._res_voltages_getter(warning=True)
 
-    @property
+    @cached_property
     def voltage_phases(self) -> list[str]:
         """The phases of the voltages."""
         return calculate_voltage_phases(self.phases)
@@ -241,7 +242,7 @@ class Bus(Element):
         while remaining:
             branch = remaining.pop()
             visited.add(branch)
-            if not isinstance(branch, Line | Switch):
+            if not isinstance(branch, (Line, Switch)):
                 continue
             for element in branch._connected_elements:
                 if not isinstance(element, Bus) or element is self or element in buses:
@@ -294,7 +295,7 @@ class Bus(Element):
         while remaining:
             branch = remaining.pop()
             visited.add(branch)
-            if not isinstance(branch, Line | Switch):
+            if not isinstance(branch, (Line, Switch)):
                 continue
             for element in branch._connected_elements:
                 if not isinstance(element, Bus) or element.id in visited_buses:

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -235,7 +235,7 @@ class Line(AbstractBranch):
             self._cy_element = CyShuntLine(
                 n=self._n1,
                 y_shunt=parameters._y_shunt.reshape(self._n1 * self._n2) * self._length,
-                z_line=parameters._z_line * self._length,
+                z_line=parameters._z_line.reshape(self._n1 * self._n2) * self._length,
             )
         else:
             self._cy_element = CySimplifiedLine(
@@ -269,7 +269,7 @@ class Line(AbstractBranch):
         if self._cy_element is not None:
             if self._parameters.with_shunt:
                 self._cy_element.update_line_parameters(
-                    y_shunt=self._y_shunt.reshape(self._n1 * self._n2), z_line=self._z_line
+                    y_shunt=self._y_shunt.reshape(self._n1 * self._n2), z_line=self._z_line.reshape(self._n1 * self._n2)
                 )
             else:
                 self._cy_element.update_line_parameters(z_line=self._z_line.reshape(self._n1 * self._n2))

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from functools import cached_property
 from typing import Any
 
 import numpy as np
@@ -86,11 +87,10 @@ class Switch(AbstractBranch):
         super().__init__(id=id, phases1=phases, phases2=phases, bus1=bus1, bus2=bus2, geometry=geometry, **kwargs)
         self._check_elements()
         self._check_loop()
-        self._n = len(phases)
-        self._cy_element = CySwitch(self._n)
+        self._cy_element = CySwitch(self._n1)
         self._cy_connect()
 
-    @property
+    @cached_property
     def phases(self) -> str:
         """The phases of the switch. This is an alias for :attr:`phases1` and :attr:`phases2`."""
         return self._phases1
@@ -103,7 +103,7 @@ class Switch(AbstractBranch):
             element = elements.pop(-1)
             visited_1.add(element)
             for e in element._connected_elements:
-                if e not in visited_1 and (isinstance(e, Bus | Switch)) and e != self:
+                if e not in visited_1 and (isinstance(e, (Bus, Switch))) and e != self:
                     elements.append(e)
         visited_2: set[Element] = set()
         elements = [self.bus2]
@@ -111,7 +111,7 @@ class Switch(AbstractBranch):
             element = elements.pop(-1)
             visited_2.add(element)
             for e in element._connected_elements:
-                if e not in visited_2 and (isinstance(e, Bus | Switch)) and e != self:
+                if e not in visited_2 and (isinstance(e, (Bus, Switch))) and e != self:
                     elements.append(e)
         if visited_1.intersection(visited_2):
             msg = f"There is a loop of switch involving the switch {self.id!r}. It is not allowed."
@@ -232,25 +232,42 @@ class Line(AbstractBranch):
             # Connect the ground
             self._connect(self.ground)
 
-        self._n = len(phases)
         if parameters.with_shunt:
             self._cy_element = CyShuntLine(
-                n=self._n,
-                y_shunt=parameters._y_shunt.reshape(self._n * self._n) * self._length,
-                z_line=parameters._z_line.reshape(self._n * self._n) * self._length,
+                n=self._n1, y_shunt=parameters._y_shunt * self._length, z_line=parameters._z_line * self._length
             )
         else:
-            self._cy_element = CySimplifiedLine(
-                n=self._n, z_line=parameters._z_line.reshape(self._n * self._n) * self._length
-            )
+            self._cy_element = CySimplifiedLine(n=self._n1, z_line=parameters._z_line * self._length)
         self._cy_connect()
         if parameters.with_shunt:
-            ground._cy_element.connect(self._cy_element, [(0, self._n + self._n)])
+            ground._cy_element.connect(self._cy_element, [(0, self._n1 + self._n1)])
 
-    @property
+        # Cache values used in results calculations
+        self._z_line = parameters._z_line * self._length
+        self._y_shunt = parameters._y_shunt * self._length
+        self._z_line_inv = np.linalg.inv(self._z_line)
+        self._yg = self._y_shunt.sum(axis=1)  # y_ig = Y_ia + Y_ib + Y_ic + Y_in for i in {a, b, c, n}
+
+    @cached_property
     def phases(self) -> str:
         """The phases of the line. This is an alias for :attr:`phases1` and :attr:`phases2`."""
         return self._phases1
+
+    def _update_internal_parameters(self, parameters: LineParameters, length: float) -> None:
+        """Update the internal parameters of the line."""
+        self._parameters = parameters
+        self._length = length
+
+        self._z_line = parameters._z_line * length
+        self._y_shunt = parameters._y_shunt * length
+        self._z_line_inv = np.linalg.inv(self._z_line)
+        self._yg = self._y_shunt.sum(axis=1)
+
+        if self._cy_element is not None:
+            if self._parameters.with_shunt:
+                self._cy_element.update_line_parameters(y_shunt=self._y_shunt, z_line=self._z_line)
+            else:
+                self._cy_element.update_line_parameters(z_line=self._z_line)
 
     @property
     @ureg_wraps("km", (None,))
@@ -265,12 +282,10 @@ class Line(AbstractBranch):
             msg = f"A line length must be greater than 0. {value:.2f} km provided."
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LENGTH_VALUE)
-        self._length = value
         self._invalidate_network_results()
-
-        if self._cy_element is not None:
-            # Reassign the same parameters with the new length
-            self.parameters = self.parameters
+        self._length = value
+        if self._initialized:
+            self._update_internal_parameters(self._parameters, value)
 
     @property
     def parameters(self) -> LineParameters:
@@ -279,9 +294,9 @@ class Line(AbstractBranch):
 
     @parameters.setter
     def parameters(self, value: LineParameters) -> None:
-        shape = (len(self.phases),) * 2
+        shape = (self._n1, self._n2)
         if value._z_line.shape != shape:
-            msg = f"Incorrect z_line dimensions for line {self.id!r}: {value.z_line.shape} instead of {shape}"
+            msg = f"Incorrect z_line dimensions for line {self.id!r}: {value._z_line.shape} instead of {shape}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_Z_LINE_SHAPE)
 
@@ -291,7 +306,7 @@ class Line(AbstractBranch):
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINE_MODEL)
             if value._y_shunt.shape != shape:
-                msg = f"Incorrect y_shunt dimensions for line {self.id!r}: {value.y_shunt.shape} instead of {shape}"
+                msg = f"Incorrect y_shunt dimensions for line {self.id!r}: {value._y_shunt.shape} instead of {shape}"
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_Y_SHUNT_SHAPE)
             if self.ground is None:
@@ -303,47 +318,38 @@ class Line(AbstractBranch):
                 msg = "Cannot set line parameters without a shunt to a line that has shunt components."
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINE_MODEL)
-        self._parameters = value
         self._invalidate_network_results()
-
-        if self._cy_element is not None:
-            if value.with_shunt:
-                self._cy_element.update_line_parameters(
-                    (value.y_shunt.reshape(self._n * self._n) * self.length).m_as("S"),
-                    (value.z_line.reshape(self._n * self._n) * self.length).m_as("ohm"),
-                )
-            else:
-                self._cy_element.update_line_parameters(
-                    (value.z_line.reshape(self._n * self._n) * self.length).m_as("ohm")
-                )
+        self._parameters = value
+        if self._initialized:
+            self._update_internal_parameters(value, self._length)
 
     @property
     @ureg_wraps("ohm", (None,))
     def z_line(self) -> Q_[ComplexArray]:
         """Impedance of the line (in Ohm)."""
-        return self.parameters._z_line * self._length
+        return self._parameters._z_line * self._length
 
     @property
     @ureg_wraps("S", (None,))
     def y_shunt(self) -> Q_[ComplexArray]:
         """Shunt admittance of the line (in Siemens)."""
-        return self.parameters._y_shunt * self._length
+        return self._parameters._y_shunt * self._length
 
     @property
     def max_current(self) -> Q_[float] | None:
         """The maximum current loading of the line (in A)."""
         # Do not add a setter. The user must know that if they change the max_current, it changes
         # for all lines that share the parameters. It is better to set it on the parameters.
-        return self.parameters.max_current
+        return self._parameters.max_current
 
     @property
     def with_shunt(self) -> bool:
-        return self.parameters.with_shunt
+        return self._parameters.with_shunt
 
     def _res_series_values_getter(self, warning: bool) -> tuple[ComplexArray, ComplexArray]:
         pot1, pot2 = self._res_potentials_getter(warning)  # V
         du_line = pot1 - pot2
-        i_line = np.linalg.inv(self.z_line.m_as("ohm")) @ du_line  # Zₗ x Iₗ = ΔU -> I = Zₗ⁻¹ x ΔU
+        i_line = self._z_line_inv @ du_line  # Zₗ x Iₗ = ΔU -> I = Zₗ⁻¹ x ΔU
         return du_line, i_line
 
     def _res_series_currents_getter(self, warning: bool) -> ComplexArray:
@@ -370,16 +376,15 @@ class Line(AbstractBranch):
         assert self.with_shunt, "This method only works when there is a shunt"
         assert self.ground is not None
         pot1, pot2 = self._res_potentials_getter(warning)
-        vg = self.ground.res_potential.m_as("V")
-        y_shunt = self.y_shunt.m_as("S")
-        yg = y_shunt.sum(axis=1)  # y_ig = Y_ia + Y_ib + Y_ic + Y_in for i in {a, b, c, n}
-        i1_shunt = (y_shunt @ pot1 - yg * vg) / 2
-        i2_shunt = (y_shunt @ pot2 - yg * vg) / 2
+        vg = self.ground._res_potential_getter(warning=False)
+        ig = self._yg * vg
+        i1_shunt = (self._y_shunt @ pot1 - ig) / 2
+        i2_shunt = (self._y_shunt @ pot2 - ig) / 2
         return pot1, pot2, i1_shunt, i2_shunt
 
     def _res_shunt_currents_getter(self, warning: bool) -> tuple[ComplexArray, ComplexArray]:
         if not self.with_shunt:
-            zeros = np.zeros(len(self.phases), dtype=np.complex128)
+            zeros = np.zeros(self._n1, dtype=np.complex128)
             return zeros[:], zeros[:]
         _, _, cur1, cur2 = self._res_shunt_values_getter(warning)
         return cur1, cur2
@@ -392,7 +397,7 @@ class Line(AbstractBranch):
 
     def _res_shunt_power_losses_getter(self, warning: bool) -> ComplexArray:
         if not self.with_shunt:
-            return np.zeros(len(self.phases), dtype=np.complex128)
+            return np.zeros(self._n1, dtype=np.complex128)
         pot1, pot2, cur1, cur2 = self._res_shunt_values_getter(warning)
         return pot1 * cur1.conj() + pot2 * cur2.conj()
 
@@ -419,7 +424,7 @@ class Line(AbstractBranch):
 
         Returns ``None`` if the maximum current is not set.
         """
-        i_max = self.parameters._max_current
+        i_max = self._parameters._max_current
         if i_max is None:
             return None
         currents1, currents2 = self._res_currents_getter(warning=True)
@@ -432,7 +437,7 @@ class Line(AbstractBranch):
     def _to_dict(self, include_results: bool) -> JsonDict:
         res = super()._to_dict(include_results=include_results)
         res["length"] = self._length
-        res["params_id"] = self.parameters.id
+        res["params_id"] = self._parameters.id
         if self.ground is not None:
             res["ground"] = self.ground.id
         return res

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -511,7 +511,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
                     [0, -height],
                 ]
             )  # m
-            epsilon = EPSILON_0.m_as("F/m")
+            epsilon = EPSILON_0.m
         elif line_type == LineType.UNDERGROUND:
             if height >= 0:
                 msg = f"The height of a '{line_type}' line must be a negative number."
@@ -521,7 +521,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             coord = np.array([[-x, height - x], [x, height - x], [x, height + x], [-x, height + x]])  # m
             xp = x * 3
             coord_prim = np.array([[-xp, height - xp], [xp, height - xp], [xp, height + xp], [-xp, height + xp]])  # m
-            epsilon = (EPSILON_0 * EPSILON_R[insulator_type]).m_as("F/m")
+            epsilon = (EPSILON_0 * EPSILON_R[insulator_type]).m
         else:
             msg = f"The line type {line_type!r} of the line {id!r} is unknown."
             logger.error(msg)
@@ -574,9 +574,9 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         np.fill_diagonal(minus, 1)
 
         # Electrical parameters
-        r = RHO[conductor_type].m_as("ohm*m") / sections * np.eye(4, dtype=np.float64) * 1e3  # resistance (ohm/km)
+        r = RHO[conductor_type].m / sections * np.eye(4, dtype=np.float64) * 1e3  # resistance (ohm/km)
         distance[mask_diagonal] = gmr
-        inductance = MU_0.m_as("H/m") / (2 * PI) * np.log(1 / distance) * 1e3  # H/m->H/km
+        inductance = MU_0.m / (2 * PI) * np.log(1 / distance) * 1e3  # H/m->H/km
         distance[mask_diagonal] = radius
         lambdas = 1 / (2 * PI * epsilon) * np.log(distance_prim / distance)  # m/F
 
@@ -586,7 +586,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         c[mask_diagonal] = np.einsum("ij,ij->i", lambda_inv, minus)
         c[mask_off_diagonal] = -lambda_inv[mask_off_diagonal]
         g = np.zeros((4, 4), dtype=np.float64)  # conductance (S/km)
-        omega = OMEGA.m_as("rad/s")
+        omega = OMEGA.m
         g[mask_diagonal] = TAN_D[insulator_type].magnitude * np.einsum("ii->i", c) * omega
 
         # Build the impedance and admittance matrices

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -583,7 +583,7 @@ class FlexibleParameter(JsonMixin):
             logger.warning("'s_max' has been updated but now 'q_max' is greater than s_max. 'q_max' is set to s_max")
             self._q_max_value = self._s_max
         if self._q_min_value is not None and self._q_min_value < -self._s_max:
-            logger.warning("'s_max' has been updated but now 'q_min' is less than -s_max. 'q_min' is set to -s_max")
+            logger.warning("'s_max' has been updated but now 'q_min' is lower than -s_max. 'q_min' is set to -s_max")
             self._q_min_value = -self._s_max
         if self._cy_fp is not None:
             self._cy_fp.update_parameters(self._s_max, self._q_min, self._q_max)
@@ -609,12 +609,12 @@ class FlexibleParameter(JsonMixin):
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
             if value > self._s_max:
                 q_min = Q_(value, "VAr")
-                msg = f"q_min must be less than s_max ({self.s_max:P#~}) but {q_min:P#~} was provided."
+                msg = f"q_min must be lower than s_max ({self.s_max:P#~}) but {q_min:P#~} was provided."
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
             if self._q_max_value is not None and value > self._q_max_value:
                 q_min = Q_(value, "VAr")
-                msg = f"q_min must be less than q_max ({self.q_max:P#~}) but {q_min:P#~} was provided."
+                msg = f"q_min must be lower than q_max ({self.q_max:P#~}) but {q_min:P#~} was provided."
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
         self._q_min_value = value
@@ -637,7 +637,7 @@ class FlexibleParameter(JsonMixin):
         if value is not None:
             if value > self._s_max:
                 q_max = Q_(value, "VAr")
-                msg = f"q_max must be less than s_max ({self.s_max:P#~}) but {q_max:P#~} was provided."
+                msg = f"q_max must be lower than s_max ({self.s_max:P#~}) but {q_max:P#~} was provided."
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
             if value < -self._s_max:

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -550,8 +550,8 @@ class FlexibleParameter(JsonMixin):
         self.control_q = control_q
         self.projection = projection
         self._cy_fp = None
-        self._q_min = None
-        self._q_max = None
+        self._q_min_value: float | None = None
+        self._q_max_value: float | None = None
         self.s_max = s_max
         self.q_min = q_min
         self.q_max = q_max
@@ -560,8 +560,8 @@ class FlexibleParameter(JsonMixin):
             control_q=control_q._cy_control,
             projection=projection._cy_projection,
             s_max=self._s_max,
-            q_min=self.q_min.m_as("VAr"),
-            q_max=self.q_max.m_as("VAr"),
+            q_min=self._q_min,
+            q_max=self._q_max,
         )
 
     @property
@@ -579,60 +579,80 @@ class FlexibleParameter(JsonMixin):
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
         self._s_max = value
-        if self._q_max is not None and self._q_max > self._s_max:
+        if self._q_max_value is not None and self._q_max_value > self._s_max:
             logger.warning("'s_max' has been updated but now 'q_max' is greater than s_max. 'q_max' is set to s_max")
-            self._q_max = self._s_max
-        if self._q_min is not None and self._q_min < -self._s_max:
+            self._q_max_value = self._s_max
+        if self._q_min_value is not None and self._q_min_value < -self._s_max:
             logger.warning("'s_max' has been updated but now 'q_min' is less than -s_max. 'q_min' is set to -s_max")
-            self._q_min = -self._s_max
+            self._q_min_value = -self._s_max
         if self._cy_fp is not None:
-            self._cy_fp.update_parameters(self._s_max, self.q_min.m_as("VAr"), self.q_max.m_as("VAr"))
+            self._cy_fp.update_parameters(self._s_max, self._q_min, self._q_max)
+
+    @property
+    def _q_min(self) -> float:
+        return self._q_min_value if self._q_min_value is not None else -self._s_max
 
     @property
     @ureg_wraps("VAr", (None,))
     def q_min(self) -> Q_[float]:
         """The minimum reactive power of the flexible load (VAr)."""
-        return self._q_min if self._q_min is not None else -self._s_max
+        return self._q_min
 
     @q_min.setter
     @ureg_wraps(None, (None, "VAr"))
     def q_min(self, value: float | Q_[float] | None) -> None:
-        if value is not None and value < -self._s_max:
-            q_min = Q_(value, "VAr")
-            msg = f"'q_min' must be greater than -s_max ({-self.s_max:P#~}) but {q_min:P#~} was provided."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
-        if value is not None and self._q_max is not None and value > self._q_max:
-            q_min = Q_(value, "VAr")
-            msg = f"'q_min' must be greater than q_max ({self.q_max:P#~}) but {q_min:P#~} was provided."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
-        self._q_min = value
+        if value is not None:
+            if value < -self._s_max:
+                q_min = Q_(value, "VAr")
+                msg = f"q_min must be greater than -s_max ({-self.s_max:P#~}) but {q_min:P#~} was provided."
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
+            if value > self._s_max:
+                q_min = Q_(value, "VAr")
+                msg = f"q_min must be less than s_max ({self.s_max:P#~}) but {q_min:P#~} was provided."
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
+            if self._q_max_value is not None and value > self._q_max_value:
+                q_min = Q_(value, "VAr")
+                msg = f"q_min must be less than q_max ({self.q_max:P#~}) but {q_min:P#~} was provided."
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
+        self._q_min_value = value
         if self._cy_fp is not None:
-            self._cy_fp.update_parameters(self._s_max, self.q_min.m_as("VAr"), self.q_max.m_as("VAr"))
+            self._cy_fp.update_parameters(self._s_max, self._q_min, self._q_max)
+
+    @property
+    def _q_max(self) -> float:
+        return self._q_max_value if self._q_max_value is not None else self._s_max
 
     @property
     @ureg_wraps("VAr", (None,))
     def q_max(self) -> Q_[float]:
         """The maximum reactive power of the flexible load (VAr)."""
-        return self._q_max if self._q_max is not None else self._s_max
+        return self._q_max
 
     @q_max.setter
     @ureg_wraps(None, (None, "VAr"))
     def q_max(self, value: float | Q_[float] | None) -> None:
-        if value is not None and value > self._s_max:
-            q_max = Q_(value, "VAr")
-            msg = f"'q_max' must be less than s_max ({self.s_max:P#~}) but {q_max:P#~} was provided."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
-        if value is not None and self._q_min is not None and value < self._q_min:
-            q_max = Q_(value, "VAr")
-            msg = f"'q_max' must be greater than q_min ({self.q_min:P#~}) but {q_max:P#~} was provided."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
-        self._q_max = value
+        if value is not None:
+            if value > self._s_max:
+                q_max = Q_(value, "VAr")
+                msg = f"q_max must be less than s_max ({self.s_max:P#~}) but {q_max:P#~} was provided."
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
+            if value < -self._s_max:
+                q_max = Q_(value, "VAr")
+                msg = f"q_max must be greater than -s_max ({-self.s_max:P#~}) but {q_max:P#~} was provided."
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
+            if self._q_min_value is not None and value < self._q_min_value:
+                q_max = Q_(value, "VAr")
+                msg = f"q_max must be greater than q_min ({self.q_min:P#~}) but {q_max:P#~} was provided."
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE)
+        self._q_max_value = value
         if self._cy_fp is not None:
-            self._cy_fp.update_parameters(self._s_max, self.q_min.m_as("VAr"), self.q_max.m_as("VAr"))
+            self._cy_fp.update_parameters(self._s_max, self._q_min, self._q_max)
 
     @classmethod
     def constant(cls) -> Self:
@@ -1051,10 +1071,10 @@ class FlexibleParameter(JsonMixin):
             "projection": self.projection.to_dict(include_results=include_results),
             "s_max": self._s_max,
         }
-        if self._q_min is not None:
-            res["q_min"] = self._q_min
-        if self._q_max is not None:
-            res["q_max"] = self._q_max
+        if self._q_min_value is not None:
+            res["q_min"] = self._q_min_value
+        if self._q_max_value is not None:
+            res["q_max"] = self._q_max_value
         return res
 
     def _results_to_dict(self, warning: bool) -> NoReturn:

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -91,7 +91,7 @@ class AbstractLoad(Element, ABC):
         bus_id = self.bus.id if self.bus is not None else None
         return f"{type(self).__name__}(id={self.id!r}, phases={self.phases!r}, bus={bus_id!r})"
 
-    @cached_property
+    @property
     def phases(self) -> str:
         """The phases of the load."""
         return self._phases

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -346,7 +346,7 @@ class PowerLoad(AbstractLoad):
                     logger.error(msg)
                     raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_S_VALUE)
                 if power.imag < fp._q_min:
-                    msg = f"The reactive power is less than the parameter q_min for flexible load {self.id!r}"
+                    msg = f"The reactive power is lower than the parameter q_min for flexible load {self.id!r}"
                     logger.error(msg)
                     raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_S_VALUE)
                 if power.imag > fp._q_max:

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cached_property
 from typing import Any
 
 import numpy as np
@@ -91,7 +92,7 @@ class VoltageSource(Element):
             f"phases={self.phases!r})"
         )
 
-    @property
+    @cached_property
     def phases(self) -> str:
         """The phases of the source."""
         return self._phases
@@ -119,7 +120,7 @@ class VoltageSource(Element):
         if self._cy_element is not None:
             self._cy_element.update_voltages(self._voltages)
 
-    @property
+    @cached_property
     def voltage_phases(self) -> list[str]:
         """The phases of the source voltages."""
         return calculate_voltage_phases(self.phases)

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -92,7 +92,7 @@ class VoltageSource(Element):
             f"phases={self.phases!r})"
         )
 
-    @cached_property
+    @property
     def phases(self) -> str:
         """The phases of the source."""
         return self._phases

--- a/roseau/load_flow/models/tests/test_flexible_parameters.py
+++ b/roseau/load_flow/models/tests/test_flexible_parameters.py
@@ -228,7 +228,7 @@ def test_flexible_parameter():
             s_max=Q_(1e3, "kVA"),
             q_min=Q_(2e3, "kVAr"),
         )
-    assert e.value.msg == "q_min must be less than s_max (1.0 MVA) but 2.0 MVAr was provided."
+    assert e.value.msg == "q_min must be lower than s_max (1.0 MVA) but 2.0 MVAr was provided."
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE
 
     # q_max <= s_max
@@ -240,7 +240,7 @@ def test_flexible_parameter():
             s_max=Q_(1e3, "kVA"),
             q_max=Q_(2e3, "kVAr"),
         )
-    assert e.value.msg == "q_max must be less than s_max (1.0 MVA) but 2.0 MVAr was provided."
+    assert e.value.msg == "q_max must be lower than s_max (1.0 MVA) but 2.0 MVAr was provided."
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE
 
     # q_max >= -s_max
@@ -284,5 +284,5 @@ def test_flexible_parameter():
 
     with pytest.raises(RoseauLoadFlowException) as e:
         fp.q_min = Q_(2.5e3, "kVAr")
-    assert e.value.msg == "q_min must be less than q_max (2.0 MVAr) but 2.5 MVAr was provided."
+    assert e.value.msg == "q_min must be lower than q_max (2.0 MVAr) but 2.5 MVAr was provided."
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE

--- a/roseau/load_flow/models/tests/test_flexible_parameters.py
+++ b/roseau/load_flow/models/tests/test_flexible_parameters.py
@@ -216,7 +216,19 @@ def test_flexible_parameter():
             s_max=Q_(1e3, "kVA"),
             q_min=Q_(-2e3, "kVAr"),
         )
-    assert e.value.msg == "'q_min' must be greater than -s_max (-1.0 MVA) but -2.0 MVAr was provided."
+    assert e.value.msg == "q_min must be greater than -s_max (-1.0 MVA) but -2.0 MVAr was provided."
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE
+
+    # q_min <= s_max
+    with pytest.raises(RoseauLoadFlowException) as e:
+        FlexibleParameter(
+            control_p=Control.constant(),
+            control_q=Control.constant(),
+            projection=Projection(type="euclidean"),
+            s_max=Q_(1e3, "kVA"),
+            q_min=Q_(2e3, "kVAr"),
+        )
+    assert e.value.msg == "q_min must be less than s_max (1.0 MVA) but 2.0 MVAr was provided."
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE
 
     # q_max <= s_max
@@ -228,7 +240,19 @@ def test_flexible_parameter():
             s_max=Q_(1e3, "kVA"),
             q_max=Q_(2e3, "kVAr"),
         )
-    assert e.value.msg == "'q_max' must be less than s_max (1.0 MVA) but 2.0 MVAr was provided."
+    assert e.value.msg == "q_max must be less than s_max (1.0 MVA) but 2.0 MVAr was provided."
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE
+
+    # q_max >= -s_max
+    with pytest.raises(RoseauLoadFlowException) as e:
+        FlexibleParameter(
+            control_p=Control.constant(),
+            control_q=Control.constant(),
+            projection=Projection(type="euclidean"),
+            s_max=Q_(1e3, "kVA"),
+            q_max=Q_(-2e3, "kVAr"),
+        )
+    assert e.value.msg == "q_max must be greater than -s_max (-1.0 MVA) but -2.0 MVAr was provided."
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE
 
     fp = FlexibleParameter(
@@ -255,10 +279,10 @@ def test_flexible_parameter():
 
     with pytest.raises(RoseauLoadFlowException) as e:
         fp.q_max = Q_(-2.5e3, "kVAr")
-    assert e.value.msg == "'q_max' must be greater than q_min (-2.0 MVAr) but -2.5 MVAr was provided."
+    assert e.value.msg == "q_max must be greater than q_min (-2.0 MVAr) but -2.5 MVAr was provided."
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE
 
     with pytest.raises(RoseauLoadFlowException) as e:
         fp.q_min = Q_(2.5e3, "kVAr")
-    assert e.value.msg == "'q_min' must be greater than q_max (2.0 MVAr) but 2.5 MVAr was provided."
+    assert e.value.msg == "q_min must be less than q_max (2.0 MVAr) but 2.5 MVAr was provided."
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_FLEXIBLE_PARAMETER_VALUE

--- a/roseau/load_flow/models/tests/test_loads.py
+++ b/roseau/load_flow/models/tests/test_loads.py
@@ -204,7 +204,7 @@ def test_flexible_load():
     fp = [fp_pq_prod, fp_const, fp_const]
     with pytest.raises(RoseauLoadFlowException) as e:
         PowerLoad("flexible load", bus, powers=[10 - 250j, 0, 0j], phases="abcn", flexible_params=fp)
-    assert "The reactive power is lesser than the parameter q_min for flexible load" in e.value.msg
+    assert "The reactive power is less than the parameter q_min for flexible load" in e.value.msg
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_S_VALUE
 
     fp = [fp_pq_prod, fp_const, fp_const]

--- a/roseau/load_flow/models/tests/test_loads.py
+++ b/roseau/load_flow/models/tests/test_loads.py
@@ -204,7 +204,7 @@ def test_flexible_load():
     fp = [fp_pq_prod, fp_const, fp_const]
     with pytest.raises(RoseauLoadFlowException) as e:
         PowerLoad("flexible load", bus, powers=[10 - 250j, 0, 0j], phases="abcn", flexible_params=fp)
-    assert "The reactive power is less than the parameter q_min for flexible load" in e.value.msg
+    assert "The reactive power is lower than the parameter q_min for flexible load" in e.value.msg
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_S_VALUE
 
     fp = [fp_pq_prod, fp_const, fp_const]

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -219,6 +219,10 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         Returns:
             The parameters (``z2``, ``ym``, ``k``, ``orientation``).
         """
+        return self._to_zyk()
+
+    def _to_zyk(self) -> tuple[complex, complex, float, float]:
+        """Compute the transformer parameters ``z2``, ``ym``, ``k`` and ``orientation``."""
         # Off-load test
         # Iron losses resistance (Ohm)
         r_iron = self._uhv**2 / self._p0


### PR DESCRIPTION
This PR includes some optimizations that together added up to 3x performance improvements in a timeseries study I am doing especially on line results. The main things done are:
1. Caching whenever possible for things that we know are immutable like phases, z_line and its inverse matrices, voltage_phases, etc.
2. Avoiding the use of pint `.m_as` as much as possible. When using pint quantities, accessing the value using `.m` is much faster in tight loops when we know that the unit we want is the default one. Also avoiding the whole pint conversion interface (using `ureg_wraps` in our case) contributed the most to the performance improvements as it avoids the double conversion to a quantity then to a value.
3. Inlining results access in the `res_` properties on the electrical network to avoid calling `_res_currents_getter` several times for example.
4. A few other micro-optimizations