### PR TITLE
Invalidate the license cache

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`259` The cache of the license object was not reset after the activation of a new license key.
 - {gh-pr}`258` Add basic plotting functionality in the new `roseau.load_flow.plotting` module. The
   `plot_interactive_map` function plots an electrical network on an interactive map using the folium
   library and the `plot_voltage_phasors` function plots the voltage phasors of a bus, load or source

--- a/roseau/load_flow/license.py
+++ b/roseau/load_flow/license.py
@@ -82,10 +82,12 @@ def activate_license(key: str | None = None) -> None:
             variable `ROSEAU_LOAD_FLOW_LICENSE_KEY` is used. If this variable is not set, an error
             is raised.
     """
+    global _license
     if key is None:
         key = os.getenv("ROSEAU_LOAD_FLOW_LICENSE_KEY", "")
     try:
         cy_activate_license(key=key, cacert_filepath=certifi.where(), cache_folderpath=user_cache_dir())
+        _license = None
     except RuntimeError as e:
         msg = f"The license cannot be activated. The detailed error message is {e.args[0][2:]!r}."
         logger.error(msg)


### PR DESCRIPTION
The cache of the license object was not reset after the activation of another license key.