### PR TITLE
Remove restrictions on geometry types and allow custom CRS

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -15,6 +15,7 @@ myst:
 
 ## Unreleased
 
+- {gh-pr}`204` {gh-issue}`193` Remove restrictions on geometry types. Allow specifying the CRS of the geometries.
 - {gh-pr}`203` {gh-issue}`186` Detect invalid element overrides when connecting a new element with the
   same ID and type of an existing element.
 - {gh-pr}`202` {gh-issue}`188` Explicitly prevent instantiation of abstract classes.

--- a/roseau/load_flow/_solvers.py
+++ b/roseau/load_flow/_solvers.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 from typing_extensions import Self
@@ -27,7 +27,7 @@ class AbstractSolver(ABC):
 
     name: str | None = None
 
-    def __init__(self, network: "ElectricalNetwork", **kwargs):
+    def __init__(self, network: "ElectricalNetwork") -> None:
         """AbstractSolver constructor.
 
         Args:
@@ -80,7 +80,7 @@ class AbstractSolver(ABC):
             activate_license(key=None)
         return self._cy_solver.solve_load_flow(max_iterations=max_iterations, tolerance=tolerance)
 
-    def reset_inputs(self):
+    def reset_inputs(self) -> None:
         """Reset the input vector (which is used for the first step of the newton algorithm) to its initial value"""
         self._cy_solver.reset_inputs()
 
@@ -108,7 +108,7 @@ class AbstractNewton(AbstractSolver, ABC):
 
     DEFAULT_TAPE_OPTIMIZATION: bool = True
 
-    def __init__(self, network: "ElectricalNetwork", optimize_tape: bool = DEFAULT_TAPE_OPTIMIZATION, **kwargs: Any):
+    def __init__(self, network: "ElectricalNetwork", optimize_tape: bool = DEFAULT_TAPE_OPTIMIZATION) -> None:
         """AbstractNewton constructor.
 
         Args:
@@ -119,7 +119,7 @@ class AbstractNewton(AbstractSolver, ABC):
                 If True, a tape optimization will be performed. This operation might take a bit of time, but will make
                 every subsequent load flow to run faster.
         """
-        super().__init__(network=network, **kwargs)
+        super().__init__(network=network)
         self.optimize_tape = optimize_tape
 
     def save_matrix(self, prefix: str) -> None:
@@ -144,11 +144,8 @@ class Newton(AbstractNewton):
     name = "newton"
 
     def __init__(
-        self,
-        network: "ElectricalNetwork",
-        optimize_tape: bool = AbstractNewton.DEFAULT_TAPE_OPTIMIZATION,
-        **kwargs: Any,
-    ):
+        self, network: "ElectricalNetwork", optimize_tape: bool = AbstractNewton.DEFAULT_TAPE_OPTIMIZATION
+    ) -> None:
         """Newton constructor.
 
         Args:
@@ -159,7 +156,7 @@ class Newton(AbstractNewton):
                 If True, a tape optimization will be performed. This operation might take a bit of time, but will make
                 every subsequent load flow to run faster.
         """
-        super().__init__(network=network, optimize_tape=optimize_tape, **kwargs)
+        super().__init__(network=network, optimize_tape=optimize_tape)
         self._cy_solver = CyNewton(network=network._cy_electrical_network, optimize_tape=optimize_tape)
 
     def update_network(self, network: "ElectricalNetwork") -> None:
@@ -185,8 +182,7 @@ class NewtonGoldstein(AbstractNewton):
         m1: float = DEFAULT_M1,
         m2: float = DEFAULT_M2,
         optimize_tape: bool = AbstractNewton.DEFAULT_TAPE_OPTIMIZATION,
-        **kwargs: Any,
-    ):
+    ) -> None:
         """NewtonGoldstein constructor.
 
         Args:
