### PR TITLE
Make calculate_voltages unit aware

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,7 +19,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- MacOS wheels roseau-load-flow-engine are now published on PyPI. This means that `pip install roseau-load-flow`
+- {gh-pr}`224` The `calculate_voltages` function now accepts and return pint quantities.
+- MacOS wheels for roseau-load-flow-engine are now published on PyPI. This means that `pip install roseau-load-flow`
   should now work on MacOS.
 - Added support for running in Google Colab documents.
 - Fixed a bug in license checks caching on Windows.

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,7 +19,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- {gh-pr}`224` The `calculate_voltages` function now accepts and return pint quantities.
+- {gh-pr}`225` The `calculate_voltages` function now accepts and return pint quantities.
 - MacOS wheels for roseau-load-flow-engine are now published on PyPI. This means that `pip install roseau-load-flow`
   should now work on MacOS.
 - Added support for running in Google Colab documents.

--- a/doc/usage/Extras.md
+++ b/doc/usage/Extras.md
@@ -103,7 +103,7 @@ vector of voltages. Example:
 >>> potentials = 230 * np.array([1, np.exp(-2j * np.pi / 3), np.exp(2j * np.pi / 3), 0])
 >>> potentials
 array([ 230.  +0.j        , -115.-199.18584287j, -115.+199.18584287j,
-          0.  +0.j        ]) <Unit('volt')>
+          0.  +0.j        ])
 >>> phases = "abcn"
 >>> calculate_voltages(potentials, phases)
 array([ 230.  +0.j        , -115.-199.18584287j, -115.+199.18584287j]) <Unit('volt')>
@@ -127,8 +127,8 @@ To get the phases of the voltage, you can use `calculate_voltage_phases`:
 Of course these functions work with arbitrary phases:
 
 ```pycon
->>> calculate_voltages(potentials[:2], phases[:2]) <Unit('volt')>
-array([345.+199.18584287j])
+>>> calculate_voltages(potentials[:2], phases[:2])
+array([345.+199.18584287j]) <Unit('volt')>
 >>> calculate_voltage_phases(phases[:2])
 ['ab']
 >>> calculate_voltage_phases("abc")

--- a/doc/usage/Extras.md
+++ b/doc/usage/Extras.md
@@ -103,10 +103,10 @@ vector of voltages. Example:
 >>> potentials = 230 * np.array([1, np.exp(-2j * np.pi / 3), np.exp(2j * np.pi / 3), 0])
 >>> potentials
 array([ 230.  +0.j        , -115.-199.18584287j, -115.+199.18584287j,
-          0.  +0.j        ])
+          0.  +0.j        ]) <Unit('volt')>
 >>> phases = "abcn"
 >>> calculate_voltages(potentials, phases)
-array([ 230.  +0.j        , -115.-199.18584287j, -115.+199.18584287j])
+array([ 230.  +0.j        , -115.-199.18584287j, -115.+199.18584287j]) <Unit('volt')>
 ```
 
 Because the phases include the neutral, the voltages calculated are phase-to-neutral voltages.
@@ -114,7 +114,7 @@ You can also calculate phase-to-phase voltages by omitting the neutral:
 
 ```pycon
 >>> calculate_voltages(potentials[:-1], phases[:-1])
-array([ 345.+199.18584287j,    0.-398.37168574j, -345.+199.18584287j])
+array([ 345.+199.18584287j,    0.-398.37168574j, -345.+199.18584287j]) <Unit('volt')>
 ```
 
 To get the phases of the voltage, you can use `calculate_voltage_phases`:
