### PR TITLE
Dynamically calculate the stacklevel of the first frame outside of `roseau.load_flow` for warnings

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`273` Dynamically calculate the stacklevel of the first frame outside of `roseau.load_flow` for warnings
 - {gh-pr}`272` {gh-issue}`271`: Fix segfault when phases of a potential reference are not the same as the bus phases.
 - {gh-pr}`270` Use [Rye](https://rye.astral.sh/) instead of [Poetry](https://python-poetry.org/) as dependency manager.
 - {gh-pr}`269` Optimize the SVG files of the documentation.

--- a/roseau/load_flow/io/dgs/__init__.py
+++ b/roseau/load_flow/io/dgs/__init__.py
@@ -33,6 +33,7 @@ from roseau.load_flow.models import (
     VoltageSource,
 )
 from roseau.load_flow.typing import Id, StrPath
+from roseau.load_flow.utils._exceptions import find_stack_level
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,7 @@ def network_from_dgs(
                 "line types from the library to the project before exporting otherwise a "
                 "LineParameter object will be created for each line."
             )
-            warnings.warn(msg, stacklevel=3)
+            warnings.warn(msg, stacklevel=find_stack_level())
         else:
             generate_typ_lne(typ_lne=typ_lne, lines_params=lines_params)
         generate_lines(
@@ -184,7 +185,7 @@ def _parse_dgs_version(data: dict[str, Any]) -> tuple[int, ...]:
             f"The DGS version {dgs_version} is too old, this may cause conversion errors. Try "
             f"updating the version before exporting."
         )
-        warnings.warn(msg, stacklevel=4)
+        warnings.warn(msg, stacklevel=find_stack_level())
     return dgs_version_tuple
 
 

--- a/roseau/load_flow/io/dgs/lines.py
+++ b/roseau/load_flow/io/dgs/lines.py
@@ -8,6 +8,7 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.io.dgs.constants import CONDUCTOR_TYPES, INSULATOR_TYPES, LINE_TYPES
 from roseau.load_flow.models import Bus, Ground, Line, LineParameters
 from roseau.load_flow.typing import Id
+from roseau.load_flow.utils._exceptions import find_stack_level
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +205,7 @@ def generate_lines(
                 elif nb_points == 1:
                     warnings.warn(
                         f"Failed to read geometry data for line {line_id!r}: it has a single GPS point.",
-                        stacklevel=4,
+                        stacklevel=find_stack_level(),
                     )
                 else:
                     assert nb_cols == 2, f"Expected 2 GPS columns (Latitude/Longitude), got {nb_cols}."
@@ -218,7 +219,8 @@ def generate_lines(
                     )
             except Exception as e:
                 warnings.warn(
-                    f"Failed to read geometry data for line {line_id!r}: {type(e).__name__}: {e}", stacklevel=4
+                    f"Failed to read geometry data for line {line_id!r}: {type(e).__name__}: {e}",
+                    stacklevel=find_stack_level(),
                 )
         lines[line_id] = Line(
             id=line_id,

--- a/roseau/load_flow/io/dgs/switches.py
+++ b/roseau/load_flow/io/dgs/switches.py
@@ -7,6 +7,7 @@ import shapely
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models import Bus, Switch
 from roseau.load_flow.typing import Id
+from roseau.load_flow.utils._exceptions import find_stack_level
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ def generate_switches(
         on_off = elm_coup.at[switch_id, "on_off"]
         if not on_off:
             warnings.warn(
-                f"Switch {switch_id!r} is open but switches are always closed in roseau-load-flow.", stacklevel=4
+                f"Switch {switch_id!r} is open but switches are always closed in roseau-load-flow.",
+                stacklevel=find_stack_level(),
             )
         switches[switch_id] = Switch(id=switch_id, phases=phases, bus1=bus1, bus2=bus2, geometry=geometry)

--- a/roseau/load_flow/models/core.py
+++ b/roseau/load_flow/models/core.py
@@ -10,6 +10,7 @@ from shapely.geometry.base import BaseGeometry
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.typing import Id
 from roseau.load_flow.utils import Identifiable, JsonMixin
+from roseau.load_flow.utils._exceptions import find_stack_level
 from roseau.load_flow_engine.cy_engine import CyElement
 
 if TYPE_CHECKING:
@@ -169,13 +170,7 @@ class Element(ABC, Identifiable, JsonMixin):
                     "ensure the validity of results."
                 ),
                 category=UserWarning,
-                # Ignore all private RLF stacks:
-                # - this method
-                # - _res_..._getter caller function
-                # - res_... property
-                # - ureg wrappers
-                # TODO: dynamic stacklevel computation similar to pandas and matplotlib
-                stacklevel=6,
+                stacklevel=find_stack_level(),
             )
         self._fetch_results = False
         return value

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -29,6 +29,7 @@ from roseau.load_flow.utils import (
     JsonMixin,
     LineType,
 )
+from roseau.load_flow.utils._exceptions import find_stack_level
 
 logger = logging.getLogger(__name__)
 
@@ -1442,7 +1443,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
                     f"The {matrix_name} matrix of line type {self.id!r} has off-diagonal elements "
                     f"with a non-zero real part."
                 )
-                warnings.warn(msg, category=UserWarning, stacklevel=4)
+                warnings.warn(msg, category=UserWarning, stacklevel=find_stack_level())
             # Check that the real coefficients are non-negative
             if (matrix.real < 0.0).any():
                 msg = f"The {matrix_name} matrix of line type {self.id!r} has coefficients with negative real part."

--- a/roseau/load_flow/models/loads/flexible_parameters.py
+++ b/roseau/load_flow/models/loads/flexible_parameters.py
@@ -17,6 +17,7 @@ from roseau.load_flow.typing import (
 )
 from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import JsonMixin, _optional_deps
+from roseau.load_flow.utils._exceptions import find_stack_level
 from roseau.load_flow_engine.cy_engine import CyControl, CyFlexibleParameter, CyProjection
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,7 @@ class Control(JsonMixin):
                     f"different from 0 were given: {msg}"
                 ),
                 category=UserWarning,
