### PR TITLE
Fix constant current loads definition

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`277` Fix the definition of constant current loads to be the magnitudes of the currents
+  and their phase shift from the voltages instead of the absolute phase shift. Currents should no
+  longer be rotated by 120° to be in sync with the voltages.
+- {gh-pr}`276` Add a backward-forward solver (experimental).
 - {gh-pr}`275` Use [uv](https://docs.astral.sh/uv/) instead of [Rye](https://rye.astral.sh/) as dependency manager.
 - {gh-pr}`273` Dynamically calculate the stacklevel of the first frame outside of `roseau.load_flow` for warnings
 - {gh-pr}`272` {gh-issue}`271`: Fix segfault when phases of a potential reference are not the same as the bus phases.
@@ -26,7 +30,6 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 - {gh-pr}`269` Optimize the SVG files of the documentation.
 - {gh-pr}`268` Set up ReadTheDoc to automatically compile the documentation.
 - {gh-pr}`267` Add a section in the documentation on Google Colab secrets.
-- {gh-pr}`276` Add a backward-forward solver (experimental).
 
 ## Version 0.10.0
 

--- a/doc/models/Ground.md
+++ b/doc/models/Ground.md
@@ -135,7 +135,7 @@ en.res_buses.transform([np.abs, ft.partial(np.angle, deg=True)])
 # | ('bus3', 'c') |                   395.28    |                  120.043 |
 
 # The requested voltages of the voltage sources are respected
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'ab') |                   400     |            6.31922e-19 |

--- a/doc/models/Ground.md
+++ b/doc/models/Ground.md
@@ -135,7 +135,7 @@ en.res_buses.transform([np.abs, ft.partial(np.angle, deg=True)])
 # | ('bus3', 'c') |                   395.28    |                  120.043 |
 
 # The requested voltages of the voltage sources are respected
-en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages[["voltage"]].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'ab') |                   400     |            6.31922e-19 |

--- a/doc/models/Load/CurrentLoad.md
+++ b/doc/models/Load/CurrentLoad.md
@@ -20,25 +20,30 @@ _ZIP_ equation: $S = 0 \times V^0 + i \times V^1 + 0 \times V^2 \implies S \prop
 
 ## Equations
 
-The equations are the following (star loads):
+The equations are the following for star loads given the constant currents {math}`i_{\mathrm{abc}}`:
 
 ```{math}
 \left\{
     \begin{aligned}
-        \underline{I_{\mathrm{abc}}} &= \mathrm{constant} \\
+        \underline{I_{\mathrm{abc}}} &= i_{\mathrm{abc}} * \frac{\underline{V_{\mathrm{abc}}}
+        -\underline{V_{\mathrm{n}}}}{|\underline{V_{\mathrm{abc}}}-\underline{V_{\mathrm{n}}}|} \\
         \underline{I_{\mathrm{n}}} &= -\sum_{p\in\{\mathrm{a},\mathrm{b},\mathrm{c}\}}\underline{I_{p}}
     \end{aligned}
 \right.
 ```
 
-And the following (delta loads):
+And the following for delta loads given the constant currents {math}`i_{\mathrm{ab}}`,
+{math}`i_{\mathrm{bc}}` and {math}`i_{\mathrm{ca}}`:
 
 ```{math}
 \left\{
     \begin{aligned}
-        \underline{I_{\mathrm{ab}}} &= \mathrm{constant} \\
-        \underline{I_{\mathrm{bc}}} &= \mathrm{constant} \\
-        \underline{I_{\mathrm{ca}}} &= \mathrm{constant}
+        \underline{I_{\mathrm{ab}}} &= i_{\mathrm{ab}} * \frac{\underline{V_{\mathrm{a}}}
+        -\underline{V_{\mathrm{b}}}}{|\underline{V_{\mathrm{a}}}-\underline{V_{\mathrm{b}}}|} \\
+        \underline{I_{\mathrm{bc}}} &= i_{\mathrm{bc}} * \frac{\underline{V_{\mathrm{b}}}
+        -\underline{V_{\mathrm{c}}}}{|\underline{V_{\mathrm{b}}}-\underline{V_{\mathrm{c}}}|} \\
+        \underline{I_{\mathrm{ca}}} &= i_{\mathrm{ca}} * \frac{\underline{V_{\mathrm{c}}}
+        -\underline{V_{\mathrm{a}}}}{|\underline{V_{\mathrm{c}}}-\underline{V_{\mathrm{a}}}|}
     \end{aligned}
 \right.
 ```
@@ -74,15 +79,15 @@ en.solve_load_flow()
 
 # Get the current of the load (equal to the one provided)
 en.res_loads["current"].transform([np.abs, ft.partial(np.angle, deg=True)])
