### PR TITLE
Modify TransformerParameters from_catalogue method

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,10 +19,16 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- {gh-pr}`212` Modify the constructor of `TransformerParameters` to take the `z2` and `ym` parameters
-  directly instead of the open and short circuit tests parameters. You can still create an object from
-  these tests using the `from_open_and_short_circuit_tests` constructor. This change comes with other
-  changes to `TransformerParameters`, notably:
+- {gh-pr}`217` Add an ID override to `TransformerParameters.from_catalogue` similar to
+  `LineParameters.from_catalogue`.
+- {gh-issue}`216` {gh-pr}`217` **BREAKING CHANGE**: Rename the `id` parameter of `TransformerParameters`
+  catalogue methods to `name` to be consistent with `LineParameters`.
+  **If you call these methods by keyword arguments**, make sure to update your usage of
+  `TransformerParameters.from_catalogue(id="xxx")` to `TransformerParameters.from_catalogue(name="xxx")`.
+- {gh-pr}`212` **BREAKING CHANGE**: Modify the constructor of `TransformerParameters` to take the `z2`
+  and `ym` parameters directly instead of the open and short circuit tests parameters. You can still
+  create an object from these tests using the `from_open_and_short_circuit_tests` constructor. This
+  change comes with other changes to `TransformerParameters`, notably:
   - The `z2`, `ym`, `k`, and `orientation` are now always available as attributes on the instance
   - The `to_zyk` method is deprecated in favour of the direct attribute access on the instance. This
     method will be removed in a future version

--- a/doc/usage/Catalogues.md
+++ b/doc/usage/Catalogues.md
@@ -186,7 +186,7 @@ This catalogue can be retrieved in the form of a dataframe using:
 
 _Truncated output_
 
-| Id                           | Manufacturer | Product range | Efficiency | Nominal power (kVA) | Type  | High voltage (kV) | Low voltage (kV) |
+| Name                         | Manufacturer | Product range | Efficiency | Nominal power (kVA) | Type  | High voltage (kV) | Low voltage (kV) |
 | :--------------------------- | :----------- | :------------ | :--------- | ------------------: | :---- | ----------------: | ---------------: |
 | FT_Standard_Standard_100kVA  | FT           | Standard      | Standard   |                 100 | Dyn11 |                20 |              0.4 |
 | FT_Standard_Standard_160kVA  | FT           | Standard      | Standard   |                 160 | Dyn11 |                20 |              0.4 |
@@ -241,7 +241,7 @@ _Truncated output_
 
 The following data are available in this table:
 
-- the **id**: a unique id among the catalogue.
+- the **name**: a unique name of the transformer in the catalogue.
 - the **manufacturer**: two manufacturers are available. `"SE"` stands for "Schneider-Electric" and `"FT"` stands for
   "France Transfo".
 - the product **range** which depends on the manufacturer
@@ -258,7 +258,7 @@ following command only retrieves transformer parameters of transformers with an 
 >>> TransformerParameters.get_catalogue(efficiency="A0Ak")
 ```
 
-| Id                     | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
+| Name                   | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
 | :--------------------- | :----------- | :------------ | :--------- | :---- | ------------------: | ----------------: | ---------------: |
 | SE_Minera_A0Ak_50kVA   | SE           | Minera        | A0Ak       | Yzn11 |                50.0 |              20.0 |              0.4 |
 | SE_Minera_A0Ak_100kVA  | SE           | Minera        | A0Ak       | Dyn11 |               100.0 |              20.0 |              0.4 |
@@ -281,7 +281,7 @@ or only transformers with a wye winding on the primary side (using a regular exp
 >>> TransformerParameters.get_catalogue(type=r"^y.*$")
 ```
 
-| Id                       | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
+| Name                     | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
 | :----------------------- | :----------- | :------------ | :--------- | :---- | ------------------: | ----------------: | ---------------: |
 | SE_Minera_A0Ak_50kVA     | SE           | Minera        | A0Ak       | Yzn11 |                50.0 |              20.0 |              0.4 |
 | SE_Minera_B0Bk_50kVA     | SE           | Minera        | B0Bk       | Yzn11 |                50.0 |              20.0 |              0.4 |