@@ -203,7 +199,7 @@ class NewtonGoldstein(AbstractNewton):
             m2:
                 The second constant of the Goldstein and Price linear search.
         """
-        super().__init__(network=network, optimize_tape=optimize_tape, **kwargs)
+        super().__init__(network=network, optimize_tape=optimize_tape)
         if m1 >= m2:
             msg = "For the 'newton_goldstein' solver, the inequality m1 < m2 should be respected."
             logger.error(msg)

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -1,9 +1,9 @@
 import logging
 from functools import cached_property
-from typing import Any, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import numpy as np
-from shapely import LineString, Point
+from shapely.geometry.base import BaseGeometry
 from typing_extensions import Self
 
 from roseau.load_flow.converters import calculate_voltages
@@ -27,15 +27,7 @@ class AbstractBranch(Element):
     type: ClassVar[Literal["line", "transformer", "switch"]]
 
     def __init__(
-        self,
-        id: Id,
-        bus1: Bus,
-        bus2: Bus,
-        *,
-        phases1: str,
-        phases2: str,
-        geometry: Point | LineString | None = None,
-        **kwargs: Any,
+        self, id: Id, bus1: Bus, bus2: Bus, *, phases1: str, phases2: str, geometry: BaseGeometry | None = None
     ) -> None:
         """AbstractBranch constructor.
 
@@ -60,7 +52,7 @@ class AbstractBranch(Element):
         """
         if type(self) is AbstractBranch:
             raise TypeError("Can't instantiate abstract class AbstractBranch")
-        super().__init__(id, **kwargs)
+        super().__init__(id)
         self._check_phases(id, phases1=phases1)
         self._check_phases(id, phases2=phases2)
         self._n1 = len(phases1)
@@ -74,12 +66,10 @@ class AbstractBranch(Element):
         self._res_currents: tuple[ComplexArray, ComplexArray] | None = None
 
     def __repr__(self) -> str:
-        s = f"{type(self).__name__}(id={self.id!r}, phases1={self.phases1!r}, phases2={self.phases2!r}"
-        s += f", bus1={self.bus1.id!r}, bus2={self.bus2.id!r}"
-        if self.geometry is not None:
-            s += f", geometry={self.geometry}"
-        s += ")"
-        return s
+        return (
+            f"{type(self).__name__}(id={self.id!r}, bus1={self.bus1!r}, bus2={self.bus2!r}, "
+            f"phases1={self.phases1!r}, phases2={self.phases2!r})"
+        )
 
     @property
     def phases1(self) -> str:

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 import numpy as np
 import pandas as pd
-from shapely import Point
+from shapely.geometry.base import BaseGeometry
 from typing_extensions import Self
 
 from roseau.load_flow.converters import calculate_voltage_phases, calculate_voltages, phasor_to_sym
@@ -37,11 +37,10 @@ class Bus(Element):
         id: Id,
         *,
         phases: str,
-        geometry: Point | None = None,
+        geometry: BaseGeometry | None = None,
         potentials: ComplexArrayLike1D | None = None,
         min_voltage: float | None = None,
         max_voltage: float | None = None,
-        **kwargs: Any,
     ) -> None:
         """Bus constructor.
 
@@ -55,7 +54,7 @@ class Bus(Element):
                 :attr:`.allowed_phases`.
 
             geometry:
-                An optional geometry of the bus; a :class:`~shapely.Point` that represents the
+                An optional geometry of the bus; a :class:`~shapely.Geometry` that represents the
                 x-y coordinates of the bus.
 
             potentials:
@@ -74,7 +73,7 @@ class Bus(Element):
                 It must be a phase-neutral voltage if the bus has a neutral, phase-phase otherwise.
                 Either a float (V) or a :class:`Quantity <roseau.load_flow.units.Q_>` of float.
         """
-        super().__init__(id, **kwargs)
+        super().__init__(id)
         self._check_phases(id, phases=phases)
         self._phases = phases
         initialized = potentials is not None

--- a/roseau/load_flow/models/core.py
+++ b/roseau/load_flow/models/core.py
@@ -30,7 +30,7 @@ class Element(ABC, Identifiable, JsonMixin):
     important. For a full list of supported phases, use ``print(<Element class>.allowed_phases)``.
     """
 