@@ -127,7 +127,7 @@ To get the phases of the voltage, you can use `calculate_voltage_phases`:
 Of course these functions work with arbitrary phases:
 
 ```pycon
->>> calculate_voltages(potentials[:2], phases[:2])
+>>> calculate_voltages(potentials[:2], phases[:2]) <Unit('volt')>
 array([345.+199.18584287j])
 >>> calculate_voltage_phases(phases[:2])
 ['ab']

--- a/roseau/load_flow/__init__.py
+++ b/roseau/load_flow/__init__.py
@@ -8,6 +8,7 @@ See Package Contents below for a list of available classes and functions.
 
 import importlib.metadata
 
+from roseau.load_flow import converters
 from roseau.load_flow.__about__ import (
     __authors__,
     __copyright__,
@@ -58,6 +59,7 @@ __all__ = [
     "__url__",
     "__version__",
     "show_versions",
+    "converters",
     # Electrical Network
     "ElectricalNetwork",
     # Buses

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Literal
 from shapely.geometry.base import BaseGeometry
 from typing_extensions import Self
 
-from roseau.load_flow.converters import calculate_voltages
+from roseau.load_flow.converters import _calculate_voltages
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import ComplexArray, Id, JsonDict
@@ -134,7 +134,7 @@ class AbstractBranch(Element):
 
     def _res_voltages_getter(self, warning: bool) -> tuple[ComplexArray, ComplexArray]:
         pot1, pot2 = self._res_potentials_getter(warning)
-        return calculate_voltages(pot1, self.phases1), calculate_voltages(pot2, self.phases2)
+        return _calculate_voltages(pot1, self.phases1), _calculate_voltages(pot2, self.phases2)
 
     @property
     @ureg_wraps(("V", "V"), (None,))

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -8,7 +8,7 @@ import pandas as pd
 from shapely.geometry.base import BaseGeometry
 from typing_extensions import Self
 
-from roseau.load_flow.converters import calculate_voltage_phases, calculate_voltages, phasor_to_sym
+from roseau.load_flow.converters import _calculate_voltages, calculate_voltage_phases, phasor_to_sym
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import ComplexArray, ComplexArrayLike1D, Id, JsonDict
@@ -137,7 +137,7 @@ class Bus(Element):
 
     def _res_voltages_getter(self, warning: bool) -> ComplexArray:
         potentials = np.array(self._res_potentials_getter(warning=warning))
-        return calculate_voltages(potentials, self.phases)
+        return _calculate_voltages(potentials, self.phases)
 
     @property
     @ureg_wraps("V", (None,))

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Final, Literal
 
 import numpy as np
 
-from roseau.load_flow.converters import calculate_voltage_phases, calculate_voltages
+from roseau.load_flow.converters import _calculate_voltages, calculate_voltage_phases
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
@@ -148,7 +148,7 @@ class AbstractLoad(Element, ABC):
 
     def _res_voltages_getter(self, warning: bool) -> ComplexArray:
         potentials = self._res_potentials_getter(warning)
-        return calculate_voltages(potentials, self.phases)
+        return _calculate_voltages(potentials, self.phases)
 
     @property
     @ureg_wraps("V", (None,))

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -544,7 +544,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         Returns:
             The values ``p0``, the losses (in W), and ``i0``, the current (in %) during open-circuit test.
         """
-        from roseau.load_flow.converters import calculate_voltages
+        from roseau.load_flow.converters import _calculate_voltages
         from roseau.load_flow.models import Bus, PotentialRef, Transformer, VoltageSource
         from roseau.load_flow.network import ElectricalNetwork
 
@@ -566,7 +566,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             if "n" in phases_hv:
                 voltages = self._uhv / np.sqrt(3) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
             else:
-                voltages = calculate_voltages(
+                voltages = _calculate_voltages(
                     potentials=self._uhv / np.sqrt(3) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), phases="abc"
                 )
 
@@ -584,7 +584,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         in_ = self._sn / self._uhv if self.type in ("single", "center") else self._sn / (np.sqrt(3) * self._uhv)
 
         # Additional checks
-        u_secondary = abs(calculate_voltages(potentials=bus_lv.res_potentials.m, phases=phases_lv))
+        u_secondary = abs(_calculate_voltages(potentials=bus_lv.res_potentials.m, phases=phases_lv))
         if self.type == "single":
             expected_u_secondary = self._ulv
         elif self.type == "center":
@@ -608,7 +608,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             The values ``psc``, the losses (in W), and ``vsc``, the voltages on LV side (in %) during short-circuit
             test.
         """
-        from roseau.load_flow.converters import calculate_voltages
+        from roseau.load_flow.converters import _calculate_voltages
         from roseau.load_flow.models import Bus, PotentialRef, Transformer, VoltageSource
         from roseau.load_flow.network import ElectricalNetwork
 
@@ -636,7 +636,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             if "n" in phases_hv:
                 voltages = vsc * self._uhv / np.sqrt(3) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3])
             else:
-                voltages = calculate_voltages(
+                voltages = _calculate_voltages(
                     potentials=vsc * self._uhv / np.sqrt(3) * np.exp([0, -2j * np.pi / 3, 2j * np.pi / 3]), phases="abc"
                 )
 


### PR DESCRIPTION
- Make `calculate_voltages` accept pint quantities and return a pint uantity
- Expose the converters module at the top level import so that `rlf.converters` work