@@ -294,7 +294,7 @@ or only transformers meeting both criteria
 >>> TransformerParameters.get_catalogue(efficiency="A0Ak", type=r"^y.*$")
 ```
 
-| Id                   | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
+| Name                 | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
 | :------------------- | :----------- | :------------ | :--------- | :---- | ------------------: | ----------------: | ---------------: |
 | SE_Minera_A0Ak_50kVA | SE           | Minera        | A0Ak       | Yzn11 |                50.0 |              20.0 |              0.4 |
 
@@ -310,7 +310,7 @@ nominal power of 3150 kVA, the following two commands return the same table:
 ... TransformerParameters.get_catalogue(sn=Q_(3150, "kVA"))
 ```
 
-| Id                           | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
+| Name                         | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
 | :--------------------------- | :----------- | :------------ | :--------- | :---- | ------------------: | ----------------: | ---------------: |
 | FT_Standard_Standard_3150kVA | FT           | Standard      | Standard   | Dyn11 |              3150.0 |              20.0 |              0.4 |
 | SE_Vegeta_C0Bk_3150kVA       | SE           | Vegeta        | C0Bk       | Dyn11 |              3150.0 |              20.0 |              0.4 |
@@ -329,10 +329,10 @@ For instance, these parameters filter the catalogue down to a single transformer
 TransformerParameters(id='SE_Minera_A0Ak_50kVA')
 ```
 
-The `id` filter can be directly used:
+The `name` filter can be directly used:
 
 ```pycon