-    def __init__(self, id: Id, **kwargs: Any) -> None:
+    def __init__(self, id: Id) -> None:
         """Element constructor.
 
         Args:

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Final
 
 from typing_extensions import Self
 
@@ -35,14 +35,14 @@ class Ground(Element):
 
     allowed_phases: Final = frozenset({"a", "b", "c", "n"})
 
-    def __init__(self, id: Id, **kwargs: Any) -> None:
+    def __init__(self, id: Id) -> None:
         """Ground constructor.
 
         Args:
             id:
                 A unique ID of the ground in the network grounds.
         """
-        super().__init__(id, **kwargs)
+        super().__init__(id)
         # A map of bus id to phase connected to this ground.
         self._connected_buses: dict[Id, str] = {}
         self._res_potential: complex | None = None

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -1,9 +1,9 @@
 import logging
 import warnings
-from typing import Any, Final
+from typing import Final
 
 import numpy as np
-from shapely import LineString, Point
+from shapely.geometry.base import BaseGeometry
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.branches import AbstractBranch
@@ -34,14 +34,7 @@ class Switch(AbstractBranch):
     """
 
     def __init__(
-        self,
-        id: Id,
-        bus1: Bus,
-        bus2: Bus,
-        *,
-        phases: str | None = None,
-        geometry: Point | None = None,
-        **kwargs: Any,
+        self, id: Id, bus1: Bus, bus2: Bus, *, phases: str | None = None, geometry: BaseGeometry | None = None
     ) -> None:
         """Switch constructor.
 
@@ -79,11 +72,8 @@ class Switch(AbstractBranch):
                 )
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
-        if geometry is not None and not isinstance(geometry, Point):
-            msg = f"The geometry for a {type(self)} must be a point: {geometry.geom_type} provided."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_GEOMETRY_TYPE)
-        super().__init__(id=id, phases1=phases, phases2=phases, bus1=bus1, bus2=bus2, geometry=geometry, **kwargs)
+
+        super().__init__(id=id, phases1=phases, phases2=phases, bus1=bus1, bus2=bus2, geometry=geometry)
         self._check_elements()
         self._check_loop()
         self._cy_element = CySwitch(self._n1)
@@ -154,8 +144,7 @@ class Line(AbstractBranch):
         length: float | Q_[float],
         phases: str | None = None,
         ground: Ground | None = None,
-        geometry: LineString | None = None,
-        **kwargs: Any,
+        geometry: BaseGeometry | None = None,
     ) -> None:
         """Line constructor.
 
@@ -204,13 +193,9 @@ class Line(AbstractBranch):
                 )
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
-        if geometry is not None and not isinstance(geometry, LineString):
-            msg = f"The geometry for a {type(self).__name__} must be a linestring: {geometry.geom_type} provided."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_GEOMETRY_TYPE)
 
         self._initialized = False
-        super().__init__(id, bus1, bus2, phases1=phases, phases2=phases, geometry=geometry, **kwargs)
+        super().__init__(id, bus1, bus2, phases1=phases, phases2=phases, geometry=geometry)
         self.ground = ground
         self.length = length
         self.parameters = parameters

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC
 from functools import cached_property
-from typing import Any, ClassVar, Final, Literal
+from typing import ClassVar, Final, Literal
 
 import numpy as np
 
@@ -40,7 +40,7 @@ class AbstractLoad(Element, ABC):
     allowed_phases: Final = Bus.allowed_phases
     """The allowed phases for a load are the same as for a :attr:`bus<Bus.allowed_phases>`."""
 
-    def __init__(self, id: Id, bus: Bus, *, phases: str | None = None, **kwargs: Any) -> None:
+    def __init__(self, id: Id, bus: Bus, *, phases: str | None = None) -> None:
         """AbstractLoad constructor.
 
         Args:
@@ -58,7 +58,7 @@ class AbstractLoad(Element, ABC):
         """
         if type(self) is AbstractLoad:
             raise TypeError("Can't instantiate abstract class AbstractLoad")
-        super().__init__(id, **kwargs)
+        super().__init__(id)
         if phases is None:
             phases = bus.phases
         else:
@@ -260,7 +260,6 @@ class PowerLoad(AbstractLoad):
         powers: ComplexArrayLike1D,
         phases: str | None = None,
         flexible_params: list[FlexibleParameter] | None = None,
-        **kwargs: Any,
     ) -> None:
         """PowerLoad constructor.
 
@@ -286,7 +285,7 @@ class PowerLoad(AbstractLoad):
                 the load is considered as flexible (or controllable) and the parameters are used
                 to compute the flexible power of the load.
         """
