### PR TITLE
Error when transformer has null impedance

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`262` Raise a proper error when a transformer is defined with null impedance.
 - {gh-pr}`259` The cache of the license object was not reset after the activation of a new license key.
 - {gh-pr}`258` {gh-pr}`261` Add basic plotting functionality in the new `roseau.load_flow.plotting`
   module. The `plot_interactive_map` function plots an electrical network on an interactive map using

--- a/roseau/load_flow/exceptions.py
+++ b/roseau/load_flow/exceptions.py
@@ -47,6 +47,7 @@ class RoseauLoadFlowExceptionCode(StrEnum):
     BAD_TRANSFORMER_WINDINGS = auto()
     BAD_TRANSFORMER_TYPE = auto()
     BAD_TRANSFORMER_VOLTAGES = auto()
+    BAD_TRANSFORMER_IMPEDANCE = auto()
     BAD_TRANSFORMER_PARAMETERS = auto()
 
     # Switch

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -771,3 +771,15 @@ def test_compute_open_short_circuit_parameters():
     psc, vsc = tp._compute_short_circuit_parameters()
     assert np.isclose(psc.m, tp.psc.m, rtol=0.001)
     assert np.isclose(vsc.m, tp.vsc.m)
+
+
+def test_ideal_transformer():
+    # Ideal transformer not yet supported
+    with pytest.raises(RoseauLoadFlowException) as e:
+        TransformerParameters(id="test", type="Dyn11", sn=50e3, uhv=20e3, ulv=400, z2=0.0, ym=0.0)
+    assert e.value.msg == (
+        "Transformer type 'test' has a null series impedance z2. Ideal transformers are not supported."
+    )
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_IMPEDANCE
+    # OK
+    TransformerParameters(id="test", type="Dyn11", sn=50e3, uhv=20e3, ulv=400, z2=0.0000001, ym=0.0)

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -98,6 +98,11 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_VOLTAGES)
 
+        if np.isclose(z2, 0.0):
+            msg = f"Transformer type {id!r} has a null series impedance z2. Ideal transformers are not supported."
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_IMPEDANCE)
+
         self._sn: float = sn
         self._uhv: float = uhv
         self._ulv: float = ulv


### PR DESCRIPTION
Currently we raise a "decomposition failed" error when we run a load flow with ideal transformer, this improves the error.