### PR TITLE
Explicitly prevent the instantiation of abstract classes

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -15,6 +15,7 @@ myst:
 
 ## Unreleased
 
+- {gh-pr}`202` {gh-issue}`188` Explicitly prevent instantiation of abstract classes.
 - {gh-pr}`201` {gh-issue}`185` Add `type` attribute to the load classes and rename branches `branch_type`
   attribute to `type` for consistency. Please replace `branch.branch_type` by `branch.type` in your code.
   In addition, loads data frames gained two new columns:

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -58,6 +58,8 @@ class AbstractBranch(Element):
             geometry:
                 The geometry of the branch.
         """
+        if type(self) is AbstractBranch:
+            raise TypeError("Can't instantiate abstract class AbstractBranch")
         super().__init__(id, **kwargs)
         self._check_phases(id, phases1=phases1)
         self._check_phases(id, phases2=phases2)

--- a/roseau/load_flow/models/core.py
+++ b/roseau/load_flow/models/core.py
@@ -38,6 +38,8 @@ class Element(ABC, Identifiable, JsonMixin):
                 A unique ID of the element in the network. Two elements of the same type cannot
                 have the same ID.
         """
+        if type(self) is Element:
+            raise TypeError("Can't instantiate abstract class Element")
         super().__init__(id)
         self._connected_elements: list[Element] = []
         self._network: ElectricalNetwork | None = None

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -56,6 +56,8 @@ class AbstractLoad(Element, ABC):
                 :attr:`allowed_phases`. All phases of the load, except ``"n"``, must be present in
                 the phases of the connected bus. By default, the phases of the bus are used.
         """
+        if type(self) is AbstractLoad:
+            raise TypeError("Can't instantiate abstract class AbstractLoad")
         super().__init__(id, **kwargs)
         if phases is None:
             phases = bus.phases

--- a/roseau/load_flow/models/tests/test_element.py
+++ b/roseau/load_flow/models/tests/test_element.py
@@ -1,0 +1,14 @@
+import pytest
+
+from roseau.load_flow.models import AbstractBranch, AbstractLoad, Bus, Element
+
+
+def test_abstract_classes():
+    with pytest.raises(TypeError, match="Can't instantiate abstract class Element"):
+        Element("element_id")
+    bus1 = Bus("bus1", phases="an")
+    bus2 = Bus("bus2", phases="an")
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AbstractBranch"):
+        AbstractBranch("branch_id", bus1=bus1, bus2=bus2, phases1="an", phases2="an")
+    with pytest.raises(TypeError, match="Can't instantiate abstract class AbstractLoad"):
+        AbstractLoad("load_id", bus=bus1, phases="an")


### PR DESCRIPTION
Closes #188 

Inheriting from `ABC` (or using `ABCMeta` as a metaclass) prevents the instantiation of classes that have abstract methods but not classes without abstract methods. This PR improves the error in case someone tries to instantiate `Element`, `AbstractLoad`, or `AbstractBranch`. I used the same error type and message used by `ABC`. An example before and after:

**Before**
could raise any error; currently raises:
```pycon
>>> lf.AbstractLoad("load", bus=lf.Bus("bus", phases="abcn"), powers=[-1e3, -1e3, -1e3])
AttributeError: 'AbstractLoad' object has no attribute 'type'
```

**After**
always raises
```pycon
>>> lf.AbstractLoad("load", bus=lf.Bus("bus", phases="abcn"), powers=[-1e3, -1e3, -1e3])
TypeError: Can't instantiate abstract class AbstractLoad
```