### PR TITLE
Allow floating neutrals for loads and sources

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`227` Sources and loads are now allowed to have floating neutrals. This means that a load/source
+  with `phases="abcn"` can now be connected to a bus with `phases="abc"`.
 - {gh-pr}`225` The `calculate_voltages` function now accepts and return pint quantities.
 - MacOS wheels for roseau-load-flow-engine are now published on PyPI. This means that `pip install roseau-load-flow`
   should now work on MacOS.

--- a/doc/models/Load/index.md
+++ b/doc/models/Load/index.md
@@ -44,6 +44,12 @@ Here is the diagram of a star-connected three-phase load:
 
 In _Roseau Load Flow_, the `phases` argument of the constructor must contain `"n"` for star loads.
 
+```{note}
+You can create star connected constant-power or constant-impedance loads even on buses that don't
+have a neutral. In this case, the load's neutral will be floating and its potential can be accessed
+similar to normal star loads.
+```
+
 ### Delta connection
 
 Here is the diagram of a delta-connected three-phase load:

--- a/doc/models/VoltageSource.md
+++ b/doc/models/VoltageSource.md
@@ -58,6 +58,11 @@ The equations that model a star voltage source are:
 Where $\underline{U}\in\mathbb{C}^3$ is the voltage vector (user defined parameter) and
 $\underline{V}\in\mathbb{C}^4$ is the node potentials vector (variable).
 
+```{note}
+You can create star connected sources even on buses that don't have a neutral. In this case, the
+source's neutral will be floating and its potential can be accessed similar to normal star sources.
+```
+
 ### Delta connection
 
 The diagram of the delta voltage source is:

--- a/roseau/load_flow/io/tests/test_dgs.py
+++ b/roseau/load_flow/io/tests/test_dgs.py
@@ -1,11 +1,7 @@
-from roseau.load_flow.models import AbstractLoad, VoltageSource
 from roseau.load_flow.network import ElectricalNetwork
 
 
 def test_from_dgs(dgs_network_path, monkeypatch):
-    # Test with floating neutral (monkeypatch the whole test function)
-    monkeypatch.setattr(AbstractLoad, "_floating_neutral_allowed", True)
-    monkeypatch.setattr(VoltageSource, "_floating_neutral_allowed", True)
     # Read DGS
     en = ElectricalNetwork.from_dgs(dgs_network_path)
     # Check the validity of the network

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -6,7 +6,6 @@ from roseau.load_flow import Line
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.io.dict import v0_to_v1_converter
 from roseau.load_flow.models import (
-    AbstractLoad,
     Bus,
     Ground,
     LineParameters,
@@ -145,8 +144,6 @@ def test_to_dict():
 def test_v0_to_v1_converter(monkeypatch):
     # Do not change `dict_v0` or the network manually, add/update the converters until the test passes
 
-    # Test with floating neutral (monkeypatch the whole test function)
-    monkeypatch.setattr(AbstractLoad, "_floating_neutral_allowed", True)
     dict_v0 = {
         "buses": [
             {

--- a/roseau/load_flow/models/tests/test_loads.py
+++ b/roseau/load_flow/models/tests/test_loads.py
@@ -457,6 +457,7 @@ def test_power_load_res_powers(bus_ph, load_ph, s, res_pot, res_cur):
     load = PowerLoad("load", bus, powers=s, phases=load_ph)
     bus._res_potentials = np.array(res_pot, dtype=complex)
     load._res_currents = np.array(res_cur, dtype=complex)
+    load._res_potentials = bus._get_potentials_of(load.phases, warning=False)
     assert np.allclose(sum(load.res_powers), sum(load.powers))
 
 
@@ -526,6 +527,7 @@ def test_current_load_res_powers(bus_ph, load_ph, i, res_pot, res_cur):
     load = CurrentLoad("load", bus, currents=i, phases=load_ph)
     bus._res_potentials = np.array(res_pot, dtype=complex)
     load._res_currents = np.array(res_cur, dtype=complex)
+    load._res_potentials = bus._get_potentials_of(load.phases, warning=False)
     load_powers = load.res_voltages * load.currents.conj()  # S = V * I*
     assert np.allclose(sum(load.res_powers), sum(load_powers))
 
@@ -626,6 +628,7 @@ def test_impedance_load_res_powers(bus_ph, load_ph, z, res_pot, res_cur):
     load = ImpedanceLoad("load", bus, impedances=z, phases=load_ph)
     bus._res_potentials = np.array(res_pot, dtype=complex)
     load._res_currents = np.array(res_cur, dtype=complex)
+    load._res_potentials = bus._get_potentials_of(load.phases, warning=False)
     load_powers = np.abs(load.res_voltages) ** 2 / load.impedances.conj()  # S = |V|² / Z*
     assert np.allclose(sum(load.res_powers), sum(load_powers))
 
@@ -655,6 +658,7 @@ def test_load_voltages(bus_ph, load_ph, bus_vph, load_vph):
 
     res_cur = [0.1 + 0j, 0.2 + 0j, 0.3 + 0j, 0.6 + 0j]
     load._res_currents = np.array(res_cur[: len(load_ph)], dtype=complex)
+    load._res_potentials = bus._get_potentials_of(load.phases, warning=False)
 
     assert bus.voltage_phases == bus_vph
     assert len(bus.res_voltages) == len(bus.voltage_phases)
@@ -668,6 +672,7 @@ def test_non_flexible_load_res_flexible_powers():
     load = PowerLoad("load", bus, powers=[2300], phases="an")
     bus._res_potentials = np.array([230, 0], dtype=complex)
     load._res_currents = np.array([10, -10], dtype=complex)
+    load._res_potentials = bus._get_potentials_of(load.phases, warning=False)
     with pytest.raises(RoseauLoadFlowException) as e:
         _ = load.res_flexible_powers
     assert e.value.msg == "The load 'load' is not flexible and does not have flexible powers"

--- a/scripts/network_files_upgrade.py
+++ b/scripts/network_files_upgrade.py
@@ -36,12 +36,6 @@ def update_bad_transformer_id(path: Path) -> None:
 
 
 if __name__ == "__main__":
-    # from roseau.load_flow import AbstractLoad, VoltageSource
-    #
-    # # Allow floating neutral otherwise the upgrade will fail for some files
-    # AbstractLoad._floating_neutral_allowed = True
-    # VoltageSource._floating_neutral_allowed = True
-
     for path in all_network_paths():
         try:
             upgrade_network(path)


### PR DESCRIPTION
This was always allowed internally with a private flag but is now exposed to the users.
The only behavioral change is how we get the results of the potentials of the load. Previously we used the potentials of the bus connected to the load. This cannot be always used now as a floating neutral means that the neutral does not exist for the bus and its potential must be obtained from the load or source element directly. The change remains internal and has no effect on currently valid code or JSON files.