->>> TransformerParameters.from_catalogue(id="SE_Minera_A0Ak_50kVA")
+>>> TransformerParameters.from_catalogue(name="SE_Minera_A0Ak_50kVA")
 TransformerParameters(id='SE_Minera_A0Ak_50kVA')
 ```
 

--- a/roseau/load_flow/data/transformers/Catalogue.csv
+++ b/roseau/load_flow/data/transformers/Catalogue.csv
@@ -1,4 +1,4 @@
-id,manufacturer,range,efficiency,sn,vsc,psc,i0,p0,type,uhv,ulv,du1,du0.8,eff1 100%,eff0.8 100%,eff1 75%,eff0.8 75%
+name,manufacturer,range,efficiency,sn,vsc,psc,i0,p0,type,uhv,ulv,du1,du0.8,eff1 100%,eff0.8 100%,eff1 75%,eff0.8 75%
 FT_Standard_Standard_100kVA,FT,Standard,Standard,100000,0.04,2150,0.025,210,Dyn11,20000,400,2.21,3.75,97.69,97.13,98.14,97.69
 FT_Standard_Standard_160kVA,FT,Standard,Standard,160000,0.04,2350,0.023,460,Dyn11,20000,400,1.54,3.43,98.27,97.85,98.54,98.18
 FT_Standard_Standard_250kVA,FT,Standard,Standard,250000,0.04,3250,0.021,650,Dyn11,20000,400,1.37,3.33,98.46,98.09,98.7,98.37

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -874,9 +874,14 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             raise_if_not_found=True,
         )
 
-        cls._assert_one_found(
-            found_data=catalogue_data["name"].tolist(), display_name="line parameters", query_info=query_info
-        )
+        try:
+            cls._assert_one_found(
+                found_data=catalogue_data["name"].tolist(), display_name="line parameters", query_info=query_info
+            )
+        except RoseauLoadFlowException as e:
+            if name is None and id is not None:
+                e.msg += " Did you mean to filter by name instead of id?"
+            raise
         idx = catalogue_data.index[0]
         name = str(catalogue_data.at[idx, "name"])
         r = catalogue_data.at[idx, "r"]

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -859,7 +859,8 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
 
             id:
                 A unique ID for the created line parameters object (optional). If ``None``
-                (default), the id of the created object will be its name in the catalogue.
+                (default), the id of the created object will be its name in the catalogue. Note
+                that this parameter is not used in the data filtering.
 
         Returns:
             The created line parameters.

--- a/roseau/load_flow/models/tests/test_buses.py
+++ b/roseau/load_flow/models/tests/test_buses.py
@@ -189,7 +189,7 @@ def test_propagate_limits():  # noqa: C901
 
     lp_mv = LineParameters("lp_mv", z_line=np.eye(3), y_shunt=0.1 * np.eye(3))
     lp_lv = LineParameters("lp_lv", z_line=np.eye(4))
-    tp = TransformerParameters.from_catalogue(id="SE_Minera_A0Ak_100kVA", manufacturer="SE")
+    tp = TransformerParameters.from_catalogue(name="SE_Minera_A0Ak_100kVA", manufacturer="SE")
 
     Line("l1_mv", b1_mv, b2_mv, length=1.5, parameters=lp_mv, ground=g)
     Line("l2_mv", b2_mv, b3_mv, length=2, parameters=lp_mv, ground=g)
@@ -307,7 +307,7 @@ def test_get_connected_buses():
 
     lp_mv = LineParameters("lp_mv", z_line=np.eye(3), y_shunt=0.1 * np.eye(3))
     lp_lv = LineParameters("lp_lv", z_line=np.eye(4))
-    tp = TransformerParameters.from_catalogue(id="SE_Minera_A0Ak_100kVA", manufacturer="SE")
+    tp = TransformerParameters.from_catalogue(name="SE_Minera_A0Ak_100kVA", manufacturer="SE")
 
     Line("l1_mv", b1_mv, b2_mv, length=1.5, parameters=lp_mv, ground=g)
     Line("l2_mv", b2_mv, b3_mv, length=2, parameters=lp_mv, ground=g)

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -427,6 +427,12 @@ def test_from_catalogue():
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.CATALOGUE_SEVERAL_FOUND
 
+    # Success
+    tp = TransformerParameters.from_catalogue(name="SE_Minera_AA0Ak_160kVA")
+    assert tp.id == "SE_Minera_AA0Ak_160kVA"
+    tp = TransformerParameters.from_catalogue(name="SE_Minera_AA0Ak_160kVA", id="tp-test1")
+    assert tp.id == "tp-test1"
+
 
 def test_get_catalogue():
     # Get the entire catalogue

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -357,12 +357,12 @@ def test_catalogue_data():
         "Don't forget to delete files that are useless too."
     )
 
-    # Check that the id is unique
-    assert catalogue_data["id"].is_unique, error_message
+    # Check that the name is unique
+    assert catalogue_data["name"].is_unique, error_message
 
-    catalogue_data.set_index("id", inplace=True)
+    catalogue_data.set_index("name", inplace=True)
     for idx in catalogue_data.index:
-        tp = TransformerParameters.from_catalogue(id=idx)
+        tp = TransformerParameters.from_catalogue(name=idx)
 
         # The entry of the catalogue has been found
         assert tp.id in catalogue_data.index, error_message
@@ -386,7 +386,7 @@ def test_catalogue_data():
 
 def test_from_catalogue():
     # Unknown strings
-    for field_name in ("id", "manufacturer", "range", "efficiency", "type"):
+    for field_name in ("name", "manufacturer", "range", "efficiency", "type"):
         # String
         with pytest.raises(RoseauLoadFlowException) as e:
             TransformerParameters.from_catalogue(**{field_name: "unknown"})
@@ -436,7 +436,7 @@ def test_get_catalogue():
 
     # Filter on a single attribute
     for field_name, value, expected_size in (
-        ("id", "SE_Minera_A0Ak_50kVA", 1),
+        ("name", "SE_Minera_A0Ak_50kVA", 1),
         ("manufacturer", "SE", 148),
         ("range", r"min.*", 67),
         ("efficiency", "c0", 29),
@@ -450,7 +450,7 @@ def test_get_catalogue():
 
     # Filter on two attributes
     for field_name, value, expected_size in (
-        ("id", "SE_Minera_A0Ak_50kVA", 1),
+        ("name", "SE_Minera_A0Ak_50kVA", 1),
         ("range", "minera", 67),
         ("efficiency", "c0", 29),
         ("type", r"^d.*11$", 144),
@@ -463,7 +463,7 @@ def test_get_catalogue():
 
     # Filter on three attributes
     for field_name, value, expected_size in (
-        ("id", "se_VEGETA_C0BK_3150kva", 1),
+        ("name", "se_VEGETA_C0BK_3150kva", 1),
         ("efficiency", r"c0[abc]k", 15),
         ("type", "dyn", 41),
         ("sn", Q_(160, "kVA"), 3),

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -561,7 +561,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
     @classmethod
     def _get_catalogue(
         cls,
-        id: str | re.Pattern[str] | None,
+        name: str | re.Pattern[str] | None,
         manufacturer: str | re.Pattern[str] | None,
         range: str | re.Pattern[str] | None,
         efficiency: str | re.Pattern[str] | None,
@@ -579,7 +579,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         # Filter on string/regular expressions
         query_msg_list = []
         for value, column_name, display_name, display_name_plural in (
-            (id, "id", "id", "ids"),
+            (name, "name", "name", "names"),
             (manufacturer, "manufacturer", "manufacturer", "manufacturers"),
             (range, "range", "range", "ranges"),
             (efficiency, "efficiency", "efficiency", "efficiencies"),
@@ -627,7 +627,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
     @ureg_wraps(None, (None, None, None, None, None, None, "VA", "V", "V"))
     def from_catalogue(
         cls,
-        id: str | re.Pattern[str] | None = None,
+        name: str | re.Pattern[str] | None = None,
         manufacturer: str | re.Pattern[str] | None = None,
         range: str | re.Pattern[str] | None = None,
         efficiency: str | re.Pattern[str] | None = None,
@@ -639,8 +639,8 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         """Build a transformer parameters from one in the catalogue.
 
         Args:
-            id:
-                The id of the transformer to get from the catalogue. It can be a regular expression.
+            name:
+                The name of the transformer to get from the catalogue. It can be a regular expression.
 
             manufacturer:
                 The name of the manufacturer to get. It can be a regular expression.
@@ -669,7 +669,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         """
         # Get the catalogue data
         catalogue_data, query_info = cls._get_catalogue(
-            id=id,
+            name=name,
             manufacturer=manufacturer,
             range=range,
             efficiency=efficiency,
@@ -681,13 +681,13 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         )
 
         cls._assert_one_found(
-            found_data=catalogue_data["id"].tolist(), display_name="transformers", query_info=query_info
+            found_data=catalogue_data["name"].tolist(), display_name="transformers", query_info=query_info
         )
 
         # A single one has been chosen
         idx = catalogue_data.index[0]
         return cls.from_open_and_short_circuit_tests(
-            id=catalogue_data.at[idx, "id"],
+            id=catalogue_data.at[idx, "name"],
             type=catalogue_data.at[idx, "type"],
             uhv=catalogue_data.at[idx, "uhv"],
             ulv=catalogue_data.at[idx, "ulv"],
@@ -702,7 +702,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
     @ureg_wraps(None, (None, None, None, None, None, None, "VA", "V", "V"))
     def get_catalogue(
         cls,
-        id: str | re.Pattern[str] | None = None,
+        name: str | re.Pattern[str] | None = None,
         manufacturer: str | re.Pattern[str] | None = None,
         range: str | re.Pattern[str] | None = None,
         efficiency: str | re.Pattern[str] | None = None,
@@ -717,8 +717,8 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         parameter, all the catalogue will be returned.
 
         Args:
-            id:
-                An optional manufacturer to filter the output. It can be a regular expression.
+            name:
+                An optional name to filter the output. It can be a regular expression.
 
             manufacturer:
                 An optional manufacturer to filter the output. It can be a regular expression.
@@ -745,7 +745,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             The catalogue data as a dataframe.
         """
         catalogue_data, _ = cls._get_catalogue(
-            id=id,
+            name=name,
             manufacturer=manufacturer,
             range=range,
             efficiency=efficiency,
@@ -762,7 +762,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             catalogue_data.drop(columns=["i0", "p0", "psc", "vsc"])
             .rename(
                 columns={
-                    "id": "Id",
+                    "name": "Name",
                     "manufacturer": "Manufacturer",
                     "range": "Product range",
                     "efficiency": "Efficiency",
@@ -777,7 +777,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
                     # "vsc": "Impedance voltage (%)",
                 }
             )
-            .set_index("Id")
+            .set_index("Name")
         )
 
     #

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -80,7 +80,7 @@ def test_connect_and_disconnect():
     load_bus2 = Bus(id="load_bus2", phases="abcn")
     ground2 = Ground("ground2")
     ground2.connect(bus=load_bus2)
-    tp = TransformerParameters.from_catalogue(id="SE_Minera_A0Ak_50kVA")
+    tp = TransformerParameters.from_catalogue(name="SE_Minera_A0Ak_50kVA")
     Transformer(id="transfo", bus1=load_bus, bus2=load_bus2, parameters=tp)
     with pytest.raises(RoseauLoadFlowException) as e:
         en._check_validity(constructed=False)


### PR DESCRIPTION
This PR modifies the `TransformerParameters.from_catalogue` method to be consistent with the `LineParameters.from_catalogue` method by using the parameter `name` to filter the catalogue data and adds a parameter `id` to override the ID of the created instance.
This was a source of confusion in #216. The docstring of `id` and the error message in case it was used as a filter instead of `name` will now hopefully avoid such confusion.

Closes #216 