### PR TITLE
Improve asssigning of potential refs in DGS networks

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,13 +19,16 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`230` Improve the algorithm for assigning potential references for DGS networks.
+
 - {gh-pr}`229` Several fixes and improvements to the PowerFactory import:
 
-  - Fix the "Export Definition Folder" bundled with _Roseau Load Flow_ as a pfd file;
-  - Lines with missing types will create a LineParameters automatically. This is the case when the
-    `TypLne` objects are inherited from an external library in PowerFactory and not included in the
-    project being exported;
-  - Importing "General Load (`ElmLod`)" elements in now supported;
+  - Update the "Export Definition Folder" bundled with _Roseau Load Flow_ as a pfd file;
+  - Support lines with missing type ID. This is the case when the `TypLne` objects are inherited
+    from an external library in PowerFactory and not included in the project being exported; A
+    `LineParameters` object is automatically created for these lines;
+  - Support "General Load (`ElmLod`)" elements;
+  - Preserve Geometry information on buses and branches;
   - Improve handling of phases of several elements. Previously, phases were hard-coded.
   - Fix the unit of the power of static generators;
   - Fix the re-sizing of the matrices of line types without neutral elements;

--- a/roseau/load_flow/io/dgs/sources.py
+++ b/roseau/load_flow/io/dgs/sources.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 import pandas as pd
 
-from roseau.load_flow.models import AbstractLoad, Bus, Ground, PotentialRef, VoltageSource
+from roseau.load_flow.models import AbstractLoad, Bus, VoltageSource
 from roseau.load_flow.typing import Id
 
 logger = logging.getLogger(__name__)
@@ -13,11 +13,8 @@ def generate_sources(
     elm_xnet: pd.DataFrame,
     sources: dict[Id, AbstractLoad],
     buses: dict[Id, Bus],
-    potential_refs: dict[Id, PotentialRef],
     sta_cubic: pd.DataFrame,
     elm_term: pd.DataFrame,
-    ground: Ground,
-    has_transfomers: bool,
 ) -> None:
     """Generate the sources of the network from External Network data.
 
@@ -31,20 +28,11 @@ def generate_sources(
         buses:
             The dictionary of the all buses.
 
-        potential_refs:
-            The dictionary of the all potential references.
-
         sta_cubic:
             The "StaCubic" dataframe of cubicles.
 
         elm_term:
             The "ElmTerm" dataframe containing the bus data.
-
-        ground:
-            The ground element to connect to the neutral of the source bus if any.
-
-        has_transfomers:
-            Does the network have any transformer?
     """
     for source_id in elm_xnet.index:
         id_sta_cubic_source = elm_xnet.at[source_id, "bus1"]  # id of the cubicle connecting the source and its bus
@@ -54,9 +42,5 @@ def generate_sources(
         voltages = un * tap * np.array([1, np.exp(-2j * np.pi / 3), np.exp(2j * np.pi / 3)])
         source_bus = buses[bus_id]
 
+        # TODO remove hard coded phases (requires adapting voltages for delta sources)
         sources[source_id] = VoltageSource(id=source_id, bus=source_bus, phases="abcn", voltages=voltages)
-        if "n" in source_bus.phases:
-            ground.connect(source_bus)
-        elif has_transfomers:
-            source_pref = PotentialRef(f"pref (source {source_id!r})", element=source_bus)  # Delta potential ref
-            potential_refs[source_pref.id] = source_pref

--- a/roseau/load_flow/io/dgs/transformers.py
+++ b/roseau/load_flow/io/dgs/transformers.py
@@ -3,7 +3,7 @@ import logging
 import pandas as pd
 import shapely
 
-from roseau.load_flow.models import AbstractBranch, Bus, Ground, Transformer, TransformerParameters
+from roseau.load_flow.models import AbstractBranch, Bus, Transformer, TransformerParameters
 from roseau.load_flow.typing import Id
 from roseau.load_flow.units import Q_
 
@@ -52,7 +52,6 @@ def generate_transformers(
     sta_cubic: pd.DataFrame,
     transformers_tap: dict[Id, int],
     transformers_params: dict[Id, TransformerParameters],
-    ground: Ground,
 ) -> None:
     """Generate the transformers of the network.
 
@@ -74,9 +73,6 @@ def generate_transformers(
 
         transformers_params:
             The dictionary of all transformers parameters.
-
-        ground:
-            The ground object to connect to secondary bus of the transformer.
     """
     for idx in elm_tr.index:
         type_id = elm_tr.at[idx, "typ_id"]  # id of the transformer type
@@ -92,4 +88,3 @@ def generate_transformers(
         branches[idx] = Transformer(
             id=idx, bus1=bus1, bus2=bus2, parameters=transformers_params[type_id], tap=tap, geometry=geometry
         )
-        ground.connect(bus=bus2)


### PR DESCRIPTION
This PR implements a better algorithm for auto assigning potential references to DGS networks.
It replaces the heuristic used earlier that worked for simple networks like MV/LV network with one transformer, LV network with neutral and MV network without neutral to work with any network configuration.

The new algorithm is based on the method `_check_ref` we use to check the correctness of potential references but it adds potential references instead of raising an error. The algorithm is currently DGS specific it makes some assumptions that may not be true in the general case.

We might want to consider adding a similar functionality for the general case later though. This could be useful for users who simply don't care about this low level functionality or for use in a graphical user interface.