### PR TITLE
Un-deprecate results_to_dict and remove results_from_dict

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -15,6 +15,10 @@ myst:
 
 ## Unreleased
 
+- {gh-pr}`206` {gh-issue}`187` Un-deprecate `results_to_dict/json` methods and remove deprecated
+  `results_from_dict/json` methods.
+- {gh-pr}`205` {gh-issue}`200` Fix error when propagating the potentials from a voltage source with fewer phases
+  than the bus.
 - {gh-pr}`204` {gh-issue}`193` Remove restrictions on geometry types. Allow specifying the CRS of the geometries.
 - {gh-pr}`203` {gh-issue}`186` Detect invalid element overrides when connecting a new element with the
   same ID and type of an existing element.

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -2,7 +2,6 @@ import logging
 from functools import cached_property
 from typing import ClassVar, Literal
 
-import numpy as np
 from shapely.geometry.base import BaseGeometry
 from typing_extensions import Self
 
@@ -186,13 +185,6 @@ class AbstractBranch(Element):
                 "currents2": [[i.real, i.imag] for i in currents2],
             }
         return res
-
-    def _results_from_dict(self, data: JsonDict) -> None:
-        currents1 = np.array([complex(i[0], i[1]) for i in data["currents1"]], dtype=np.complex128)
-        currents2 = np.array([complex(i[0], i[1]) for i in data["currents2"]], dtype=np.complex128)
-        self._res_currents = (currents1, currents2)
-        self._fetch_results = False
-        self._no_results = False
 
     def _results_to_dict(self, warning: bool) -> JsonDict:
         currents1, currents2 = self._res_currents_getter(warning)

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -366,11 +366,6 @@ class Bus(Element):
             res["results"] = {"potentials": [[v.real, v.imag] for v in potentials]}
         return res
 
-    def _results_from_dict(self, data: JsonDict) -> None:
-        self._res_potentials = np.array([complex(v[0], v[1]) for v in data["potentials"]], dtype=np.complex128)
-        self._fetch_results = False
-        self._no_results = False
-
     def _results_to_dict(self, warning: bool) -> JsonDict:
         return {
             "id": self.id,

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -117,11 +117,6 @@ class Ground(Element):
             res["results"] = {"potential": [v.real, v.imag]}
         return res
 
-    def _results_from_dict(self, data: JsonDict) -> None:
-        self._res_potential = complex(*data["potential"])
-        self._fetch_results = False
-        self._no_results = False
-
     def _results_to_dict(self, warning: bool) -> JsonDict:
         v = self._res_potential_getter(warning)
         return {"id": self.id, "potential": [v.real, v.imag]}

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -1018,11 +1018,6 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         logger.error(msg)
         raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
 
-    def _results_from_dict(self, data: JsonDict) -> None:
-        msg = f"The {type(self).__name__} has no results to import."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
-
     #
     # Utility
     #

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -405,11 +405,6 @@ class Control(JsonMixin):
         logger.error(msg)
         raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
 
-    def _results_from_dict(self, data: JsonDict) -> NoReturn:
-        msg = f"The {type(self).__name__} has no results to import."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
-
 
 class Projection(JsonMixin):
     """This class defines the projection on the feasible circle for a flexible load.
@@ -497,11 +492,6 @@ class Projection(JsonMixin):
 
     def _results_to_dict(self, warning: bool) -> NoReturn:
         msg = f"The {type(self).__name__} has no results to export."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
-
-    def _results_from_dict(self, data: JsonDict) -> NoReturn:
-        msg = f"The {type(self).__name__} has no results to import."
         logger.error(msg)
         raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
 
@@ -1086,11 +1076,6 @@ class FlexibleParameter(JsonMixin):
 
     def _results_to_dict(self, warning: bool) -> NoReturn:
         msg = f"The {type(self).__name__} has no results to export."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
-
-    def _results_from_dict(self, data: JsonDict) -> NoReturn:
-        msg = f"The {type(self).__name__} has no results to import."
         logger.error(msg)
         raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
 

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -234,11 +234,6 @@ class AbstractLoad(Element, ABC):
             res["results"] = {"currents": [[i.real, i.imag] for i in currents]}
         return res
 
-    def _results_from_dict(self, data: JsonDict) -> None:
-        self._res_currents = np.array([complex(i[0], i[1]) for i in data["currents"]], dtype=np.complex128)
-        self._fetch_results = False
-        self._no_results = False
-
     def _results_to_dict(self, warning: bool) -> JsonDict:
         return {
             "id": self.id,
@@ -410,11 +405,6 @@ class PowerLoad(AbstractLoad):
             flexible_powers = self._res_flexible_powers_getter(warning=False)
             res["results"]["powers"] = [[s.real, s.imag] for s in flexible_powers]
         return res
-
-    def _results_from_dict(self, data: JsonDict) -> None:
-        super()._results_from_dict(data=data)
-        if self.is_flexible:
-            self._res_flexible_powers = np.array([complex(p[0], p[1]) for p in data["powers"]], dtype=np.complex128)
 
     def _results_to_dict(self, warning: bool) -> JsonDict:
         if self.is_flexible:

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -123,11 +123,6 @@ class PotentialRef(Element):
             res["results"] = {"current": [i.real, i.imag]}
         return res
 
-    def _results_from_dict(self, data: JsonDict) -> None:
-        self._res_current = complex(*data["current"])
-        self._fetch_results = False
-        self._no_results = False
-
     def _results_to_dict(self, warning: bool) -> JsonDict:
         i = self._res_current_getter(warning)
         return {"id": self.id, "current": [i.real, i.imag]}

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -206,11 +206,6 @@ class VoltageSource(Element):
             res["results"] = {"currents": [[i.real, i.imag] for i in currents]}
         return res
 
-    def _results_from_dict(self, data: JsonDict) -> None:
-        self._res_currents = np.array([complex(i[0], i[1]) for i in data["currents"]], dtype=np.complex128)
-        self._fetch_results = False
-        self._no_results = False
-
     def _results_to_dict(self, warning: bool) -> JsonDict:
         return {
             "id": self.id,

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -317,11 +317,6 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         logger.error(msg)
         raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
 
-    def _results_from_dict(self, data: JsonDict) -> NoReturn:
-        msg = f"The {type(self).__name__} has no results to import."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_NO_RESULTS)
-
     #
     # Catalogue Mixin
     #


### PR DESCRIPTION
Fixes #187

I added the documentation in the docstring for now. I think we can create a "Time series tutorial" at a later time and mention the `results_to_dict` method there as part of that workflow.