### PR TITLE
Allow a ground to be connected to multiple phases of the same bus with a warning

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`274` Allow a ground to be connected to multiple phases of the same bus with a warning.
 - {gh-pr}`273` Dynamically calculate the stacklevel of the first frame outside of `roseau.load_flow` for warnings
 - {gh-pr}`272` {gh-issue}`271`: Fix segfault when phases of a potential reference are not the same as the bus phases.
 - {gh-pr}`270` Use [Rye](https://rye.astral.sh/) instead of [Poetry](https://python-poetry.org/) as dependency manager.

--- a/roseau/load_flow/models/tests/test_grounds.py
+++ b/roseau/load_flow/models/tests/test_grounds.py
@@ -1,0 +1,22 @@
+import pytest
+
+from roseau.load_flow.models import Bus, Ground
+from roseau.load_flow.testing import assert_json_close
+
+
+def test_ground_to_multiple_bus_phases():
+    bus = Bus("B", phases="abcn")
+    ground = Ground("G")
+    ground.connect(bus, phase="n")
+    with pytest.warns(UserWarning, match=r"Ground 'G' is already connected to bus 'B'"):
+        ground.connect(bus, phase="a")
+    assert ground.connected_buses == {"B": "na"}
+
+    ground_dict = ground.to_dict()
+    expected_dict = {"id": "G", "buses": [{"id": "B", "phase": "na"}]}
+    assert_json_close(ground_dict, expected_dict)
+    for d in expected_dict["buses"]:
+        d["bus"] = bus
+    with pytest.warns(UserWarning, match=r"Ground 'G' is already connected to bus 'B'"):
+        new_ground = Ground.from_dict(expected_dict)
+    assert new_ground.connected_buses == {"B": "na"}


### PR DESCRIPTION
This used to raise before because it is almost certainly an error. We needed it in some of the niche cases we were testing so now it warns instead.