-                stacklevel=2,
+                stacklevel=find_stack_level(),
             )
 
         # Raise an error if the useful values are not well-ordered and positive

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -13,6 +13,7 @@ from roseau.load_flow.models.core import Element
 from roseau.load_flow.models.loads.flexible_parameters import FlexibleParameter
 from roseau.load_flow.typing import ComplexArray, ComplexScalarOrArrayLike1D, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.utils._exceptions import find_stack_level
 from roseau.load_flow.utils.constants import PositiveSequence
 from roseau.load_flow_engine.cy_engine import (
     CyAdmittanceLoad,
@@ -90,7 +91,7 @@ class AbstractLoad(Element, ABC):
             warnings.warn(
                 message=f"Neutral connection requested for load {id!r} with no neutral phase",
                 category=UserWarning,
-                stacklevel=3,
+                stacklevel=find_stack_level(),
             )
             connect_neutral = None
         self._connect(bus)

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -10,6 +10,7 @@ from roseau.load_flow.models.core import Element
 from roseau.load_flow.models.grounds import Ground
 from roseau.load_flow.typing import Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.utils._exceptions import find_stack_level
 from roseau.load_flow_engine.cy_engine import CyDeltaPotentialRef, CyPotentialRef
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,11 @@ class PotentialRef(Element):
                 a neutral, otherwise, the sum of the potentials of the bus phases is set to zero.
         """
         if "phase" in deprecated_kw and phases is None:
-            warnings.warn("The 'phase' argument is deprecated, use 'phases' instead.", DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                "The 'phase' argument is deprecated, use 'phases' instead.",
+                DeprecationWarning,
+                stacklevel=find_stack_level(),
+            )
             phases = deprecated_kw.pop("phase")
         if deprecated_kw:
             raise TypeError(

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -12,6 +12,7 @@ from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.typing import ComplexArray, ComplexScalarOrArrayLike1D, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.utils._exceptions import find_stack_level
 from roseau.load_flow.utils.constants import PositiveSequence
 from roseau.load_flow_engine.cy_engine import CyDeltaVoltageSource, CyVoltageSource
 
@@ -101,7 +102,7 @@ class VoltageSource(Element):
             warnings.warn(
                 message=f"Neutral connection requested for source {id!r} with no neutral phase",
                 category=UserWarning,
-                stacklevel=2,
+                stacklevel=find_stack_level(),
             )
             connect_neutral = None
         self._connect(bus)

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -40,6 +40,7 @@ from roseau.load_flow.models import (
 )
 from roseau.load_flow.typing import Id, JsonDict, MapOrSeq, Solver, StrPath
 from roseau.load_flow.utils import CatalogueMixin, JsonMixin, _optional_deps
+from roseau.load_flow.utils._exceptions import find_stack_level
 from roseau.load_flow.utils.types import _DTYPES, LoadTypeDtype, VoltagePhaseDtype
 from roseau.load_flow_engine.cy_engine import CyElectricalNetwork
 
@@ -640,7 +641,7 @@ class ElectricalNetwork(JsonMixin, CatalogueMixin[JsonDict]):
                     "ensure the validity of results."
                 ),
                 category=UserWarning,
-                stacklevel=2,
+                stacklevel=find_stack_level(),
             )
 
     @property

--- a/roseau/load_flow/utils/_exceptions.py
+++ b/roseau/load_flow/utils/_exceptions.py
@@ -1,0 +1,40 @@
+# The find_stack_level function is adapted from the `pandas.util._exceptions.find_stack_level`
+# function from the pandas library licensed under the BSD 3-Clause license.
+# pandas source code is available at https://github.com/pandas-dev/pandas
+import inspect
+from pathlib import Path
+
+_pkg_and_tests_dirs: tuple[str, tuple[str, ...]] | None = None
+
+
+def _get_dirs() -> tuple[str, tuple[str, ...]]:
+    global _pkg_and_tests_dirs
+    if _pkg_and_tests_dirs is None:
+        import roseau.load_flow
+
+        pkg_dir = Path(roseau.load_flow.__file__).parent
+        test_dirs = tuple(str(p) for p in pkg_dir.glob("**/tests") if p.is_dir())
+        _pkg_and_tests_dirs = str(pkg_dir), test_dirs
+    return _pkg_and_tests_dirs
+
+
+def find_stack_level() -> int:
+    """Find the first place in the stack that is not inside `roseau.load_flow` (tests notwithstanding)."""
+    pkg_dir, test_dirs = _get_dirs()
+
+    # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
+    frame = inspect.currentframe()
+    try:
+        n = 0
+        while frame:  # pragma: no cover
+            filename = inspect.getfile(frame)
+            if filename.startswith(pkg_dir) and not filename.startswith(test_dirs):
+                frame = frame.f_back
+                n += 1
+            else:
+                break
+    finally:
+        # See note in https://docs.python.org/3/library/inspect.html#inspect.Traceback
+        # And Issue https://github.com/pandas-dev/pandas/issues/54628
+        del frame
+    return max(n, 2)


### PR DESCRIPTION
An internal change that has no public effect except for better warning locations.