-        super().__init__(id=id, bus=bus, phases=phases, **kwargs)
+        super().__init__(id=id, bus=bus, phases=phases)
 
         if bus.short_circuits:
             msg = (
@@ -432,9 +431,7 @@ class CurrentLoad(AbstractLoad):
 
     type: Final = "current"
 
-    def __init__(
-        self, id: Id, bus: Bus, *, currents: ComplexArrayLike1D, phases: str | None = None, **kwargs: Any
-    ) -> None:
+    def __init__(self, id: Id, bus: Bus, *, currents: ComplexArrayLike1D, phases: str | None = None) -> None:
         """CurrentLoad constructor.
 
         Args:
@@ -454,7 +451,7 @@ class CurrentLoad(AbstractLoad):
                 :attr:`allowed_phases`. All phases of the load, except ``"n"``, must be present in
                 the phases of the connected bus. By default, the phases of the bus are used.
         """
-        super().__init__(id=id, phases=phases, bus=bus, **kwargs)
+        super().__init__(id=id, phases=phases, bus=bus)
         self.currents = currents  # handles size checks and unit conversion
         if self.phases == "abc":
             self._cy_element = CyDeltaCurrentLoad(n=self._n, currents=self._currents)
@@ -482,9 +479,7 @@ class ImpedanceLoad(AbstractLoad):
 
     type: Final = "impedance"
 
-    def __init__(
-        self, id: Id, bus: Bus, *, impedances: ComplexArrayLike1D, phases: str | None = None, **kwargs: Any
-    ) -> None:
+    def __init__(self, id: Id, bus: Bus, *, impedances: ComplexArrayLike1D, phases: str | None = None) -> None:
         """ImpedanceLoad constructor.
 
         Args:
@@ -504,7 +499,7 @@ class ImpedanceLoad(AbstractLoad):
                 :attr:`allowed_phases`. All phases of the load, except ``"n"``, must be present in
                 the phases of the connected bus. By default, the phases of the bus are used.
         """
-        super().__init__(id=id, phases=phases, bus=bus, **kwargs)
+        super().__init__(id=id, phases=phases, bus=bus)
         self.impedances = impedances
         if self.phases == "abc":
             self._cy_element = CyDeltaAdmittanceLoad(n=self._n, admittances=1.0 / self._impedances)

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Final
+from typing import Final
 
 from typing_extensions import Self
 
@@ -26,7 +26,7 @@ class PotentialRef(Element):
 
     allowed_phases: Final = frozenset({"a", "b", "c", "n"})
 
-    def __init__(self, id: Id, element: Bus | Ground, *, phase: str | None = None, **kwargs: Any) -> None:
+    def __init__(self, id: Id, element: Bus | Ground, *, phase: str | None = None) -> None:
         """PotentialRef constructor.
 
         Args:
@@ -42,7 +42,7 @@ class PotentialRef(Element):
                 if the bus has a neutral otherwise the equation ``Va + Vb + Vc = 0`` of the bus
                 sets the potential reference.
         """
-        super().__init__(id, **kwargs)
+        super().__init__(id)
         if isinstance(element, Bus):
             if phase is None:
                 phase = "n" if "n" in element.phases else None

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cached_property
-from typing import Any, Final
+from typing import Final
 
 import numpy as np
 from typing_extensions import Self
@@ -23,9 +23,7 @@ class VoltageSource(Element):
     """The allowed phases for a voltage source are the same as for a :attr:`bus<Bus.allowed_phases>`."""
     _floating_neutral_allowed: bool = False
 
-    def __init__(
-        self, id: Id, bus: Bus, *, voltages: ComplexArrayLike1D, phases: str | None = None, **kwargs: Any
-    ) -> None:
+    def __init__(self, id: Id, bus: Bus, *, voltages: ComplexArrayLike1D, phases: str | None = None) -> None:
         """Voltage source constructor.
 
         Args:
@@ -47,7 +45,7 @@ class VoltageSource(Element):
                 :attr:`allowed_phases`. All phases of the source, except ``"n"``, must be present in
                 the phases of the connected bus. By default, the phases of the bus are used.
         """
-        super().__init__(id, **kwargs)
+        super().__init__(id)
         self._connect(bus)
 
         if phases is None:

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Any, Final
+from typing import Final
 
-from shapely import Point
+from shapely.geometry.base import BaseGeometry
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.branches import AbstractBranch
@@ -49,8 +49,7 @@ class Transformer(AbstractBranch):
         tap: float = 1.0,
         phases1: str | None = None,
         phases2: str | None = None,
-        geometry: Point | None = None,
-        **kwargs: Any,
+        geometry: BaseGeometry | None = None,
     ) -> None:
         """Transformer constructor.
 
@@ -83,11 +82,6 @@ class Transformer(AbstractBranch):
             geometry:
                 The geometry of the transformer.
         """
