### PR TITLE
Update the docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,10 +13,10 @@ A clear and concise description of what the bug is.
 Minimal Working Example to understand the problem
 
 ```python
-from roseau.load_flow import *
+import roseau.load_flow as rlf
 
 # Your code here
-# Please do not add username, password or API keys here
+# PLEASE DO NOT ADD LICENSE KEYS HERE
 ```
 
 **Expected behavior**
@@ -27,9 +27,9 @@ A clear and concise description of what you expected to happen.
 Please copy/paste here the output of the function `show_versions`
 
 ```python
-from roseau.load_flow import show_versions
+import roseau.load_flow as rlf
 
-show_versions()
+rlf.show_versions()
 ```
 
 ```

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- MacOS wheels roseau-load-flow-engine are now published on PyPI. This means that `pip install roseau-load-flow`
+  should now work on MacOS.
+- Added support for running in Google Colab documents.
+- Fixed a bug in license checks caching on Windows.
 - {gh-issue}`222` {gh-pr}`223` `from_catalogue()` methods of the electrical network and transformer
   and line parameters now perform "full match" comparison on textual inputs. If you need the old
   behavior, use regular expression wild cards `.*` in the input string.

--- a/doc/models/Bus.md
+++ b/doc/models/Bus.md
@@ -32,16 +32,16 @@ A bus is identified by its unique id and must define the phases it is connected 
 have all the phases of the elements connected to it.
 
 ```python
-from roseau.load_flow import Bus, PowerLoad
+import roseau.load_flow as rlf
 
-bus1 = Bus(id="bus1", phases="abcn")  # A three-phase bus with a neutral
-bus2 = Bus(id="bus2", phases="abc")  # A three-phase bus without a neutral
-bus3 = Bus(id="bus3", phases="an")  # A single-phase bus
+bus1 = rlf.Bus(id="bus1", phases="abcn")  # A three-phase bus with a neutral
+bus2 = rlf.Bus(id="bus2", phases="abc")  # A three-phase bus without a neutral
+bus3 = rlf.Bus(id="bus3", phases="an")  # A single-phase bus
 