-# |               |    absolute |   angle |
-# |:--------------|------------:|--------:|
-# | ('load', 'a') | 5           |       0 |
-# | ('load', 'b') | 5           |    -120 |
-# | ('load', 'c') | 5           |     120 |
-# | ('load', 'n') | 1.77636e-15 |     180 |
+# |               |    absolute |      angle |
+# |:--------------|------------:|-----------:|
+# | ('load', 'a') | 5           |          0 |
+# | ('load', 'b') | 5           |       -120 |
+# | ('load', 'c') | 5           |        120 |
+# | ('load', 'n') | 1.77636e-15 |   -71.5651 |
 
 # Get the voltages of the network
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages["voltage"].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                    230.94 |                      0 |
@@ -99,10 +104,10 @@ en.solve_load_flow()
 
 # Get the currents of the loads of the network
 en.res_loads["current"].transform([np.abs, ft.partial(np.angle, deg=True)])
-# |               |   absolute |   angle |
-# |:--------------|-----------:|--------:|
-# | ('load', 'a') |    5       |       0 |
-# | ('load', 'b') |    2.5     |    -120 |
-# | ('load', 'c') |    0       |     180 |
-# | ('load', 'n') |    4.33013 |     150 |
+# |               |   absolute |       angle |
+# |:--------------|-----------:|------------:|
+# | ('load', 'a') |    5       |   -0.187647 |
+# | ('load', 'b') |    2.5     |     119.999 |
+# | ('load', 'c') |    0       |          -0 |
+# | ('load', 'n') |    4.32197 |    -150.188 |
 ```

--- a/doc/models/Load/ImpedanceLoad.md
+++ b/doc/models/Load/ImpedanceLoad.md
@@ -20,26 +20,27 @@ _ZIP_ equation: $S = 0 \times V^0 + 0 \times V^1 + z \times V^2 \implies S \prop
 
 ## Equations
 
-The equations are the following (star loads):
+The equations are the following for star loads given the constant impedances {math}`z_{\mathrm{abc}}`:
 
 ```{math}
 \left\{
     \begin{aligned}
         \underline{I_{\mathrm{abc}}} &= \frac{\underline{V_{\mathrm{abc}}}-\underline{V_{\mathrm{n}}}}{
-        \underline{Z_{\mathrm{abc}}}} \\
+        \underline{z_{\mathrm{abc}}}} \\
         \underline{I_{\mathrm{n}}} &= -\sum_{p\in\{\mathrm{a},\mathrm{b},\mathrm{c}\}}\underline{I_{p}}
     \end{aligned}
 \right.
 ```
 
-And the following (delta loads):
+And the following for delta loads given the constant impedances {math}`z_{\mathrm{ab}}`,
+{math}`z_{\mathrm{bc}}` and {math}`z_{\mathrm{ca}}`:
 
 ```{math}
 \left\{
     \begin{aligned}
-        \underline{I_{\mathrm{ab}}} &= \frac{\underline{V_{\mathrm{a}}}-\underline{V_{\mathrm{b}}}}{\underline{Z_{\mathrm{ab}}}} \\
-        \underline{I_{\mathrm{bc}}} &= \frac{\underline{V_{\mathrm{b}}}-\underline{V_{\mathrm{c}}}}{\underline{Z_{\mathrm{bc}}}} \\
-        \underline{I_{\mathrm{ca}}} &= \frac{\underline{V_{\mathrm{c}}}-\underline{V_{\mathrm{a}}}}{\underline{Z_{\mathrm{ca}}}}
+        \underline{I_{\mathrm{ab}}} &= \frac{\underline{V_{\mathrm{a}}}-\underline{V_{\mathrm{b}}}}{\underline{z_{\mathrm{ab}}}} \\
+        \underline{I_{\mathrm{bc}}} &= \frac{\underline{V_{\mathrm{b}}}-\underline{V_{\mathrm{c}}}}{\underline{z_{\mathrm{bc}}}} \\
+        \underline{I_{\mathrm{ca}}} &= \frac{\underline{V_{\mathrm{c}}}-\underline{V_{\mathrm{a}}}}{\underline{z_{\mathrm{ca}}}}
     \end{aligned}
 \right.
 ```
@@ -78,7 +79,7 @@ load.res_voltages / load.res_currents[:3]
 # array([40.+3.j, 40.+3.j, 40.+3.j]) <Unit('volt / ampere')>
 
 # Get the voltages of the network
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages["voltage"].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                   230.94  |           -6.40192e-19 |
@@ -97,7 +98,7 @@ load.res_voltages / load.res_currents[:3]
 # array([40.+4.j, 20.+2.j, 10.+1.j]) <Unit('volt / ampere')>
 
 # Get the voltages of the network
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages["voltage"].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                   230.94  |               0        |

--- a/doc/models/Load/PowerLoad.md
+++ b/doc/models/Load/PowerLoad.md
@@ -20,28 +20,29 @@ _ZIP_ equation: $S = s \times V^0 + 0 \times V^1 + 0 \times V^2 \implies S = \ma
 
 ## Equations
 
-The equations are the following (star loads):
+The equations are the following for star loads given the constant powers {math}`s_{\mathrm{abc}}`:
 
 ```{math}
 \left\{
     \begin{aligned}
-        \underline{I_{\mathrm{abc}}} &= \left(\frac{\underline{S_{\mathrm{abc}}}}{\underline{V_{\mathrm{abc}}}
+        \underline{I_{\mathrm{abc}}} &= \left(\frac{\underline{s_{\mathrm{abc}}}}{\underline{V_{\mathrm{abc}}}
         -\underline{V_{\mathrm{n}}}}\right)^{\star} \\
         \underline{I_{\mathrm{n}}} &= -\sum_{p\in\{\mathrm{a},\mathrm{b},\mathrm{c}\}}\underline{I_{p}}
     \end{aligned}
 \right.
 ```
 
-And the following (delta loads):
+And the following for delta loads given the constant powers {math}`s_{\mathrm{ab}}`,
+{math}`s_{\mathrm{bc}}` and {math}`s_{\mathrm{ca}}`:
 
 ```{math}
 \left\{
     \begin{aligned}
-        \underline{I_{\mathrm{ab}}} &= \left(\frac{\underline{S_{\mathrm{ab}}}}{\underline{V_{\mathrm{a}}}-\underline
+        \underline{I_{\mathrm{ab}}} &= \left(\frac{\underline{s_{\mathrm{ab}}}}{\underline{V_{\mathrm{a}}}-\underline
         {V_{\mathrm{b}}}}\right)^{\star} \\
-        \underline{I_{\mathrm{bc}}} &= \left(\frac{\underline{S_{\mathrm{bc}}}}{\underline{V_{\mathrm{b}}}-\underline
+        \underline{I_{\mathrm{bc}}} &= \left(\frac{\underline{s_{\mathrm{bc}}}}{\underline{V_{\mathrm{b}}}-\underline
         {V_{\mathrm{c}}}}\right)^{\star} \\
-        \underline{I_{\mathrm{ca}}} &= \left(\frac{\underline{S_{\mathrm{ca}}}}{\underline{V_{\mathrm{c}}}-\underline
+        \underline{I_{\mathrm{ca}}} &= \left(\frac{\underline{s_{\mathrm{ca}}}}{\underline{V_{\mathrm{c}}}-\underline
         {V_{\mathrm{a}}}}\right)^{\star}
     \end{aligned}
 \right.
@@ -86,7 +87,7 @@ en.res_loads["power"]
 # | ('load', 'n') | -5.57569e-31+ 2.25385e-32j |
 
 # Get the voltages of the network
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages["voltage"].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                   230.94  |            9.69325e-22 |
@@ -110,7 +111,7 @@ en.res_loads["power"]
 # | ('load', 'n') | -148.93 + 3.78664e-14j |
 
 # Get the voltages of the network, bus2 voltages are no longer equal
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages["voltage"].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                   230.94  |            4.05321e-24 |

--- a/doc/models/Transformer/Center_Tapped_Transformer.md
+++ b/doc/models/Transformer/Center_Tapped_Transformer.md
@@ -160,7 +160,7 @@ en.res_transformers[["current2"]].transform([np.abs, ft.partial(np.angle, deg=Tr
 # the load has 0VA on this phase.
 
 # The voltages at the buses of the network
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
 # |                      |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------------|--------------------------:|-----------------------:|
 # | ('source_bus', 'an') |                 11547     |            9.20565e-25 |

--- a/doc/models/Transformer/Center_Tapped_Transformer.md
+++ b/doc/models/Transformer/Center_Tapped_Transformer.md
@@ -160,7 +160,7 @@ en.res_transformers[["current2"]].transform([np.abs, ft.partial(np.angle, deg=Tr
 # the load has 0VA on this phase.
 
 # The voltages at the buses of the network
-en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages[["voltage"]].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                      |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------------|--------------------------:|-----------------------:|
 # | ('source_bus', 'an') |                 11547     |            9.20565e-25 |

--- a/doc/models/Transformer/Single_Phase_Transformer.md
+++ b/doc/models/Transformer/Single_Phase_Transformer.md
@@ -130,7 +130,7 @@ en.res_transformers[["power1", "power2"]].abs()
 # | ('transfo', 'n') |    0     |        0 |
 
 # The voltages at the buses of the network
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                    230.94 |               0        |

--- a/doc/models/Transformer/Single_Phase_Transformer.md
+++ b/doc/models/Transformer/Single_Phase_Transformer.md
@@ -130,7 +130,7 @@ en.res_transformers[["power1", "power2"]].abs()
 # | ('transfo', 'n') |    0     |        0 |
 
 # The voltages at the buses of the network
-en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages[["voltage"]].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:---------------|--------------------------:|-----------------------:|
 # | ('bus1', 'an') |                    230.94 |               0        |

--- a/doc/models/Transformer/Three_Phase_Transformer.md
+++ b/doc/models/Transformer/Three_Phase_Transformer.md
@@ -672,7 +672,7 @@ en.res_transformers[["current2"]].transform([np.abs, ft.partial(np.angle, deg=Tr
 # | ('transfo', 'n') |                2.25156e-13 |                -80.4634 |
 
 # The voltages at the buses of the network
-en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages[["voltage"]].transform([np.abs, ft.partial(np.angle, deg=True)])
 # |                  |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:-----------------|--------------------------:|-----------------------:|
 # | ('bus_mv', 'ab') |                 20000     |               0        |

--- a/doc/models/Transformer/Three_Phase_Transformer.md
+++ b/doc/models/Transformer/Three_Phase_Transformer.md
@@ -672,7 +672,7 @@ en.res_transformers[["current2"]].transform([np.abs, ft.partial(np.angle, deg=Tr
 # | ('transfo', 'n') |                2.25156e-13 |                -80.4634 |
 
 # The voltages at the buses of the network
-en.res_buses_voltages.transform([np.abs, ft.partial(np.angle, deg=True)])
+en.res_buses_voltages.transform[["voltage"]]([np.abs, ft.partial(np.angle, deg=True)])
 # |                  |   ('voltage', 'absolute') |   ('voltage', 'angle') |
 # |:-----------------|--------------------------:|-----------------------:|
 # | ('bus_mv', 'ab') |                 20000     |               0        |

--- a/roseau/load_flow/models/tests/test_loads.py
+++ b/roseau/load_flow/models/tests/test_loads.py
@@ -771,19 +771,13 @@ def test_loads_scalar_values():
 
     # Current load
     load = CurrentLoad(id="load6", bus=bus, currents=2 + 1j, phases="abcn")
-    np.testing.assert_allclose(
-        load.currents.m, [(2 + 1j), (2 + 1j) * np.exp(-2j * np.pi / 3), (2 + 1j) * np.exp(2j * np.pi / 3)], strict=True
-    )
+    np.testing.assert_allclose(load.currents.m, [2 + 1j, 2 + 1j, 2 + 1j], strict=True)
     load.currents = 4 + 2j
-    np.testing.assert_allclose(
-        load.currents.m, [(4 + 2j), (4 + 2j) * np.exp(-2j * np.pi / 3), (4 + 2j) * np.exp(2j * np.pi / 3)], strict=True
-    )
+    np.testing.assert_allclose(load.currents.m, [4 + 2j, 4 + 2j, 4 + 2j], strict=True)
     load = CurrentLoad(id="load7", bus=bus, currents=2 + 1j, phases="abc")
-    np.testing.assert_allclose(
-        load.currents.m, [(2 + 1j), (2 + 1j) * np.exp(-2j * np.pi / 3), (2 + 1j) * np.exp(2j * np.pi / 3)], strict=True
-    )
+    np.testing.assert_allclose(load.currents.m, [2 + 1j, 2 + 1j, 2 + 1j], strict=True)
     load = CurrentLoad(id="load8", bus=bus, currents=2 + 1j, phases="bcn")
-    np.testing.assert_allclose(load.currents.m, [(2 + 1j), -(2 + 1j)], strict=True)
+    np.testing.assert_allclose(load.currents.m, [2 + 1j, 2 + 1j], strict=True)
     load = CurrentLoad(id="load9", bus=bus, currents=2 + 1j, phases="ca")
     np.testing.assert_allclose(load.currents.m, [2 + 1j], strict=True)
     load = CurrentLoad(id="load10", bus=bus, currents=2 + 1j, phases="an")


### PR DESCRIPTION
Fix the definition of constant current loads to be the magnitudes of the currents and their phase shift from the voltages instead of the absolute phase shift. Currents should no longer be rotated by 120° to be in sync with the voltages.