-        if geometry is not None and not isinstance(geometry, Point):
-            msg = f"The geometry for a {type(self)} must be a point: {geometry.geom_type} provided."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_GEOMETRY_TYPE)
-
         if parameters.type == "single":
             phases1, phases2 = self._compute_phases_single(
                 id=id, bus1=bus1, bus2=bus2, phases1=phases1, phases2=phases2
@@ -101,7 +95,7 @@ class Transformer(AbstractBranch):
                 id=id, bus1=bus1, bus2=bus2, parameters=parameters, phases1=phases1, phases2=phases2
             )
 
-        super().__init__(id, bus1, bus2, phases1=phases1, phases2=phases2, geometry=geometry, **kwargs)
+        super().__init__(id, bus1, bus2, phases1=phases1, phases2=phases2, geometry=geometry)
         self.tap = tap
         self._parameters = parameters
 

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -89,6 +89,10 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
             galvanically isolated section of the network is expected. A potential reference can
             be connected to a bus or to a ground.
 
+        crs:
+            An optional Coordinate Reference System to use with geo data frames. If not provided,
+            the ``EPSG:4326`` CRS will be used.
+
     Attributes:
         buses (dict[Id, roseau.load_flow.Bus]):
             Dictionary of buses of the network indexed by their IDs. Also available as a
@@ -128,6 +132,7 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
         sources: MapOrSeq[VoltageSource],
         grounds: MapOrSeq[Ground],
         potential_refs: MapOrSeq[PotentialRef],
+        crs: str | CRS | None = None,
     ) -> None:
         self.buses = self._elements_as_dict(buses, RoseauLoadFlowExceptionCode.BAD_BUS_ID)
         self.branches = self._elements_as_dict(branches, RoseauLoadFlowExceptionCode.BAD_BRANCH_ID)
@@ -141,6 +146,9 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
         self._create_network()
         self._valid = True
         self._solver = AbstractSolver.from_dict(data={"name": self._DEFAULT_SOLVER, "params": {}}, network=self)
+        if crs is None:
+            crs = "EPSG:4326"
+        self.crs = CRS(crs)
 
     def __repr__(self) -> str:
         def count_repr(__o: Sized, /, singular: str, plural: str | None = None) -> str:
@@ -248,7 +256,7 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                 index="id",
             ),
             geometry="geometry",
-            crs=CRS("EPSG:4326"),
+            crs=self.crs,
         )
 
     @property
@@ -272,7 +280,7 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                 index="id",
             ),
             geometry="geometry",
-            crs=CRS("EPSG:4326"),
+            crs=self.crs,
         )
 
     @property
@@ -306,7 +314,7 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                 index="id",
             ),
             geometry="geometry",
-            crs=CRS("EPSG:4326"),
+            crs=self.crs,
         )
 
     @property
@@ -339,7 +347,7 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                 index="id",
             ),
             geometry="geometry",
-            crs=CRS("EPSG:4326"),
+            crs=self.crs,
         )
 
     @property
@@ -360,7 +368,7 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                 index="id",
             ),
             geometry="geometry",
-            crs=CRS("EPSG:4326"),
+            crs=self.crs,
         )
 
     @property

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -125,10 +125,9 @@ def test_connect_and_disconnect():
     # Remove line => impossible
     with pytest.raises(RoseauLoadFlowException) as e:
         en._disconnect_element(line)
-    assert (
-        e.value.msg
-        == "Line(id='line', phases1='abcn', phases2='abcn', bus1='source', bus2='load bus') is a Line and it cannot "
-        "be disconnected from a network."
+    assert e.value.msg == (
+        "Line(id='line', bus1=Bus(id='source', phases='abcn'), bus2=Bus(id='load bus', phases='abcn'), "
+        "phases1='abcn', phases2='abcn') is a Line and it cannot be disconnected from a network."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_ELEMENT_OBJECT
 


### PR DESCRIPTION
Resolves #193

- Remove the restriction that the geometry of a bus must be a point, etc
- Add a new `crs` parameter to the network's constructor to allow the user to specify the CRS of their geometries, default set to `"EPSG:4326"`

I also noticed  spurious `**kwargs` in constructors remaining from the SaaS version where we needed to pass arbitrary keywords to elements. I removed them as they are no longer used.