-PowerLoad(id="load1", bus=bus1, powers=[100, 0, 50j], phases="abcn")  # OK
-PowerLoad(id="load2", bus=bus1, powers=[100, 0, 50j], phases="abc")  # OK
-PowerLoad(id="load3", bus=bus2, powers=[100], phases="ab")  # OK
-PowerLoad(
+rlf.PowerLoad(id="load1", bus=bus1, powers=[100, 0, 50j], phases="abcn")  # OK
+rlf.PowerLoad(id="load2", bus=bus1, powers=[100, 0, 50j], phases="abc")  # OK
+rlf.PowerLoad(id="load3", bus=bus2, powers=[100], phases="ab")  # OK
+rlf.PowerLoad(
     id="load4", bus=bus3, powers=[100], phases="ab"
 )  # Error: bus3 does not have phase "b"
 ```
@@ -50,10 +50,10 @@ Since a bus represents a point in the network, it is possible to define the coor
 point:
 
 ```python
+import roseau.load_flow as rlf
 from shapely import Point
-from roseau.load_flow import Bus
 
-bus = Bus(id="bus", phases="abc", geometry=Point(1.0, -2.5))
+bus = rlf.Bus(id="bus", phases="abc", geometry=Point(1.0, -2.5))
 ```
 
 This information is not used by the load flow solver but could be used to generate geographical
@@ -69,37 +69,29 @@ Here is an example of a simple short-circuit between two phases:
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    Line,
-    LineParameters,
-    PotentialRef,
-    Q_,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Two buses
-bus1 = Bus(id="bus1", phases="abcn")
-bus2 = Bus(id="bus2", phases="abcn")
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+bus2 = rlf.Bus(id="bus2", phases="abcn")
 
 # A line
-lp = LineParameters(id="lp", z_line=Q_((0.3 + 0.35j) * np.eye(4), "ohm/km"))
-line = Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=Q_(1, "km"))
+lp = rlf.LineParameters(id="lp", z_line=rlf.Q_((0.3 + 0.35j) * np.eye(4), "ohm/km"))
+line = rlf.Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=rlf.Q_(1, "km"))
 
 # A voltage source on the first bus
 un = 400 / np.sqrt(3)
-voltages = Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+voltages = rlf.Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 # The neutral of the voltage source is fixed at potential 0
-pref = PotentialRef(id="pref", element=bus1, phase="n")
+pref = rlf.PotentialRef(id="pref", element=bus1, phase="n")
 
 # Create a short-circuit on bus2 between phases "a" and "b"
 bus2.add_short_circuit("a", "b")
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # Get the currents flowing to the line from bus1

--- a/doc/models/Ground.md
+++ b/doc/models/Ground.md
@@ -52,74 +52,64 @@ After solving this load flow, the following assertions will be verified:
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Q_,
-    Bus,
-    ElectricalNetwork,
-    Ground,
-    Line,
-    LineParameters,
-    PotentialRef,
-    PowerLoad,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Define two grounds elements
-g1 = Ground(id="g1")
-g2 = Ground(id="g2")
+g1 = rlf.Ground(id="g1")
+g2 = rlf.Ground(id="g2")
 
 # Define three buses
-bus1 = Bus(id="bus1", phases="abc")
-bus2 = Bus(id="bus2", phases="abc")
-bus3 = Bus(id="bus3", phases="abc")
+bus1 = rlf.Bus(id="bus1", phases="abc")
+bus2 = rlf.Bus(id="bus2", phases="abc")
+bus3 = rlf.Bus(id="bus3", phases="abc")
 
 # Define a voltage source on the first bus
 un = 400
-voltages = Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+voltages = rlf.Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 # Define the impedance and admittance parameters of the lines (can be reused)
-parameters = LineParameters(
+parameters = rlf.LineParameters(
     id="parameters",
-    z_line=Q_((0.12 + 0.1j) * np.eye(3), "ohm/km"),
-    y_shunt=Q_(2e-4j * np.eye(3), "S/km"),
+    z_line=rlf.Q_((0.12 + 0.1j) * np.eye(3), "ohm/km"),
+    y_shunt=rlf.Q_(2e-4j * np.eye(3), "S/km"),
 )
 
 # Define a line between bus1 and bus2 (using g1 for the shunt connections)
-line1 = Line(
+line1 = rlf.Line(
     id="line1",
     bus1=bus1,
     bus2=bus2,
     parameters=parameters,
-    length=Q_(2, "km"),
+    length=rlf.Q_(2, "km"),
     ground=g1,
 )
 
 # Define a line between bus2 and bus3 (using g2 for the shunt connections)
-line2 = Line(
+line2 = rlf.Line(
     id="line2",
     bus1=bus2,
     bus2=bus3,
     parameters=parameters,
-    length=Q_(2.5, "km"),
+    length=rlf.Q_(2.5, "km"),
     ground=g2,
 )
 
 # Add a load on bus3
-load = PowerLoad(
+load = rlf.PowerLoad(
     id="load",
     bus=bus3,
-    powers=Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA"),
+    powers=rlf.Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA"),
 )
 
 # Set the phase "a" of the first bus to the ground g1
 g1.connect(bus=bus1, phase="a")
 
 # Set the potential of the ground element g1 to 0V
-pref = PotentialRef(id="pref", element=g1)
+pref = rlf.PotentialRef(id="pref", element=g1)
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # Get the ground potentials

--- a/doc/models/Line/Parameters.md
+++ b/doc/models/Line/Parameters.md
@@ -141,10 +141,10 @@ It means that we try to define $\underline{Z_0}=\underline{Z_1}$ and $\underline
 
 ```pycon
 >>> import numpy as np
-... from roseau.load_flow import LineParameters, Q_
+... import roseau.load_flow as rlf
 
 >>> # A basic example when z0=z1
-... line_parameters = LineParameters.from_sym(
+... line_parameters = rlf.LineParameters.from_sym(
 ...     "sym_line_example", z0=0.2 + 0.1j, z1=0.2 + 0.1j, y0=0.00014106j, y1=0.00014106j
 ... )
 
@@ -164,7 +164,7 @@ array(
 
 
 >>> # Simple example in "downgraded" model
-... line_parameters = LineParameters.from_sym(
+... line_parameters = rlf.LineParameters.from_sym(
 ...     "NKBA NOR  25.00 kV", z0=0.0j, z1=1.0 + 1.0j, y0=0.0j, y1=1e-06j
 ... )
 The symmetric model data provided for line type 'NKBA NOR  25.00 kV' produces invalid line impedance matrix... It is
@@ -186,7 +186,7 @@ array(
 
 
 >>> # 4x4 matrix
-... line_parameters = LineParameters.from_sym(
+... line_parameters = rlf.LineParameters.from_sym(
 ...     "sym_neutral_underground_line_example",
 ...     z0=0.188 + 0.8224j,
 ...     z1=0.188 + 0.0812j,
@@ -451,18 +451,18 @@ the point $B$, etc. The prime positions are the positions of the images of the c
 The formulas of the previous sections are used to get the impedance and shunt admittances matrices.
 
 ```pycon
->>> from roseau.load_flow import LineParameters, Q_, LineType, ConductorType, InsulatorType
+>>> import roseau.load_flow as rlf
 
 >>> # A twisted line example
-... line_parameters = LineParameters.from_geometry(
+... line_parameters = rlf.LineParameters.from_geometry(
 ...     "twisted_example",
-...     line_type=LineType.TWISTED,
-...     conductor_type=ConductorType.AL,
-...     insulator_type=InsulatorType.PEX,
+...     line_type=rlf.LineType.TWISTED,
+...     conductor_type=rlf.ConductorType.AL,
+...     insulator_type=rlf.InsulatorType.PEX,
 ...     section=150,  # mm²
 ...     section_neutral=70,  # mm²
 ...     height=10,  # m
-...     external_diameter=Q_(4, "cm"),
+...     external_diameter=rlf.Q_(4, "cm"),
 ... )
 
 >>> line_parameters.z_line
@@ -533,14 +533,14 @@ Please note that for underground lines, the provided height $h$ must be negative
 ```
 
 ```pycon
->>> from roseau.load_flow import LineParameters, Q_, LineType, ConductorType, InsulatorType
+>>> import roseau.load_flow as rlf
 
 >>> # An underground line example
-... line_parameters = LineParameters.from_geometry(
+... line_parameters = rlf.LineParameters.from_geometry(
 ...     "underground_example",
-...     line_type=LineType.UNDERGROUND,
-...     conductor_type=ConductorType.AL,
-...     insulator_type=InsulatorType.PVC,
+...     line_type=rlf.LineType.UNDERGROUND,
+...     conductor_type=rlf.ConductorType.AL,
+...     insulator_type=rlf.InsulatorType.PVC,
 ...     section=150, #mm²
 ...     section_neutral=70, #mm²
 ...     height=-1.5, # m # Underground so negative!

--- a/doc/models/Line/ShuntLine.md
+++ b/doc/models/Line/ShuntLine.md
@@ -77,28 +77,18 @@ connects a constant power load to a voltage source.
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    Line,
-    LineParameters,
-    PotentialRef,
-    PowerLoad,
-    Q_,
-    VoltageSource,
-    Ground,
-)
+import roseau.load_flow as rlf
 
 # Two buses
-bus1 = Bus(id="bus1", phases="abcn")
-bus2 = Bus(id="bus2", phases="abcn")
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+bus2 = rlf.Bus(id="bus2", phases="abcn")
 
 # Create a ground element and set its potential to zero
-ground = Ground(id="ground")
-pref = PotentialRef(id="pref", element=ground)
+ground = rlf.Ground(id="ground")
+pref = rlf.PotentialRef(id="pref", element=ground)
 
 # A shunt line
-z_line = Q_(
+z_line = rlf.Q_(
     np.array(
         [
             [0.3 + 0.35j, 0.25j, 0.25j, 0.25j],
@@ -109,7 +99,7 @@ z_line = Q_(
     ),
     "ohm/km",
 )
-y_shunt = Q_(
+y_shunt = rlf.Q_(
     np.array(
         [
             [20 + 475j, -68j, -10j, -68j],
@@ -120,25 +110,25 @@ y_shunt = Q_(
     ),
     "uS/km",  # micro Siemens per kilometer
 )
-line_parameters = LineParameters(id="line_parameters", z_line=z_line, y_shunt=y_shunt)
-line = Line(
+line_parameters = rlf.LineParameters(id="line_parameters", z_line=z_line, y_shunt=y_shunt)
+line = rlf.Line(
     id="line",
     bus1=bus1,
     bus2=bus2,
     parameters=line_parameters,
-    length=Q_(1, "km"),
+    length=rlf.Q_(1, "km"),
     ground=ground,
 )
 
 # A voltage source on the first bus
 un = 400 / np.sqrt(3)
-voltages = Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+voltages = rlf.Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 
 # A power load on the second bus
-load = PowerLoad(
-    id="load", bus=bus2, powers=Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
+load = rlf.PowerLoad(
+    id="load", bus=bus2, powers=rlf.Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
 )
 
 # The impedance matrix (in Ohm) can be accessed from the line instance
@@ -164,7 +154,7 @@ line.with_shunt
 # True
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # The current "entering" into the line from the bus1

--- a/doc/models/Line/SimplifiedLine.md
+++ b/doc/models/Line/SimplifiedLine.md
@@ -55,36 +55,27 @@ Here is a simplified line connecting a constant power load to a voltage source.
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    Line,
-    LineParameters,
-    PotentialRef,
-    PowerLoad,
-    Q_,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Two buses
-bus1 = Bus(id="bus1", phases="abcn")
-bus2 = Bus(id="bus2", phases="abcn")
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+bus2 = rlf.Bus(id="bus2", phases="abcn")
 
 # A line
-lp = LineParameters(id="lp", z_line=Q_(0.35 * np.eye(4), "ohm/km"))
-line = Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=Q_(1, "km"))
+lp = rlf.LineParameters(id="lp", z_line=rlf.Q_(0.35 * np.eye(4), "ohm/km"))
+line = rlf.Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=rlf.Q_(1, "km"))
 
 # A voltage source on the first bus
 un = 400 / np.sqrt(3)
-voltages = Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+voltages = rlf.Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 # The neutral of the voltage source is fixed at potential 0
-pref = PotentialRef(id="pref", element=bus1, phase="n")
+pref = rlf.PotentialRef(id="pref", element=bus1, phase="n")
 
 # A power load on the second bus
-load = PowerLoad(
-    id="load", bus=bus2, powers=Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
+load = rlf.PowerLoad(
+    id="load", bus=bus2, powers=rlf.Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
 )
 
 # The impedance matrix (in Ohm) can be accessed from the line instance
@@ -109,7 +100,7 @@ line.y_shunt
 # ) <Unit('siemens')>
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # The current flowing into the line from bus1

--- a/doc/models/Line/index.md
+++ b/doc/models/Line/index.md
@@ -132,11 +132,10 @@ $S/km$ (or an equivalent unit).
 
 ```python
 import numpy as np
-
-from roseau.load_flow import LineParameters, Q_
+import roseau.load_flow as rlf
 
 # An impedance matrix
-z_line = Q_(
+z_line = rlf.Q_(
     np.array(
         [
             [0.3 + 0.35j, 0.25j, 0.25j, 0.25j],
@@ -149,7 +148,7 @@ z_line = Q_(
 )
 
 # A shunt admittance matrix
-y_shunt = Q_(
+y_shunt = rlf.Q_(
     np.array(
         [
             [20 + 475j, -68j, -10j, -68j],
@@ -162,10 +161,10 @@ y_shunt = Q_(
 )
 
 # The line parameter for a simple line (no shunt)
-simple_line_parameters = LineParameters(id="simple_line_parameters", z_line=z_line)
+simple_line_parameters = rlf.LineParameters(id="simple_line_parameters", z_line=z_line)
 
 # The line parameter for a line with a shunt
-shunt_line_parameters = LineParameters(
+shunt_line_parameters = rlf.LineParameters(
     id="shunt_line_parameters", z_line=z_line, y_shunt=y_shunt
 )
 ```

--- a/doc/models/Load/CurrentLoad.md
+++ b/doc/models/Load/CurrentLoad.md
@@ -48,42 +48,33 @@ And the following (delta loads):
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    Line,
-    LineParameters,
-    PotentialRef,
-    CurrentLoad,
-    Q_,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Two buses
-bus1 = Bus(id="bus1", phases="abcn")
-bus2 = Bus(id="bus2", phases="abcn")
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+bus2 = rlf.Bus(id="bus2", phases="abcn")
 
 # A line
-lp = LineParameters(id="lp", z_line=Q_(0.35 * np.eye(4), "ohm/km"))
-line = Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=Q_(1, "km"))
+lp = rlf.LineParameters(id="lp", z_line=rlf.Q_(0.35 * np.eye(4), "ohm/km"))
+line = rlf.Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=rlf.Q_(1, "km"))
 
 # A voltage source on the first bus
 un = 400 / np.sqrt(3)
-voltages = Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+voltages = rlf.Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 # The neutral of the voltage source is fixed at potential 0
-pref = PotentialRef(id="pref", element=bus1, phase="n")
+pref = rlf.PotentialRef(id="pref", element=bus1, phase="n")
 
 # A current load on the second bus
-load = CurrentLoad(
+load = rlf.CurrentLoad(
     id="load",
     bus=bus2,
-    currents=Q_(5 * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "A"),
+    currents=rlf.Q_(5 * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "A"),
 )
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # Get the current of the load (equal to the one provided)
@@ -107,7 +98,7 @@ en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
 # | ('bus2', 'cn') |                    229.19 |                    120 |
 
 # Modify the load value to create an unbalanced load
-load.currents = Q_(
+load.currents = rlf.Q_(
     np.array([5.0, 2.5, 0]) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "A"
 )
 en.solve_load_flow()

--- a/doc/models/Load/FlexibleLoad/Control.md
+++ b/doc/models/Load/FlexibleLoad/Control.md
@@ -23,13 +23,13 @@ No control is applied, this is equivalent to a classical power load. The constan
 built like this:
 
 ```python
-from roseau.load_flow import Control
+import roseau.load_flow as rlf
 
 # Use the constructor. Note that the voltages are not important in this case.
-control = Control(type="constant", u_min=0.0, u_down=0.0, u_up=0.0, u_max=0.0)
+control = rlf.Control(type="constant", u_min=0.0, u_down=0.0, u_up=0.0, u_max=0.0)
 
 # Or prefer using the shortcut
-control = Control.constant()
+control = rlf.Control.constant()
 ```
 
 (models-flexible_load-p_u_control)=
@@ -68,15 +68,21 @@ $\underline{S(U)}$ point may lie outside the disc of radius $S^{\max}$ in the $(
 [Projection page](models-flexible_load-projections) for more details about this case.
 
 ```python
-from roseau.load_flow import Control, Q_
+import roseau.load_flow as rlf
 
 # Use the constructor. Note that u_min and u_down are useless with the production control
-production_control = Control(
-    type="p_max_u_production", u_min=0, u_down=0, u_up=Q_(240, "V"), u_max=Q_(250, "V")
+production_control = rlf.Control(
+    type="p_max_u_production",
+    u_min=0,
+    u_down=0,
+    u_up=rlf.Q_(240, "V"),
+    u_max=rlf.Q_(250, "V"),
 )
 
 # Or prefer the shortcut
-production_control = Control.p_max_u_production(u_up=Q_(240, "V"), u_max=Q_(250, "V"))
+production_control = rlf.Control.p_max_u_production(
+    u_up=rlf.Q_(240, "V"), u_max=rlf.Q_(250, "V")
+)
 ```
 
 ### Consumption
@@ -95,15 +101,21 @@ $\underline{S(U)}$ point may lie outside the disc of radius $S^{\max}$ in the $(
 [Projection page](models-flexible_load-projections) for more details about this case.
 
 ```python
-from roseau.load_flow import Control, Q_
+import roseau.load_flow as rlf
 
 # Use the constructor. Note that u_max and u_up are useless with the consumption control
-consumption_control = Control(
-    type="p_max_u_consumption", u_min=Q_(210, "V"), u_down=Q_(220, "V"), u_up=0, u_max=0
+consumption_control = rlf.Control(
+    type="p_max_u_consumption",
+    u_min=rlf.Q_(210, "V"),
+    u_down=rlf.Q_(220, "V"),
+    u_up=0,
+    u_max=0,
 )
 
 # Or prefer the shortcut
-consumption_control = Control.p_max_u_consumption(u_min=Q_(210, "V"), u_down=Q_(220, "V"))
+consumption_control = rlf.Control.p_max_u_consumption(
+    u_min=rlf.Q_(210, "V"), u_down=rlf.Q_(220, "V")
+)
 ```
 
 (models-flexible_load-q_u_control)=
@@ -129,20 +141,23 @@ The function $s_{\alpha}$ used for the $Q(U)$ control is derived from the *soft 
 ```
 
 ```python
-from roseau.load_flow import Control, Q_
+import roseau.load_flow as rlf
 
 # Use the constructor. Note that all the voltages are important.
-control = Control(
+control = rlf.Control(
     type="q_u",
-    u_min=Q_(210, "V"),
-    u_down=Q_(220, "V"),
-    u_up=Q_(240, "V"),
-    u_max=Q_(250, "V"),
+    u_min=rlf.Q_(210, "V"),
+    u_down=rlf.Q_(220, "V"),
+    u_up=rlf.Q_(240, "V"),
+    u_max=rlf.Q_(250, "V"),
 )
 
 # Or prefer the shortcut
-control = Control.q_u(
-    u_min=Q_(210, "V"), u_down=Q_(220, "V"), u_up=Q_(240, "V"), u_max=Q_(250, "V")
+control = rlf.Control.q_u(
+    u_min=rlf.Q_(210, "V"),
+    u_down=rlf.Q_(220, "V"),
+    u_up=rlf.Q_(240, "V"),
+    u_max=rlf.Q_(250, "V"),
 )
 ```
 

--- a/doc/models/Load/FlexibleLoad/FlexibleParameter.md
+++ b/doc/models/Load/FlexibleLoad/FlexibleParameter.md
@@ -28,15 +28,18 @@ Here, we define a flexible parameter with:
 - an $S^{\max}$ of 5 kVA.
 
 ```python
-from roseau.load_flow import FlexibleParameter, Control, Projection, Q_
+import roseau.load_flow as rlf
 
-fp = FlexibleParameter(
-    control_p=Control.constant(),
-    control_q=Control.q_u(
-        u_min=Q_(210, "V"), u_down=Q_(220, "V"), u_up=Q_(240, "V"), u_max=Q_(250, "V")
+fp = rlf.FlexibleParameter(
+    control_p=rlf.Control.constant(),
+    control_q=rlf.Control.q_u(
+        u_min=rlf.Q_(210, "V"),
+        u_down=rlf.Q_(220, "V"),
+        u_up=rlf.Q_(240, "V"),
+        u_max=rlf.Q_(250, "V"),
     ),
-    projection=Projection(type="keep_p"),
-    s_max=Q_(5, "kVA"),
+    projection=rlf.Projection(type="keep_p"),
+    s_max=rlf.Q_(5, "kVA"),
 )
 ```
 
@@ -52,26 +55,28 @@ flexible parameter with constant $P$ control and use it three times in the load 
 
 ```python
 import numpy as np
+import roseau.load_flow as rlf
 
-from roseau.load_flow import FlexibleParameter, Control, Projection, Q_, PowerLoad, Bus
-
-bus = Bus(id="bus", phases="abcn")
+bus = rlf.Bus(id="bus", phases="abcn")
 
 # Create a flexible parameter object
-fp = FlexibleParameter(
-    control_p=Control.constant(),
-    control_q=Control.q_u(
-        u_min=Q_(210, "V"), u_down=Q_(220, "V"), u_up=Q_(240, "V"), u_max=Q_(250, "V")
+fp = rlf.FlexibleParameter(
+    control_p=rlf.Control.constant(),
+    control_q=rlf.Control.q_u(
+        u_min=rlf.Q_(210, "V"),
+        u_down=rlf.Q_(220, "V"),
+        u_up=rlf.Q_(240, "V"),
+        u_max=rlf.Q_(250, "V"),
     ),
-    projection=Projection(type="keep_p"),
-    s_max=Q_(5, "kVA"),
+    projection=rlf.Projection(type="keep_p"),
+    s_max=rlf.Q_(5, "kVA"),
 )
 
 # Use it for the three phases of the load
-load = PowerLoad(
+load = rlf.PowerLoad(
     id="load",
     bus=bus,
-    powers=Q_(np.array([1000, 1000, 1000]) * (1 - 0.3j), "VA"),
+    powers=rlf.Q_(np.array([1000, 1000, 1000]) * (1 - 0.3j), "VA"),
     flexible_params=[fp, fp, fp],  # <- this makes the load "flexible"
 )
 ```
@@ -88,35 +93,39 @@ bus with a neutral. Two different controls are applied by the load on the two ph
 
 ```python
 import numpy as np
+import roseau.load_flow as rlf
 
-from roseau.load_flow import FlexibleParameter, Control, Projection, Q_, PowerLoad, Bus
-
-bus = Bus(id="bus", phases="abcn")
+bus = rlf.Bus(id="bus", phases="abcn")
 
 # Create a first flexible parameter (Q(U) control)
-fp1 = FlexibleParameter(
-    control_p=Control.constant(),
-    control_q=Control.q_u(
-        u_min=Q_(210, "V"), u_down=Q_(220, "V"), u_up=Q_(240, "V"), u_max=Q_(250, "V")
+fp1 = rlf.FlexibleParameter(
+    control_p=rlf.Control.constant(),
+    control_q=rlf.Control.q_u(
+        u_min=rlf.Q_(210, "V"),
+        u_down=rlf.Q_(220, "V"),
+        u_up=rlf.Q_(240, "V"),
+        u_max=rlf.Q_(250, "V"),
     ),
-    projection=Projection(type="keep_p"),
-    s_max=Q_(5, "kVA"),
+    projection=rlf.Projection(type="keep_p"),
+    s_max=rlf.Q_(5, "kVA"),
 )
 
 # Create a second flexible parameter (P(U) control)
-fp2 = FlexibleParameter(
-    control_p=Control.p_max_u_consumption(u_min=Q_(210, "V"), u_down=Q_(220, "V")),
-    control_q=Control.constant(),
-    projection=Projection(type="euclidean"),
-    s_max=Q_(3, "kVA"),
+fp2 = rlf.FlexibleParameter(
+    control_p=rlf.Control.p_max_u_consumption(
+        u_min=rlf.Q_(210, "V"), u_down=rlf.Q_(220, "V")
+    ),
+    control_q=rlf.Control.constant(),
+    projection=rlf.Projection(type="euclidean"),
+    s_max=rlf.Q_(3, "kVA"),
 )
 
 # Use them in a load
-load = PowerLoad(
+load = rlf.PowerLoad(
     id="load",
     bus=bus,
     phases="abn",
-    powers=Q_(np.array([1000, 1000]) * (1 - 0.3j), "VA"),
+    powers=rlf.Q_(np.array([1000, 1000]) * (1 - 0.3j), "VA"),
     flexible_params=[fp1, fp2],
 )
 ```
@@ -135,37 +144,41 @@ client.
 
 ```python
 import numpy as np
+import roseau.load_flow as rlf
 
-from roseau.load_flow import FlexibleParameter, Control, Projection, Q_, PowerLoad, Bus
-
-bus = Bus(id="bus", phases="abc")
+bus = rlf.Bus(id="bus", phases="abc")
 
 # Create a flexible parameter
-fp = FlexibleParameter(
-    control_p=Control.p_max_u_production(u_up=Q_(245, "V"), u_max=Q_(250, "V")),
-    control_q=Control.q_u(
-        u_min=Q_(210, "V"), u_down=Q_(220, "V"), u_up=Q_(240, "V"), u_max=Q_(245, "V")
+fp = rlf.FlexibleParameter(
+    control_p=rlf.Control.p_max_u_production(
+        u_up=rlf.Q_(245, "V"), u_max=rlf.Q_(250, "V")
     ),
-    projection=Projection(type="euclidean"),
-    s_max=Q_(5, "kVA"),
+    control_q=rlf.Control.q_u(
+        u_min=rlf.Q_(210, "V"),
+        u_down=rlf.Q_(220, "V"),
+        u_up=rlf.Q_(240, "V"),
+        u_max=rlf.Q_(245, "V"),
+    ),
+    projection=rlf.Projection(type="euclidean"),
+    s_max=rlf.Q_(5, "kVA"),
 )
 
 # Or using the shortcut
-fp = FlexibleParameter.pq_u_production(
-    up_up=Q_(245, "V"),
-    up_max=Q_(250, "V"),
-    uq_min=Q_(210, "V"),
-    uq_down=Q_(220, "V"),
-    uq_up=Q_(240, "V"),
-    uq_max=Q_(245, "V"),
-    s_max=Q_(5, "kVA"),
+fp = rlf.FlexibleParameter.pq_u_production(
+    up_up=rlf.Q_(245, "V"),
+    up_max=rlf.Q_(250, "V"),
+    uq_min=rlf.Q_(210, "V"),
+    uq_down=rlf.Q_(220, "V"),
+    uq_up=rlf.Q_(240, "V"),
+    uq_max=rlf.Q_(245, "V"),
+    s_max=rlf.Q_(5, "kVA"),
 )
 
 # Use it in a load
-load = PowerLoad(
+load = rlf.PowerLoad(
     id="load",
     bus=bus,
-    powers=Q_(-np.array([1000, 1000, 1000]), "VA"),  # <- negative powers (generator)
+    powers=rlf.Q_(-np.array([1000, 1000, 1000]), "VA"),  # <- negative powers (generator)
     flexible_params=[fp, fp, fp],
 )
 ```

--- a/doc/models/Load/FlexibleLoad/Projection.md
+++ b/doc/models/Load/FlexibleLoad/Projection.md
@@ -10,7 +10,7 @@ myst:
     "keywords lang=fr": |
       simulation, réseau, électrique, charge flexible, domaine de faisabilité, projection, euclidienne, P constant,
       Q constant
-    "keywords lang=en": simulation, distribution grid, flexible load, projection, euclidian, constant P, constant Q
+    "keywords lang=en": simulation, distribution grid, flexible load, projection, euclidean, constant P, constant Q
 ---
 
 (models-flexible_load-projections)=
@@ -50,9 +50,9 @@ not specified.
 ```
 
 ```python
-from roseau.load_flow import Projection
+import roseau.load_flow as rlf
 
-projection = Projection(type="euclidean")  # alpha and epsilon can be provided
+projection = rlf.Projection(type="euclidean")  # alpha and epsilon can be provided
 ```
 
 ```{important}
@@ -70,9 +70,9 @@ Keep the value of $P$ computed by the control and project $Q$ on the feasible do
 ```
 
 ```python
-from roseau.load_flow import Projection
+import roseau.load_flow as rlf
 
-projection = Projection(type="keep_p")  # alpha and epsilon can be provided
+projection = rlf.Projection(type="keep_p")  # alpha and epsilon can be provided
 ```
 
 ```{important}
@@ -90,9 +90,9 @@ Keep the value of $Q$ computed by the control and project $P$ on the feasible do
 ```
 
 ```python
-from roseau.load_flow import Projection
+import roseau.load_flow as rlf
 
-projection = Projection(type="keep_q")  # alpha and epsilon can be provided
+projection = rlf.Projection(type="keep_q")  # alpha and epsilon can be provided
 ```
 
 ```{important}

--- a/doc/models/Load/ImpedanceLoad.md
+++ b/doc/models/Load/ImpedanceLoad.md
@@ -49,40 +49,31 @@ And the following (delta loads):
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    Line,
-    LineParameters,
-    PotentialRef,
-    ImpedanceLoad,
-    Q_,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Two buses
-bus1 = Bus(id="bus1", phases="abcn")
-bus2 = Bus(id="bus2", phases="abcn")
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+bus2 = rlf.Bus(id="bus2", phases="abcn")
 
 # A line
-lp = LineParameters(id="lp", z_line=Q_(0.35 * np.eye(4), "ohm/km"))
-line = Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=Q_(1, "km"))
+lp = rlf.LineParameters(id="lp", z_line=rlf.Q_(0.35 * np.eye(4), "ohm/km"))
+line = rlf.Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=rlf.Q_(1, "km"))
 
 # A voltage source on the first bus
 un = 400 / np.sqrt(3)
-voltages = Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+voltages = rlf.Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 # The neutral of the voltage source is fixed at potential 0
-pref = PotentialRef(id="pref", element=bus1, phase="n")
+pref = rlf.PotentialRef(id="pref", element=bus1, phase="n")
 
 # A power load on the second bus
-load = ImpedanceLoad(
-    id="load", bus=bus2, impedances=Q_(np.array([40 + 3j, 40 + 3j, 40 + 3j]), "ohm")
+load = rlf.ImpedanceLoad(
+    id="load", bus=bus2, impedances=rlf.Q_(np.array([40 + 3j, 40 + 3j, 40 + 3j]), "ohm")
 )
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # Get the impedances of the load (the result is equal to the provided impedance
@@ -101,7 +92,7 @@ en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
 # | ('bus2', 'cn') |                   228.948 |          120.037       |
 
 # Modify the load value to create an unbalanced load
-load.impedances = Q_(np.array([40 + 4j, 20 + 2j, 10 + 1j]), "ohm")
+load.impedances = rlf.Q_(np.array([40 + 4j, 20 + 2j, 10 + 1j]), "ohm")
 en.solve_load_flow()
 
 # Get the impedance of the load

--- a/doc/models/Load/PowerLoad.md
+++ b/doc/models/Load/PowerLoad.md
@@ -52,38 +52,29 @@ And the following (delta loads):
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    Line,
-    LineParameters,
-    PotentialRef,
-    PowerLoad,
-    Q_,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Two buses
-bus1 = Bus(id="bus1", phases="abcn")
-bus2 = Bus(id="bus2", phases="abcn")
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+bus2 = rlf.Bus(id="bus2", phases="abcn")
 
 # A line
-lp = LineParameters(id="lp", z_line=Q_(0.35 * np.eye(4), "ohm/km"))
-line = Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=Q_(1, "km"))
+lp = rlf.LineParameters(id="lp", z_line=rlf.Q_(0.35 * np.eye(4), "ohm/km"))
+line = rlf.Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=rlf.Q_(1, "km"))
 
 # A voltage source on the first bus
 un = 400 / np.sqrt(3)
-voltages = Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+voltages = rlf.Q_(un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), "V")
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 # The neutral of the voltage source is fixed at potential 0
-pref = PotentialRef(id="pref", element=bus1, phase="n")
+pref = rlf.PotentialRef(id="pref", element=bus1, phase="n")
 
 # A power load on the second bus
-load = PowerLoad(id="load", bus=bus2, powers=Q_((1000 - 300j) * np.ones(3), "VA"))
+load = rlf.PowerLoad(id="load", bus=bus2, powers=rlf.Q_((1000 - 300j) * np.ones(3), "VA"))
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # Get the powers of the loads in the network
@@ -107,7 +98,7 @@ en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
 # | ('bus2', 'cn') |                   229.414 |          119.886       |
 
 # Modify the load value to create an unbalanced load
-load.powers = Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
+load.powers = rlf.Q_(np.array([5.0, 2.5, 0]) * (1 - 0.3j), "kVA")
 en.solve_load_flow()
 
 # Get the powers of the loads in the network

--- a/doc/models/PotentialRef.md
+++ b/doc/models/PotentialRef.md
@@ -37,10 +37,10 @@ i.e. its potential is not fixed at $0V$. If you want to set its potential to $0V
 a potential reference element explicitly:
 
 ```python
-from roseau.load_flow.models import Ground, PotentialRef
+import roseau.load_flow as rlf
 
-g = Ground(id="ground")
-p_ref = PotentialRef(id="pref", element=g)
+g = rlf.Ground(id="ground")
+p_ref = rlf.PotentialRef(id="pref", element=g)
 ```
 
 With this code snippet, you have defined the following element:
@@ -55,10 +55,10 @@ It is also possible to set the reference of potentials to any phase of any bus i
 For example, to fix the potential of phase "a" of some bus to $0V$:
 
 ```python
-from roseau.load_flow.models import Bus, PotentialRef
+import roseau.load_flow as rlf
 
-bus = Bus(id="bus", phases="abcn")
-p_ref = PotentialRef(id="pref", element=bus, phase="a")
+bus = rlf.Bus(id="bus", phases="abcn")
+p_ref = rlf.PotentialRef(id="pref", element=bus, phase="a")
 ```
 
 ## API Reference

--- a/doc/models/Switch.md
+++ b/doc/models/Switch.md
@@ -42,36 +42,28 @@ Here is a switch connecting a constant power load to a voltage source.
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Q_,
-    Bus,
-    ElectricalNetwork,
-    PotentialRef,
-    PowerLoad,
-    Switch,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Two buses
-bus1 = Bus(id="bus1", phases="abcn")
-bus2 = Bus(id="bus2", phases="abcn")
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+bus2 = rlf.Bus(id="bus2", phases="abcn")
 
 # A line
-switch = Switch(id="switch", bus1=bus1, bus2=bus2)
+switch = rlf.Switch(id="switch", bus1=bus1, bus2=bus2)
 
 # A voltage source on the first bus
 un = 400 / np.sqrt(3)
 voltages = un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-vs = VoltageSource(id="source", bus=bus1, voltages=voltages)
+vs = rlf.VoltageSource(id="source", bus=bus1, voltages=voltages)
 
 # The neutral of the voltage source is fixed at potential 0
-pref = PotentialRef(id="pref", element=bus1, phase="n")
+pref = rlf.PotentialRef(id="pref", element=bus1, phase="n")
 
 # A power load on the second bus
-load = PowerLoad(id="load", bus=bus2, powers=[5000 + 1600j, 2500 + 800j, 0])
+load = rlf.PowerLoad(id="load", bus=bus2, powers=[5000 + 1600j, 2500 + 800j, 0])
 
 # Create a network and solve a load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # The current flowing into the line from bus1

--- a/doc/models/Transformer/Center_Tapped_Transformer.md
+++ b/doc/models/Transformer/Center_Tapped_Transformer.md
@@ -80,46 +80,35 @@ admittance of the transformer, $k$ the transformation ratio, and:
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    Ground,
-    Line,
-    LineParameters,
-    PotentialRef,
-    PowerLoad,
-    Transformer,
-    TransformerParameters,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Create a ground and set it as the reference potential
-ground = Ground("ground")
-pref = PotentialRef("pref", ground)
+ground = rlf.Ground("ground")
+pref = rlf.PotentialRef("pref", ground)
 
 # Create a source bus and voltage source (MV)
-source_bus = Bus("source_bus", phases="abcn")
+source_bus = rlf.Bus("source_bus", phases="abcn")
 ground.connect(source_bus)
 voltages = 20e3 / np.sqrt(3) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-vs = VoltageSource(id="vs", bus=source_bus, voltages=voltages)
+vs = rlf.VoltageSource(id="vs", bus=source_bus, voltages=voltages)
 
 # Create a load bus and a load (MV)
-load_bus = Bus(id="load_bus", phases="abc")
-mv_load = PowerLoad("mv_load", load_bus, powers=[10000, 10000, 10000])
+load_bus = rlf.Bus(id="load_bus", phases="abc")
+mv_load = rlf.PowerLoad("mv_load", load_bus, powers=[10000, 10000, 10000])
 
 # Connect the two MV buses with a line
-lp = LineParameters.from_catalogue(
+lp = rlf.LineParameters.from_catalogue(
     name="U_AL_150", model="iec"
 )  # Underground, ALuminium, 150mm²
-line = Line("line", source_bus, load_bus, parameters=lp, length=1.0, ground=ground)
+line = rlf.Line("line", source_bus, load_bus, parameters=lp, length=1.0, ground=ground)
 
 # Create a low-voltage bus and a load
-lv_bus = Bus(id="lv_bus", phases="abn")
+lv_bus = rlf.Bus(id="lv_bus", phases="abn")
 ground.connect(lv_bus)
-lv_load = PowerLoad("lv_load", lv_bus, powers=[-2000, 0])
+lv_load = rlf.PowerLoad("lv_load", lv_bus, powers=[-2000, 0])
 
 # Create a transformer
-tp = TransformerParameters.from_open_and_short_circuit_tests(
+tp = rlf.TransformerParameters.from_open_and_short_circuit_tests(
     "t",
     "center",  # <--- Center-tapped transformer
     sn=630e3,
@@ -130,10 +119,10 @@ tp = TransformerParameters.from_open_and_short_circuit_tests(
     psc=6500.0,
     vsc=0.04,
 )
-transformer = Transformer("transfo", load_bus, lv_bus, parameters=tp)
+transformer = rlf.Transformer("transfo", load_bus, lv_bus, parameters=tp)
 
 # Create the network and solve the load flow
-en = ElectricalNetwork.from_element(source_bus)
+en = rlf.ElectricalNetwork.from_element(source_bus)
 en.solve_load_flow()
 
 # The current flowing into the the line and transformer from the source side

--- a/doc/models/Transformer/Single_Phase_Transformer.md
+++ b/doc/models/Transformer/Single_Phase_Transformer.md
@@ -69,31 +69,23 @@ to a three-phase voltage source.
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    PotentialRef,
-    PowerLoad,
-    Transformer,
-    TransformerParameters,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Create the source bus and the voltage source
-bus1 = Bus(id="bus1", phases="abcn")
-pref1 = PotentialRef(id="pref1", element=bus1)
+bus1 = rlf.Bus(id="bus1", phases="abcn")
+pref1 = rlf.PotentialRef(id="pref1", element=bus1)
 
 voltages = 400 / np.sqrt(3) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-vs = VoltageSource(id="vs", bus=bus1, voltages=voltages)
+vs = rlf.VoltageSource(id="vs", bus=bus1, voltages=voltages)
 
 # Create the load bus and the load
-bus2 = Bus(id="bus2", phases="an")
-pref2 = PotentialRef(id="pref2", element=bus2)
+bus2 = rlf.Bus(id="bus2", phases="an")
+pref2 = rlf.PotentialRef(id="pref2", element=bus2)
 
-load = PowerLoad(id="load", bus=bus2, powers=[100], phases="an")
+load = rlf.PowerLoad(id="load", bus=bus2, powers=[100], phases="an")
 
 # Create the transformer
-tp = TransformerParameters.from_open_and_short_circuit_tests(
+tp = rlf.TransformerParameters.from_open_and_short_circuit_tests(
     id="Example_TP",
     type="single",  # <--- Single-phase transformer
     sn=800,
@@ -104,7 +96,7 @@ tp = TransformerParameters.from_open_and_short_circuit_tests(
     psc=25,
     vsc=0.032,
 )
-transformer = Transformer(
+transformer = rlf.Transformer(
     id="transfo",
     bus1=bus1,
     bus2=bus2,
@@ -114,7 +106,7 @@ transformer = Transformer(
 )
 
 # Create the network and solve the load flow
-en = ElectricalNetwork.from_element(bus1)
+en = rlf.ElectricalNetwork.from_element(bus1)
 en.solve_load_flow()
 
 # The current flowing into the transformer from the source side

--- a/doc/models/Transformer/Three_Phase_Transformer.md
+++ b/doc/models/Transformer/Three_Phase_Transformer.md
@@ -608,32 +608,24 @@ connects a voltage source on the MV network to a load on the LV network.
 ```python
 import functools as ft
 import numpy as np
-from roseau.load_flow import (
-    Bus,
-    ElectricalNetwork,
-    PotentialRef,
-    PowerLoad,
-    Transformer,
-    TransformerParameters,
-    VoltageSource,
-)
+import roseau.load_flow as rlf
 
 # Create a MV bus
-bus_mv = Bus(id="bus_mv", phases="abc")
+bus_mv = rlf.Bus(id="bus_mv", phases="abc")
 
 # Create a LV bus
-bus_lv = Bus(id="bus_lv", phases="abcn")
+bus_lv = rlf.Bus(id="bus_lv", phases="abcn")
 
 # Set the potential references of the MV and LV networks
-pref_mv = PotentialRef(id="pref_mv", element=bus_mv)
-pref_lv = PotentialRef(id="pref_lv", element=bus_lv, phase="n")
+pref_mv = rlf.PotentialRef(id="pref_mv", element=bus_mv)
+pref_lv = rlf.PotentialRef(id="pref_lv", element=bus_lv, phase="n")
 
 # Create a voltage source and connect it to the MV bus
 voltages = 20e3 * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-vs = VoltageSource(id="vs", bus=bus_mv, voltages=voltages)
+vs = rlf.VoltageSource(id="vs", bus=bus_mv, voltages=voltages)
 
 # Create a MV/LV transformer
-tp = TransformerParameters.from_open_and_short_circuit_tests(
+tp = rlf.TransformerParameters.from_open_and_short_circuit_tests(
     id="SE_Minera_A0Ak_100_kVA",
     type="Dyn11",
     sn=100.0 * 1e3,
@@ -644,7 +636,7 @@ tp = TransformerParameters.from_open_and_short_circuit_tests(
     psc=1250.0,
     vsc=4.0 / 100,
 )
-transformer = Transformer(
+transformer = rlf.Transformer(
     id="transfo",
     bus1=bus_mv,
     bus2=bus_lv,
@@ -655,10 +647,10 @@ transformer = Transformer(
 )
 
 # Create a LV load
-load = PowerLoad(id="load", bus=bus_lv, phases="abcn", powers=[3e3, 3e3, 3e3])
+load = rlf.PowerLoad(id="load", bus=bus_lv, phases="abcn", powers=[3e3, 3e3, 3e3])
 
 # Create the network and solve the load flow
-en = ElectricalNetwork.from_element(bus_mv)
+en = rlf.ElectricalNetwork.from_element(bus_mv)
 en.solve_load_flow()
 
 # The current flowing into the transformer from the MV bus

--- a/doc/models/Transformer/index.md
+++ b/doc/models/Transformer/index.md
@@ -122,61 +122,61 @@ following values:
 - Any windings (`"Dd0"`, `"Dz6"`, etc.) to model a three-phase transformer.
 
 ```python
-from roseau.load_flow import TransformerParameters, Q_
+import roseau.load_flow as rlf
 
 # The transformer parameters for a single-phase transformer
 single_phase_transformer_parameters = (
-    TransformerParameters.from_open_and_short_circuit_tests(
+    rlf.TransformerParameters.from_open_and_short_circuit_tests(
         id="single_phase_transformer_parameters",
         type="single",  # <--- single-phase transformer
-        uhv=Q_(20, "kV"),
-        ulv=Q_(400, "V"),
-        sn=Q_(160, "kVA"),
-        p0=Q_(300, "W"),
-        i0=Q_(1.4, "%"),
-        psc=Q_(2000, "W"),
-        vsc=Q_(4, "%"),
+        uhv=rlf.Q_(20, "kV"),
+        ulv=rlf.Q_(400, "V"),
+        sn=rlf.Q_(160, "kVA"),
+        p0=rlf.Q_(300, "W"),
+        i0=rlf.Q_(1.4, "%"),
+        psc=rlf.Q_(2000, "W"),
+        vsc=rlf.Q_(4, "%"),
     )
 )
 # Alternatively, if you have z2 and ym already:
-# single_phase_transformer_parameters = TransformerParameters(
+# single_phase_transformer_parameters = rlf.TransformerParameters(
 #     id="single_phase_transformer_parameters",
 #     type="single",
-#     uhv=Q_(20, "kV"),
-#     ulv=Q_(400, "V"),
-#     sn=Q_(160, "kVA"),
-#     z2=Q_(0.0125+0.038j, "ohm"),
-#     ym=Q_(7.5e-7-5.5e-6j, "S"),
+#     uhv=rlf.Q_(20, "kV"),
+#     ulv=rlf.Q_(400, "V"),
+#     sn=rlf.Q_(160, "kVA"),
+#     z2=rlf.Q_(0.0125+0.038j, "ohm"),
+#     ym=rlf.Q_(7.5e-7-5.5e-6j, "S"),
 # )
 
 
 # The transformer parameters for a three-phase transformer
 three_phase_transformer_parameters = (
-    TransformerParameters.from_open_and_short_circuit_tests(
+    rlf.TransformerParameters.from_open_and_short_circuit_tests(
         id="three_phase_transformer_parameters",
         type="Dyn11",  # <--- three-phase transformer with delta primary and wye secondary
-        uhv=Q_(20, "kV"),
-        ulv=Q_(400, "V"),
-        sn=Q_(160, "kVA"),
-        p0=Q_(300, "W"),
-        i0=Q_(1.4, "%"),
-        psc=Q_(2000, "W"),
-        vsc=Q_(4, "%"),
+        uhv=rlf.Q_(20, "kV"),
+        ulv=rlf.Q_(400, "V"),
+        sn=rlf.Q_(160, "kVA"),
+        p0=rlf.Q_(300, "W"),
+        i0=rlf.Q_(1.4, "%"),
+        psc=rlf.Q_(2000, "W"),
+        vsc=rlf.Q_(4, "%"),
     )
 )
 
 # The transformer parameters for a center-tapped transformer
 center_tapped_transformer_parameters = (
-    TransformerParameters.from_open_and_short_circuit_tests(
+    rlf.TransformerParameters.from_open_and_short_circuit_tests(
         id="center_tapped_transformer_parameters",
         type="center",  # <--- center-tapped transformer
-        uhv=Q_(20, "kV"),
-        ulv=Q_(400, "V"),
-        sn=Q_(160, "kVA"),
-        p0=Q_(300, "W"),
-        i0=Q_(1.4, "%"),
-        psc=Q_(2000, "W"),
-        vsc=Q_(4, "%"),
+        uhv=rlf.Q_(20, "kV"),
+        ulv=rlf.Q_(400, "V"),
+        sn=rlf.Q_(160, "kVA"),
+        p0=rlf.Q_(300, "W"),
+        i0=rlf.Q_(1.4, "%"),
+        psc=rlf.Q_(2000, "W"),
+        vsc=rlf.Q_(4, "%"),
     )
 )
 ```

--- a/doc/models/VoltageSource.md
+++ b/doc/models/VoltageSource.md
@@ -101,28 +101,28 @@ or phase-to-neutral connections of the source.
 
 ```python
 import numpy as np
-from roseau.load_flow import Bus, VoltageSource
+import roseau.load_flow as rlf
 
-bus = Bus(id="bus", phases="abcn")
+bus = rlf.Bus(id="bus", phases="abcn")
 
 # Star connection
 un = 400 / np.sqrt(3)  # 400V phase-to-phase -> 230V phase-to-neutral
 voltages = un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-VoltageSource(
+rlf.VoltageSource(
     id="vs", bus=bus, phases="abcn", voltages=voltages
 )  # Voltages are considered phase-to-neutral because phases="abcn"
 
 # Delta connection
 un = 400  # 400V phase-to-phase
 voltages = un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-VoltageSource(
+rlf.VoltageSource(
     id="vs", bus=bus, phases="abc", voltages=voltages
 )  # Voltages are considered phase-to-phase because phases="abc"
 
 # Incorrect voltage vector
 un = 400
 voltages = un * np.exp([0, -2j * np.pi / 3])  # Only two elements!!
-VoltageSource(id="vs", bus=bus, phases="abc", voltages=voltages)  # Error
+rlf.VoltageSource(id="vs", bus=bus, phases="abc", voltages=voltages)  # Error
 ```
 
 ## API Reference

--- a/doc/usage/Catalogues.md
+++ b/doc/usage/Catalogues.md
@@ -39,8 +39,8 @@ network can be provided on demand**. Please email us at
 This catalogue can be retrieved in the form of a dataframe using:
 
 ```pycon
->>> from roseau.load_flow import ElectricalNetwork
->>> ElectricalNetwork.get_catalogue()
+>>> import roseau.load_flow as rlf
+>>> rlf.ElectricalNetwork.get_catalogue()
 ```
 
 | Name                                                                              | Nb buses | Nb branches | Nb loads | Nb sources | Nb grounds | Nb potential refs | Available load points |
@@ -96,7 +96,7 @@ The arguments of the method `get_catalogue` can be used to filter the output. If
 only, you can call:
 
 ```pycon
->>> ElectricalNetwork.get_catalogue(name=r"LVFeeder.*")
+>>> rlf.ElectricalNetwork.get_catalogue(name=r"LVFeeder.*")
 ```
 
 | Name          | Nb buses | Nb branches | Nb loads | Nb sources | Nb grounds | Nb potential refs | Available load points |
@@ -125,7 +125,7 @@ only, you can call:
 A regular expression can also be used:
 
 ```pycon
->>> ElectricalNetwork.get_catalogue(name=r"LVFeeder38[0-9]+")
+>>> rlf.ElectricalNetwork.get_catalogue(name=r"LVFeeder38[0-9]+")
 ```
 
 | Name          | Nb buses | Nb branches | Nb loads | Nb sources | Nb grounds | Nb potential refs | Available load points |
@@ -138,14 +138,14 @@ You can build an `ElectricalNetwork` instance from the catalogue using the class
 `from_catalogue`. The name of the network and the name of the load point must be provided:
 
 ```pycon
->>> en = ElectricalNetwork.from_catalogue(name="LVFeeder38211", load_point_name="Summer")
+>>> en = rlf.ElectricalNetwork.from_catalogue(name="LVFeeder38211", load_point_name="Summer")
 <ElectricalNetwork: 6 buses, 5 branches, 8 loads, 1 source, 1 ground, 1 potential ref>
 ```
 
 In case no or several results match the parameters, an error is raised:
 
 ```pycon
->>> ElectricalNetwork.from_catalogue(name="LVFeeder38211", load_point_name="Unknown")
+>>> rlf.ElectricalNetwork.from_catalogue(name="LVFeeder38211", load_point_name="Unknown")
 RoseauLoadFlowException: No load points for network 'LVFeeder38211' matching the query (load_point_name='Unknown')
 have been found. Please look at the catalogue using the `get_catalogue` class method. [catalogue_not_found]
 ```
@@ -180,8 +180,8 @@ Pull requests to add some other sources are welcome!
 This catalogue can be retrieved in the form of a dataframe using:
 
 ```pycon
->>> from roseau.load_flow import TransformerParameters
->>> TransformerParameters.get_catalogue()
+>>> import roseau.load_flow as rlf
+>>> rlf.TransformerParameters.get_catalogue()
 ```
 
 _Truncated output_
@@ -255,7 +255,7 @@ The `get_catalogue` method accepts arguments (in bold above) that can be used to
 following command only retrieves transformer parameters of transformers with an efficiency of "A0Ak":
 
 ```pycon
->>> TransformerParameters.get_catalogue(efficiency="A0Ak")
+>>> rlf.TransformerParameters.get_catalogue(efficiency="A0Ak")
 ```
 
 | Name                   | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
@@ -278,7 +278,7 @@ following command only retrieves transformer parameters of transformers with an 
 or only transformers with a wye winding on the primary side (using a regular expression)
 
 ```pycon
->>> TransformerParameters.get_catalogue(type=r"y.*")
+>>> rlf.TransformerParameters.get_catalogue(type=r"y.*")
 ```
 
 | Name                     | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
@@ -291,7 +291,7 @@ or only transformers with a wye winding on the primary side (using a regular exp
 or only transformers meeting both criteria
 
 ```pycon
->>> TransformerParameters.get_catalogue(efficiency="A0Ak", type=r"y.*")
+>>> rlf.TransformerParameters.get_catalogue(efficiency="A0Ak", type=r"y.*")
 ```
 
 | Name                 | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
@@ -304,10 +304,10 @@ the values in different units. For instance, if you want to get transformer para
 nominal power of 3150 kVA, the following two commands return the same table:
 
 ```pycon
->>> TransformerParameters.get_catalogue(sn=3150e3) # in VA by default
+>>> rlf.TransformerParameters.get_catalogue(sn=3150e3) # in VA by default
 
->>> from roseau.load_flow import Q_
-... TransformerParameters.get_catalogue(sn=Q_(3150, "kVA"))
+>>> import roseau.load_flow as rlf
+... rlf.TransformerParameters.get_catalogue(sn=rlf.Q_(3150, "kVA"))
 ```
 
 | Name                         | Manufacturer | Product range | Efficiency | Type  | Nominal power (kVA) | High voltage (kV) | Low voltage (kV) |
@@ -325,21 +325,21 @@ the method `get_catalogue` to narrow down the result to a single transformer in 
 For instance, these parameters filter the catalogue down to a single transformer parameters:
 
 ```pycon
->>> TransformerParameters.from_catalogue(efficiency="A0Ak", type=r"^y.*$")
+>>> rlf.TransformerParameters.from_catalogue(efficiency="A0Ak", type=r"^y.*$")
 TransformerParameters(id='SE_Minera_A0Ak_50kVA')
 ```
 
 The `name` filter can be directly used:
 
 ```pycon
->>> TransformerParameters.from_catalogue(name="SE_Minera_A0Ak_50kVA")
+>>> rlf.TransformerParameters.from_catalogue(name="SE_Minera_A0Ak_50kVA")
 TransformerParameters(id='SE_Minera_A0Ak_50kVA')
 ```
 
 In case no or several results match the parameters, an error is raised:
 
 ```pycon
->>> TransformerParameters.from_catalogue(manufacturer="ft")
+>>> rlf.TransformerParameters.from_catalogue(manufacturer="ft")
 RoseauLoadFlowException: Several transformers matching the query (manufacturer='ft') have been found:
 'FT_Standard_Standard_100kVA', 'FT_Standard_Standard_160kVA', 'FT_Standard_Standard_250kVA',
 'FT_Standard_Standard_315kVA', 'FT_Standard_Standard_400kVA', 'FT_Standard_Standard_500kVA',
@@ -351,7 +351,7 @@ RoseauLoadFlowException: Several transformers matching the query (manufacturer='
 or if no results:
 
 ```pycon
->>> TransformerParameters.from_catalogue(manufacturer="unknown")
+>>> rlf.TransformerParameters.from_catalogue(manufacturer="unknown")
 RoseauLoadFlowException: No manufacturer matching 'unknown' has been found. Available manufacturers
 are 'FT', 'SE'. [catalogue_not_found]
 ```
@@ -375,8 +375,8 @@ The available lines data are based on the following sources:
 This catalogue can be retrieved in the form of a dataframe using:
 
 ```pycon
->>> from roseau.load_flow import LineParameters
->>> LineParameters.get_catalogue()
+>>> import roseau.load_flow as rlf
+>>> rlf.LineParameters.get_catalogue()
 ```
 
 _Truncated output_
@@ -425,7 +425,7 @@ The `get_catalogue` method accepts arguments (in bold above) that can be used to
 table. The following command only returns line parameters made of Aluminum:
 
 ```pycon
->>> LineParameters.get_catalogue(conductor_type="al")
+>>> rlf.LineParameters.get_catalogue(conductor_type="al")
 ```
 
 _Truncated output_
@@ -446,7 +446,7 @@ _Truncated output_
 or only lines with a cross-section of 240 mm² (using a regular expression)
 
 ```pycon
->>> LineParameters.get_catalogue(section=240)
+>>> rlf.LineParameters.get_catalogue(section=240)
 ```
 
 | Name     | Line type   | Conductor material | Insulator type | Cross-section (mm²) | Resistance (ohm/km) | Reactance (ohm/km) | Susceptance (S/km) | Maximal current (A) |
@@ -464,7 +464,7 @@ or only lines with a cross-section of 240 mm² (using a regular expression)
 or only lines meeting both criteria
 
 ```pycon
->>> LineParameters.get_catalogue(conductor_type="al", section=240)
+>>> rlf.LineParameters.get_catalogue(conductor_type="al", section=240)
 ```
 
 | Name     | Line type   | Conductor material | Insulator type | Cross-section (mm²) | Resistance (ohm/km) | Reactance (ohm/km) | Susceptance (S/km) | Maximal current (A) |
@@ -484,14 +484,14 @@ the method `get_catalogue` to narrow down the result to a single line in the cat
 For instance, these parameters filter the results down to a single line parameters:
 
 ```pycon
->>> LineParameters.from_catalogue(line_type="underground", conductor_type="al", section=240)
+>>> rlf.LineParameters.from_catalogue(line_type="underground", conductor_type="al", section=240)
 LineParameters(id='U_AL_240')
 ```
 
 Or you can use the `name` filter directly:
 
 ```pycon
->>> LineParameters.from_catalogue(name="U_AL_240")
+>>> rlf.LineParameters.from_catalogue(name="U_AL_240")
 LineParameters(id='U_AL_240')
 ```
 
@@ -499,7 +499,7 @@ As you can see, the `id` of the created instance is the same as the name in the 
 override this behaviour by passing the `id` parameter to `from_catalogue`:
 
 ```pycon
->>> LineParameters.from_catalogue(name="U_AL_240", id="lp-special")
+>>> rlf.LineParameters.from_catalogue(name="U_AL_240", id="lp-special")
 LineParameters(id='lp-special')
 ```
 
@@ -507,20 +507,20 @@ Line parameters created from the catalogue are 3-phase without a neutral by defa
 to create line parameters with different numbers of phases using the `nb_phases` parameter.
 
 ```pycon
->>> LineParameters.from_catalogue(name="U_AL_240").z_line.shape
+>>> rlf.LineParameters.from_catalogue(name="U_AL_240").z_line.shape
 (3, 3)
 >>> # For 3-phase with neutral lines
-... LineParameters.from_catalogue(name="U_AL_240", nb_phases=4).z_line.shape
+... rlf.LineParameters.from_catalogue(name="U_AL_240", nb_phases=4).z_line.shape
 (4, 4)
 >>> # For single-phase lines
-... LineParameters.from_catalogue(name="U_AL_240", nb_phases=2).z_line.shape
+... rlf.LineParameters.from_catalogue(name="U_AL_240", nb_phases=2).z_line.shape
 (2, 2)
 ```
 
 In case no or several results match the parameters, an error is raised:
 
 ```pycon
->>> LineParameters.from_catalogue(name= r"U_AL.*")
+>>> rlf.LineParameters.from_catalogue(name= r"U_AL.*")
 RoseauLoadFlowException: Several line parameters matching the query (name='U_AL.*') have been found:
 'U_AL_19', 'U_AL_20', 'U_AL_22', 'U_AL_25', 'U_AL_28', 'U_AL_29', 'U_AL_33', 'U_AL_34', 'U_AL_37',
 'U_AL_38', 'U_AL_40', 'U_AL_43', 'U_AL_48', 'U_AL_50', 'U_AL_54', 'U_AL_55', 'U_AL_59', 'U_AL_60',
@@ -532,7 +532,7 @@ RoseauLoadFlowException: Several line parameters matching the query (name='U_AL.
 or if no results:
 
 ```pycon
->>> LineParameters.from_catalogue(name="unknown")
+>>> rlf.LineParameters.from_catalogue(name="unknown")
 RoseauLoadFlowException: No name matching 'unknown' has been found. Available names are 'O_AL_12',
 'O_AL_13', 'O_AL_14', 'O_AL_19', 'O_AL_20', 'O_AL_22', 'O_AL_25', 'O_AL_28', 'O_AL_29', 'O_AL_33',
 'O_AL_34', 'O_AL_37', 'O_AL_38', 'O_AL_40', 'O_AL_43', 'O_AL_48', 'O_AL_50', 'O_AL_54', 'O_AL_55',

--- a/doc/usage/Connecting_Elements.md
+++ b/doc/usage/Connecting_Elements.md
@@ -84,7 +84,7 @@ The `disconnect` method is only available for loads and for voltage sources.
 >>> load.disconnect()
 ```
 
-Now, the loads no longer belongs to the network `en`. Symmetrically, the network doesn't have this load anymore:
+Now, the load no longer belongs to the network `en`. Symmetrically, the network doesn't have this load anymore:
 
 ```pycon
 >>> load.network

--- a/doc/usage/Flexible_Loads.md
+++ b/doc/usage/Flexible_Loads.md
@@ -27,26 +27,26 @@ a Delta-Wye transformer and a small LV network.
 
 ```pycon
 >>> import numpy as np
-... from roseau.load_flow import *
+... import roseau.load_flow as rlf
 
 >>> # Create a MV bus with a voltage source
-... bus0_mv = Bus(id="bus0_mv", phases="abc")
+... bus0_mv = rlf.Bus(id="bus0_mv", phases="abc")
 ... un = 20e3  # V
 ... source_voltages = [un, un * np.exp(-2j * np.pi / 3), un * np.exp(2j * np.pi / 3)]
-... vs = VoltageSource(id="vs", bus=bus0_mv, phases="abc", voltages=source_voltages)
+... vs = rlf.VoltageSource(id="vs", bus=bus0_mv, phases="abc", voltages=source_voltages)
 ... # Set the MV potential reference
-... pref_mv = PotentialRef(id="pref_mv", element=bus0_mv)
+... pref_mv = rlf.PotentialRef(id="pref_mv", element=bus0_mv)
 
 >>> # Create a LV bus and connect its neutral to the ground
-... bus0_lv = Bus(id="bus0_lv", phases="abcn")
-... ground = Ground(id="gnd")
+... bus0_lv = rlf.Bus(id="bus0_lv", phases="abcn")
+... ground = rlf.Ground(id="gnd")
 ... # Set the ground potential to 0V
-... pref_lv = PotentialRef(id="pref_lv", element=ground)
+... pref_lv = rlf.PotentialRef(id="pref_lv", element=ground)
 ... # Connect the ground to the neutral of the LV bus
 ... ground.connect(bus0_lv)
 
 >>> # Add a MV/LV transformer
-... tp = TransformerParameters.from_open_and_short_circuit_tests(
+... tp = rlf.TransformerParameters.from_open_and_short_circuit_tests(
 ...     "160_kVA",
 ...     "Dyn11",
 ...     sn=160.0 * 1e3,
@@ -57,7 +57,7 @@ a Delta-Wye transformer and a small LV network.
 ...     psc=2350.0,
 ...     vsc=4.0 / 100,
 ... )
-... transformer = Transformer(
+... transformer = rlf.Transformer(
 ...     id="transfo",
 ...     bus1=bus0_mv,
 ...     bus2=bus0_lv,
@@ -68,22 +68,22 @@ a Delta-Wye transformer and a small LV network.
 ... )
 
 >>> # Add the LV network elements
-... lp = LineParameters.from_geometry(
+... lp = rlf.LineParameters.from_geometry(
 ...     "U_AL_150",
-...     line_type=LineType.UNDERGROUND,
-...     conductor_type=ConductorType.AL,
-...     insulator_type=InsulatorType.PVC,
+...     line_type=rlf.LineType.UNDERGROUND,
+...     conductor_type=rlf.ConductorType.AL,
+...     insulator_type=rlf.InsulatorType.PVC,
 ...     section=150,
 ...     section_neutral=150,
-...     height=Q_(-1.5, "m"),
-...     external_diameter=Q_(40, "mm"),
+...     height=rlf.Q_(-1.5, "m"),
+...     external_diameter=rlf.Q_(40, "mm"),
 ... )
-... bus1 = Bus(id="bus1", phases="abcn")
-... bus2 = Bus(id="bus2", phases="abcn")
-... load_bus1 = Bus(id="load_bus1", phases="abcn")
-... load_bus2 = Bus(id="load_bus2", phases="abcn")
-... load_bus3 = Bus(id="load_bus3", phases="abcn")
-... line1 = Line(
+... bus1 = rlf.Bus(id="bus1", phases="abcn")
+... bus2 = rlf.Bus(id="bus2", phases="abcn")
+... load_bus1 = rlf.Bus(id="load_bus1", phases="abcn")
+... load_bus2 = rlf.Bus(id="load_bus2", phases="abcn")
+... load_bus3 = rlf.Bus(id="load_bus3", phases="abcn")
+... line1 = rlf.Line(
 ...     id="line1",
 ...     bus1=bus0_lv,
 ...     bus2=bus1,
@@ -92,7 +92,7 @@ a Delta-Wye transformer and a small LV network.
 ...     parameters=lp,
 ...     length=0.5,
 ... )  # km
-... line2 = Line(
+... line2 = rlf.Line(
 ...     id="line2",
 ...     bus1=bus1,
 ...     bus2=bus2,
@@ -101,7 +101,7 @@ a Delta-Wye transformer and a small LV network.
 ...     parameters=lp,
 ...     length=0.4,
 ... )
-... line3 = Line(
+... line3 = rlf.Line(
 ...     id="line3",
 ...     bus1=bus1,
 ...     bus2=load_bus1,
@@ -110,7 +110,7 @@ a Delta-Wye transformer and a small LV network.
 ...     parameters=lp,
 ...     length=0.3,
 ... )
-... line4 = Line(
+... line4 = rlf.Line(
 ...     id="line4",
 ...     bus1=bus2,
 ...     bus2=load_bus2,
@@ -119,7 +119,7 @@ a Delta-Wye transformer and a small LV network.
 ...     parameters=lp,
 ...     length=0.3,
 ... )
-... line5 = Line(
+... line5 = rlf.Line(
 ...     id="line5",
 ...     bus1=load_bus2,
 ...     bus2=load_bus3,
@@ -129,12 +129,12 @@ a Delta-Wye transformer and a small LV network.
 ...     length=0.4,
 ... )
 ... si = -3e3  # VA, negative as it is production
-... load1 = PowerLoad(id="load1", bus=load_bus1, phases="abcn", powers=[si, si, si])
-... load2 = PowerLoad(id="load2", bus=load_bus2, phases="abcn", powers=[si, si, si])
-... load3 = PowerLoad(id="load3", bus=load_bus3, phases="abcn", powers=[si, 0, 0])
+... load1 = rlf.PowerLoad(id="load1", bus=load_bus1, phases="abcn", powers=[si, si, si])
+... load2 = rlf.PowerLoad(id="load2", bus=load_bus2, phases="abcn", powers=[si, si, si])
+... load3 = rlf.PowerLoad(id="load3", bus=load_bus3, phases="abcn", powers=[si, 0, 0])
 
 >>> # Create the network
-... en = ElectricalNetwork.from_element(bus0_mv)
+... en = rlf.ElectricalNetwork.from_element(bus0_mv)
 ```
 
 Then, the load flow can be solved and the results can be retrieved.
@@ -173,13 +173,13 @@ As a consequence, the provided apparent power for phase `'a'` is the maximum tha
 ```pycon
 >>> # Let's make the load 3 flexible with a p(u) control to reduce the voltages constraints
 ... en.loads["load3"].disconnect()
-... fp = FlexibleParameter.p_max_u_production(u_up=240, u_max=250, s_max=4000)  # V and VA
-... flexible_load = PowerLoad(
+... fp = rlf.FlexibleParameter.p_max_u_production(u_up=240, u_max=250, s_max=4000)  # V and VA
+... flexible_load = rlf.PowerLoad(
 ...     id="load3",
 ...     bus=load_bus3,
 ...     phases="abcn",
 ...     powers=[si, 0, 0],  # W
-...     flexible_params=[fp, FlexibleParameter.constant(), FlexibleParameter.constant()],
+...     flexible_params=[fp, rlf.FlexibleParameter.constant(), rlf.FlexibleParameter.constant()],
 ... )
 ```
 
@@ -238,15 +238,15 @@ production is totally shut down.
 ```pycon
 >>> # Let's try with PQ(u) control, by injecting reactive power before reducing active power
 ... en.loads["load3"].disconnect()
-... fp = FlexibleParameter.pq_u_production(
+... fp = rlf.FlexibleParameter.pq_u_production(
 ...     up_up=240, up_max=250, uq_min=200, uq_down=210, uq_up=235, uq_max=240, s_max=4000  # V and VA
 ... )
-... flexible_load = PowerLoad(
+... flexible_load = rlf.PowerLoad(
 ...     id="load3",
 ...     bus=load_bus3,
 ...     phases="abcn",
 ...     powers=[si, 0, 0],
-...     flexible_params=[fp, FlexibleParameter.constant(), FlexibleParameter.constant()],
+...     flexible_params=[fp, rlf.FlexibleParameter.constant(), rlf.FlexibleParameter.constant()],
 ... )
 ```
 

--- a/doc/usage/Getting_Started.md
+++ b/doc/usage/Getting_Started.md
@@ -42,7 +42,7 @@ The following is a summary of the available elements:
 
 - Branches:
 
-  - `Line`: A line connects two buses. The physical parameters of the line like its impedance are
+  - `Line`: A line connects two buses. The physical parameters of the line, like its impedance, are
     defined by a `LineParameters` object.
   - `Switch`: A basic switch element.
   - `Transformer`: A generic transformer. The physical parameters of the transformer like its
@@ -78,61 +78,59 @@ line and a constant power load. This network is a low voltage network (three-pha
 
 ![Network](../_static/Getting_Started_Tutorial.svg)
 
-It leads to the following code
-
 ```pycon
 >>> import numpy as np
-... from roseau.load_flow import *
+... import roseau.load_flow as rlf
 
->>> # Nominal phase-to-neutral voltage
+>>> # Nominal phase-to-neutral voltage (typical european voltage)
 ... un = 400 / np.sqrt(3)  # In Volts
 
->>> # Optional network limits (for results analysis only)
+>>> # Optional network limits (for analyzing network violations)
 ... u_min = 0.9 * un  # V
 ... u_max = 1.1 * un  # V
 ... i_max = 500.0  # A
 
->>> # Create two buses (notice the phases of LV buses contain the neutral)
-... source_bus = Bus(id="sb", phases="abcn", min_voltage=u_min, max_voltage=u_max)
-... load_bus = Bus(id="lb", phases="abcn", min_voltage=u_min, max_voltage=u_max)
+>>> # Create two buses (notice the phases of LV buses include the neutral, as in typical LV networks)
+... source_bus = rlf.Bus(id="sb", phases="abcn", min_voltage=u_min, max_voltage=u_max)
+... load_bus = rlf.Bus(id="lb", phases="abcn", min_voltage=u_min, max_voltage=u_max)
 
->>> # Define the reference of potentials to be the neutral of the source bus
-... ground = Ground(id="gnd")
-... # Fix the potential of the ground at 0 V
-... pref = PotentialRef(id="pref", element=ground)
+>>> # Define the reference of potentials to be the earth's potential
+... # First define the "Ground" object representing the earth
+... ground = rlf.Ground(id="gnd")
+... # second, fix the potential of the ground at 0 V
+... pref = rlf.PotentialRef(id="pref", element=ground)
+... # third, ground the neutral wire of the source bus by connecting it to the Ground element
 ... ground.connect(source_bus, phase="n")
 
->>> # Create a LV source at the first bus
-... # (phase-to-neutral voltage because the source is connected to the neutral)
+>>> # Create a three-phase voltage source at the first bus
+... # (voltages are phase-to-neutral because the source's phases include a neutral)
 ... source_voltages = un * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-... vs = VoltageSource(id="vs", bus=source_bus, voltages=source_voltages)
+... vs = rlf.VoltageSource(id="vs", bus=source_bus, voltages=source_voltages)
 
->>> # Add a load at the second bus
-... load = PowerLoad(id="load", bus=load_bus, powers=[10e3 + 0j, 10e3, 10e3])  # VA
+>>> # Add a 30kW load at the second bus (balanced load, 10 kW per phase)
+... load = rlf.PowerLoad(id="load", bus=load_bus, powers=[10e3 + 0j, 10e3, 10e3])  # In VA
 
->>> # Add a LV line between the source bus and the load bus
-... # R = 0.1 Ohm/km, X = 0
-... lp = LineParameters(
-...     "lp", z_line=(0.1 + 0.0j) * np.eye(4, dtype=complex), max_current=i_max
-... )
-... line = Line(id="line", bus1=source_bus, bus2=load_bus, parameters=lp, length=2.0)
+>>> # Add a 2 km line between the source bus and the load bus with R = 0.1 Ohm/km and X = 0
+... lp = rlf.LineParameters("lp", z_line=(0.1 + 0.0j) * np.eye(4), max_current=i_max)
+... line = rlf.Line(id="line", bus1=source_bus, bus2=load_bus, parameters=lp, length=2.0)
 ```
 
 Notice how the phases of the load, line and source are not explicitly given. They are inferred to be
 `"abcn"` from the buses they are connected to. You can also explicitly declare the phases of these
-elements. For example, to create a delta-connected source instead, you can use the following code:
+elements. For example, to create a delta-connected source instead, you can explicitly set its phases
+to `"abc"`:
 
 ```pycon
 >>> source_voltages = un * np.sqrt(3) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
-... vs = VoltageSource(
-...     id="vs", bus=source_bus, voltages=source_voltages, phases="abc"
+... vs = rlf.VoltageSource(
+...     id="vs", bus=source_bus, voltages=source_voltages, phases="abc"  # <- delta source
 ... )
 ```
 
-Note the use of `un * np.sqrt(3)` in the source voltage as it now represents the phase-to-phase
-voltage. This is because everywhere in `roseau-load-flow`, the `voltages` of an element depend on
+Note the use of `un * np.sqrt(3)` in the source voltages as they now represent the phase-to-phase
+voltages. This is because everywhere in `roseau-load-flow`, the `voltages` of an element depend on
 the element's `phases`. Voltages of elements connected in a _Star (wye)_ configuration (elements
-that have a neutral connection indicated by the presence of the `'n'` char in their `phases`
+that have a neutral connection indicated by the presence of the `'n'` character in their `phases`
 attribute) are the **phase-to-neutral** voltages. Voltages of elements connected in a _Delta_
 configuration (elements that do not have a neutral connection indicated by the absence of the
 `'n'` char from their `phases` attribute) are the **phase-to-phase** voltages.
@@ -141,43 +139,39 @@ At this point, all the basic elements of the network have been defined and conne
 everything can be encapsulated in an `ElectricalNetwork` object, but first, some important
 notes on the `Ground` and `PotentialRef` elements:
 
-````{important}
+```{important}
 The `Ground` element does not have a fixed potential as one would expect from a real ground
-connection. The potential reference (0 Volts) is defined by the `PotentialRef` element that
-itself can be connected to any bus or ground in the network. This is to give more flexibility
-for the user to define the potential reference of their network.
+connection. The ground element here merely represents a "perfect conductor", equivalent to a
+single-conductor line with zero impedance. The potential reference, 0 Volts, is defined by the
+`PotentialRef` element that itself can be connected to any bus or ground in the network. This
+gives more flexibility for the user to define the potential reference of their network.
 
 A `PotentialRef` defines the potential reference for the network. It is a mandatory reference
 for the load flow resolution to be well-defined. A network MUST have one and only one potential
 reference per a galvanically isolated section.
 
-```{note}
-The `Ground` element is not required in this simple network as it is connected to a single
-element. No current will flow through the ground and no two points in the network will be forced
-to have the same potential. In this scenario you are allowed to define the potential reference
-directly on the bus element: `pref = PotentialRef(id="pref", element=source_bus, phase="n")` and
-not bother with creating the ground element at all.
+When in doubt, define the ground and potential reference similar to the example above.
 ```
-````
 
 An `ElectricalNetwork` object can now be created using the `from_element` constructor. The source
 bus `source_bus` is given to this constructor. All the elements connected to this bus are
 automatically included into the network.
 
 ```pycon
->>> en = ElectricalNetwork.from_element(source_bus)
+>>> en = rlf.ElectricalNetwork.from_element(source_bus)
 ```
 
 (gs-solving-load-flow)=
 
 ## Solving a load flow
 
-A [license](license-page) is required. You can use the [free, limited licence key](license-types) or get a private and unlimited one
-by contacting us at [contact@roseautechnologies.com](mailto:contact@roseautechnologies.com).
-Once you have a license key, you can activate it by following the instructions in the
+A [license](license-page) is required. You can use the [free but limited licence key](license-types)
+or get a personal and unlimited key by contacting us at
+[contact@roseautechnologies.com](mailto:contact@roseautechnologies.com).
+Once you have your license key, you can activate it by following the instructions in the
 [License activation page](license-activation).
 
-Then, the load flow can be solved by calling the `solve_load_flow` method of the `ElectricalNetwork`
+Afterwards, the load flow can be solved by calling the `solve_load_flow` method of the `ElectricalNetwork`
 
 ```pycon
 >>> en.solve_load_flow()
@@ -192,27 +186,24 @@ $1.86 \times 10^{-7}$.
 
 ## Getting the results
 
-The results are now available for every element of the network. Results can be accessed through
-special properties prefixed with `res_` on each element object. For instance, the potentials
+The results are now available for all elements of the network. Results can be accessed through
+special properties prefixed with `res_` on each element. For instance, the potentials
 of the `load_bus` can be accessed using the property `load_bus.res_potentials`. It contains 4
-values which are the potentials of its phases `a`, `b`, `c` and `n` (neutral). The potentials
-are returned as complex numbers. Calling `abs(load_bus.res_potentials)` gives you the magnitude
-of the load's potentials (in Volts) and `np.angle(load_bus.res_potentials)` gives their angle
-(phase shift) in radians.
+values representing the potentials of its phases `a`, `b`, `c` and `n` (neutral). The potentials
+are returned as complex numbers. Calling `abs(load_bus.res_potentials)` returns their magnitude
+(in Volts) and `np.angle(load_bus.res_potentials)` returns their angle (phase shift) in radians.
 
-Roseau Load Flow uses [Pint](https://pint.readthedocs.io/en/stable/) `Quantity` objects to
-present the data in unit-agnostic way for the user. Most input data (load powers, source voltages,
-etc.) are expected to be either given in SI units or using the pint Quantity interface for non-SI
-units (example below). Exceptions to this rule include the `length` parameter of the `Line` class
-with the default unit being Kilometers (km) and the `section` parameter of the `LineParameters`
-class with the default unit being Square Millimeters (mm²).
+Roseau Load Flow uses [Pint](https://pint.readthedocs.io/en/stable/) `Quantity` objects to present
+unit-aware data to the user. _Most_ input data (load powers, source voltages, etc.) are expected
+to be either given in SI units or using the pint Quantity interface for non-SI units (example below).
+Look at the documentation of a method to see its default units.
 
 In the following example, we create a load with powers expressed in kVA:
 
 ```python
-from roseau.load_flow import Q_
-
-load = PowerLoad(id="load", bus=load_bus, phases="abcn", powers=Q_([10, 10, 10], "kVA"))
+load = rlf.PowerLoad(
+    id="load", bus=load_bus, phases="abcn", powers=rlf.Q_([10, 10, 10], "kVA")
+)
 ```
 
 The results returned by the `res_` properties are also `Quantity` objects.
@@ -228,13 +219,13 @@ results for each element type:
 | `Line`                                      | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_series_power_losses`, `res_shunt_power_losses`, `res_power_losses`, `res_violated` |
 | `Transformer`                               | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_power_losses`, `res_violated`                                                      |
 | `Switch`                                    | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`                                                                                          |
-| `ImpedanceLoad`, `CurrentLoad`, `PowerLoad` | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_flexible_powers`&#8270;                                                            |
+| `ImpedanceLoad`, `CurrentLoad`, `PowerLoad` | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`, `res_flexible_powers`¹                                                                  |
 | `VoltageSource`                             | `res_currents`, `res_powers`, `res_potentials`, `res_voltages`                                                                                          |
 | `Ground`                                    | `res_potential`                                                                                                                                         |
 | `PotentialRef`                              | `res_current` _(Always zero for a successful load flow)_                                                                                                |
 
-&#8270;: `res_flexible_powers` is only available for flexible loads (`PowerLoad`s with `flexible_params`). You'll see
-an example on the usage of flexible loads in the _Flexible Loads_ page.
+¹ _`res_flexible_powers` is only available for flexible loads (`PowerLoad`s with `flexible_params`). You'll see
+an example on the usage of flexible loads in the "Flexible Loads" page._
 
 ### Getting results per object
 
@@ -285,7 +276,7 @@ The results can also be retrieved for the entire network using `res_` properties
 Available results for the network are:
 
 - `res_buses`: Buses potentials indexed by _(bus id, phase)_
-- `res_buses_voltages`: Buses voltages and voltage limits indexed by _(bus id, voltage phase)_
+- `res_buses_voltages`: Buses voltages and voltage limits indexed by _(bus id, voltage phase²)_
 - `res_branches`: Branches currents, powers, and potentials indexed by _(branch id, phase)_
 - `res_transformers`: Transformers currents, powers, potentials, and power limits indexed by
   _(transformer id, phase)_
@@ -295,21 +286,19 @@ Available results for the network are:
 - `res_loads`: Loads currents, powers, and potentials indexed by _(load id, phase)_
 - `res_loads_voltages`: Loads voltages indexed by _(load id, voltage phase)_
 - `res_loads_flexible_powers`: Loads flexible powers (only for flexible loads) indexed by
-  _(load id, phase)_
+  _(load id, voltage phase)_
 - `res_sources`: Sources currents, powers, and potentials indexed by _(source id, phase)_
 - `res_grounds`: Grounds potentials indexed by _ground id_
 - `res_potential_refs`: Potential references currents indexed by _potential ref id_ (always zero
   for a successful load flow)
 
+² _a "voltage phase" is a composite phase like `an` or `ab`_
+
 All the results are complex numbers. You can always access the magnitude of the results using
 the `abs` function and the angle in radians using the `np.angle` function. For instance,
 `abs(network.res_loads)` gives you the magnitude of the loads' results in SI units.
 
-Below are the results of the load flow for `en`:
-
-```{note}
-All the following tables are rounded to 2 decimals to be properly displayed.
-```
+Below are the results of the load flow for `en`, rounded to 2 decimal places:
 
 ```pycon
 >>> en.res_buses
@@ -362,14 +351,14 @@ All the following tables are rounded to 2 decimals to be properly displayed.
 | line    | n     |         -0-0j |           0j |       -0+0j |       -0j |           0j |             0j |           -0j |          -0-0j |         500 | False    |
 
 ```pycon
->>> en.res_transformers
+>>> en.res_transformers  # empty as the network does not contain transformers
 ```
 
 | transformer_id | phase | current1 | current2 | power1 | power2 | potential1 | potential2 | max_power | violated |
 | -------------- | ----- | -------- | -------- | ------ | ------ | ---------- | ---------- | --------- | -------- |
 
 ```pycon
->>> en.res_switches
+>>> en.res_switches  # empty as the network does not contain switches
 ```
 
 | switch_id | phase | current1 | current2 | power1 | power2 | potential1 | potential2 |
@@ -424,7 +413,7 @@ All the following tables are rounded to 2 decimals to be properly displayed.
 | pref             |      0j |
 
 Using the `transform` method of data frames, the results can easily be converted from complex values
-to magnitude and angle values.
+to magnitude and angle values (radians).
 
 ```pycon
 >>> en.res_buses_voltages["voltage"].transform([np.abs, np.angle])
@@ -500,15 +489,14 @@ Network elements can be updated. Here, the load's power values are changed to cr
 unbalanced situation.
 
 ```pycon
->>> load.powers = Q_([15, 0, 0], "kVA")
+>>> load.powers = rlf.Q_([15, 0, 0], "kVA")  # <- 15 kW on phase "a", 0 W on phases "b" and "c"
 >>> en.solve_load_flow()
 (3, 1.686343545e-07)
 >>> load_bus.res_potentials
 array([ 216.02252269  +0.j, -115.47005384-200.j, -115.47005384+200.j, 14.91758499  +0.j]) <Unit('volt')>
 ```
 
-Notice how the change was taken into account where the introduced unbalance manifested in the neutral's
-potential of the bus no longer being close to 0 V.
+Notice how the unbalance manifested in the neutral's potential of the bus no longer being close to 0 V.
 
 More information on modifying the network elements can be found in the [Modifying a network](usage-modifying-network) page.
 
@@ -530,21 +518,21 @@ The `to_json` method will overwrite the file if it already exists.
 To load the network from a JSON file, use the {meth}`~roseau.load_flow.ElectricalNetwork.from_json` method.
 
 ```pycon
->>> en = ElectricalNetwork.from_json("my_network.json")
+>>> en = rlf.ElectricalNetwork.from_json("my_network.json")
 ```
 
 By default, the `to_json` and `from_json` methods will include the load flow results if they are
-available and are valid. If you want to save/load the network without the results, you can pass
+available and valid. If you want to save/load the network without the results, you can pass
 `include_results=False` to these methods.
 
 Note that calling the `to_json()` method on a network with invalid results (say after an element
 has been modified) will raise an exception. In this case, you can use the `include_results=False`
-option to save the network without the results, or you can call the `solve_load_flow()` method to
+option to ignore the results, or you can call the `solve_load_flow()` method to
 update the results before saving the network.
 
 ```{important}
 We do not recommend modifying the JSON file manually. The content of the JSON file is not
 guaranteed to be stable across different versions of the library and should be considered an
-internal representation of the network. Any changes to the JSON file should be done through the
+implementation detail. Any changes to the JSON file should be done through the
 `ElectricalNetwork` object otherwise it may lead to unexpected behavior.
 ```

--- a/doc/usage/Plotting.md
+++ b/doc/usage/Plotting.md
@@ -19,8 +19,8 @@ On this page, the [folium](https://python-visualization.github.io/folium/index.h
 Let's take a MV network from the catalogue:
 
 ```pycon
->>> from roseau.load_flow import ElectricalNetwork
->>> en = ElectricalNetwork.from_catalogue(name="MVFeeder210", load_point_name="Winter")
+>>> import roseau.load_flow as rlf
+>>> en = rlf.ElectricalNetwork.from_catalogue(name="MVFeeder210", load_point_name="Winter")
 ```
 
 The plot will be done from the {doc}`GeoDataFrame <geopandas:docs/reference/geodataframe>` of buses and lines (we

--- a/doc/usage/Short_Circuit.md
+++ b/doc/usage/Short_Circuit.md
@@ -27,50 +27,52 @@ is impossible.
 
 ```pycon
 >>> import numpy as np
-... from roseau.load_flow import *
+... import roseau.load_flow as rlf
 
 >>> def create_network():
 ...     # Create three buses
-...     source_bus = Bus(id="sb", phases="abcn")
-...     bus1 = Bus(id="b1", phases="abcn")
-...     bus2 = Bus(id="b2", phases="abcn")
+...     source_bus = rlf.Bus(id="sb", phases="abcn")
+...     bus1 = rlf.Bus(id="b1", phases="abcn")
+...     bus2 = rlf.Bus(id="b2", phases="abcn")
 ...     # Define the reference of potentials
-...     ground = Ground(id="gnd")
-...     pref = PotentialRef(id="pref", element=ground)
+...     ground = rlf.Ground(id="gnd")
+...     pref = rlf.PotentialRef(id="pref", element=ground)
 ...     ground.connect(bus=source_bus)
 ...     # Create a LV source at the first bus
 ...     un = 400 / np.sqrt(3)
 ...     source_voltages = [un, un * np.exp(-2j * np.pi / 3), un * np.exp(2j * np.pi / 3)]
-...     vs = VoltageSource(id="vs", bus=source_bus, phases="abcn", voltages=source_voltages)
+...     vs = rlf.VoltageSource(
+...         id="vs", bus=source_bus, phases="abcn", voltages=source_voltages
+...     )
 ...     # Add LV lines
-...     lp1 = LineParameters.from_geometry(
+...     lp1 = rlf.LineParameters.from_geometry(
 ...         "U_AL_240",
-...         line_type=LineType.UNDERGROUND,
-...         conductor_type=ConductorType.AL,
-...         insulator_type=InsulatorType.PVC,
+...         line_type=rlf.LineType.UNDERGROUND,
+...         conductor_type=rlf.ConductorType.AL,
+...         insulator_type=rlf.InsulatorType.PVC,
 ...         section=240,
 ...         section_neutral=120,
-...         height=Q_(-1.5, "m"),
-...         external_diameter=Q_(50, "mm"),
+...         height=rlf.Q_(-1.5, "m"),
+...         external_diameter=rlf.Q_(50, "mm"),
 ...     )
-...     line1 = Line(
+...     line1 = rlf.Line(
 ...         id="line1", bus1=source_bus, bus2=bus1, parameters=lp1, length=1.0, ground=ground
 ...     )
-...     lp2 = LineParameters.from_geometry(
+...     lp2 = rlf.LineParameters.from_geometry(
 ...         "U_AL_150",
-...         line_type=LineType.UNDERGROUND,
-...         conductor_type=ConductorType.AL,
-...         insulator_type=InsulatorType.PVC,
+...         line_type=rlf.LineType.UNDERGROUND,
+...         conductor_type=rlf.ConductorType.AL,
+...         insulator_type=rlf.InsulatorType.PVC,
 ...         section=150,
 ...         section_neutral=150,
-...         height=Q_(-1.5, "m"),
-...         external_diameter=Q_(40, "mm"),
+...         height=rlf.Q_(-1.5, "m"),
+...         external_diameter=rlf.Q_(40, "mm"),
 ...     )
-...     line2 = Line(
+...     line2 = rlf.Line(
 ...         id="line2", bus1=bus1, bus2=bus2, parameters=lp2, length=2.0, ground=ground
 ...     )
 ...     # Create network
-...     en = ElectricalNetwork.from_element(source_bus)
+...     en = rlf.ElectricalNetwork.from_element(source_bus)
 ...     return en
 ...
 
@@ -194,7 +196,7 @@ short-circuit, or when forgetting parameters.
 
 ```pycon
 >>> try:
-...     load = PowerLoad("load", bus=en.buses["b2"], powers=[10, 10, 10])
+...     load = rlf.PowerLoad("load", bus=en.buses["b2"], powers=[10, 10, 10])
 ... except RoseauLoadFlowException as e:
 ...     print(e)
 The power load 'load' is connected on bus 'b2' that already has a short-circuit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,12 +92,17 @@ target-version = "py310"
 show-fixes = true
 extend-include = ["*.ipynb"]
 namespace-packages = ["roseau"]
-lint.select = ["E", "F", "C90", "W", "B", "UP", "I", "RUF100", "TID", "SIM", "PT", "PIE", "N", "C4", "NPY", "T10"]
-lint.unfixable = ["B"]
-lint.ignore = ["E501", "B024", "N818", "UP038"]
-lint.flake8-tidy-imports.ban-relative-imports = "all"
-lint.flake8-pytest-style.parametrize-values-type = "tuple"
-lint.mccabe.max-complexity = 15
+
+[tool.ruff.lint]
+select = ["E", "F", "C90", "W", "B", "UP", "I", "RUF100", "TID", "SIM", "PT", "PIE", "N", "C4", "NPY", "T10"]
+unfixable = ["B"]
+ignore = ["E501", "B024", "N818", "UP038"]
+flake8-tidy-imports.ban-relative-imports = "all"
+flake8-pytest-style.parametrize-values-type = "tuple"
+mccabe.max-complexity = 15
+
+[tool.ruff.format]
+docstring-code-format = true
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402", "F403", "F405"]

--- a/roseau/load_flow/converters.py
+++ b/roseau/load_flow/converters.py
@@ -125,10 +125,10 @@ def calculate_voltages(potentials: ComplexArray, phases: str) -> ComplexArray:
         Otherwise, the voltages are Phase-Phase.
 
     Example:
-        >>> potentials = 230 * np.array([1, np.exp(-2j*np.pi/3), np.exp(2j*np.pi/3), 0], dtype=np.complex128)
+        >>> potentials = 230 * np.array([1, np.exp(-2j * np.pi / 3), np.exp(2j * np.pi / 3), 0], dtype=np.complex128)
         >>> calculate_voltages(potentials, "abcn")
         array([ 230.  +0.j        , -115.-199.18584287j, -115.+199.18584287j])
-        >>> potentials = np.array([230, 230 * np.exp(-2j*np.pi/3)], dtype=np.complex128)
+        >>> potentials = np.array([230, 230 * np.exp(-2j * np.pi / 3)], dtype=np.complex128)
         >>> calculate_voltages(potentials, "ab")
         array([345.+199.18584287j])
         >>> calculate_voltages(np.array([230, 0], dtype=np.complex128), "an")

--- a/roseau/load_flow/models/core.py
+++ b/roseau/load_flow/models/core.py
@@ -165,11 +165,17 @@ class Element(ABC, Identifiable, JsonMixin):
         if warning and self.network is not None and not self.network._results_valid:
             warnings.warn(
                 message=(
-                    "The results of this element may be outdated. Please re-run a load flow to "
+                    f"The results of {type(self).__name__} {self.id!r} may be outdated. Please re-run a load flow to "
                     "ensure the validity of results."
                 ),
                 category=UserWarning,
-                stacklevel=2,
+                # Ignore all private RLF stacks:
+                # - this method
+                # - _res_..._getter caller function
+                # - res_... property
+                # - ureg wrappers
+                # TODO: dynamic stacklevel computation similar to pandas and matplotlib
+                stacklevel=6,
             )
         self._fetch_results = False
         return value

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -54,11 +54,11 @@ def single_phase_network(test_networks_path) -> ElectricalNetwork:
 
 
 @contextmanager
-def check_result_warning(expected_message: str):
+def check_result_warning(expected_message: str | re.Pattern[str]):
     with warnings.catch_warnings(record=True) as records:
         yield
     assert len(records) == 1
-    assert records[0].message.args[0] == expected_message
+    assert re.match(expected_message, records[0].message.args[0])
     assert records[0].category == UserWarning
 
 
@@ -1018,7 +1018,7 @@ def test_network_results_warning(small_network, small_network_with_results, recw
 
     # Ensure that a warning is raised no matter which result is requested
     expected_message = (
-        "The results of this element may be outdated. Please re-run a load flow to ensure the validity of results."
+        r"The results of \w+ '\w+' may be outdated. Please re-run a load flow to ensure the validity of results."
     )
     for bus in en.buses.values():
         with check_result_warning(expected_message=expected_message):

--- a/roseau/load_flow/utils/_versions.py
+++ b/roseau/load_flow/utils/_versions.py
@@ -29,6 +29,7 @@ def _get_dependency_info() -> JsonDict:
             "pint",
             "platformdirs",
             "certifi",
+            "roseau-load-flow",
             "roseau-load-flow-engine",
         )
     }
@@ -43,10 +44,10 @@ def show_versions() -> None:
     print("System Information")
     print("------------------")
     for k, v in sys_info.items():
-        print(f"{k:<20} {v}")
+        print(f"{k:<25} {v}")
 
     print()
     print("Installed Dependencies")
     print("----------------------")
     for k, v in deps.items():
-        print(f"{k:<20} {v}")
+        print(f"{k:<25} {v}")


### PR DESCRIPTION
- Update the docs to use the convention `import roseau.load_flow as rlf`
- Modify the `show_versions` function to show the version of `roseau-load-flow`
- Minor tweaks to the Getting Started page 
- Run ruff formatter on code blocks inside docstrings
- Change the warning on outdated results *of an element* to include the element type and ID instead of the generic "The results of this element may be outdated"