### PR TITLE
ENH: Remove the deprecated `from_name_mv` method

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`286` The deprecated method `LineParameters.from_name_mv` is removed.
 - {gh-pr}`283` **BREAKING CHANGE**: Several changes related to the `LineParameters`:
 
   - The `LineParameters` class changed:

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.linalg as nplin
 import pandas as pd
 from numpy._typing import NDArray
-from typing_extensions import Self, deprecated
+from typing_extensions import Self
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.typing import (
@@ -895,31 +895,6 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINE_TYPE)
 
         return coord, coord_prim, epsilon, epsilon_neutral
-
-    @classmethod
-    @deprecated(
-        "The method LineParameters.from_name_mv() is deprecated and will be removed in a future "
-        "version. Use LineParameters.from_coiffier() instead.",
-        category=FutureWarning,
-    )
-    @ureg_wraps(None, (None, None, "A"))
-    def from_name_mv(cls, name: str, max_currents: FloatScalarOrArrayLike1D | None = None) -> Self:
-        """Get the electrical parameters of a MV line from its canonical name (France specific model)
-
-        Args:
-            name:
-                The canonical name of the line parameters. It must be in the format
-                `lineType_conductorType_crossSection`. E.g. "U_AL_150".
-
-            max_currents:
-                An optional maximal current loading of the line (A). It is not used in the load flow.
-
-        Returns:
-            The corresponding line parameters.
-        """
-        obj = cls.from_coiffier_model(name=name, nb_phases=3)
-        obj.max_currents = max_currents
-        return obj
 
     @classmethod
     def from_coiffier_model(cls, name: str, nb_phases: int = 3, id: Id | None = None) -> Self:  # noqa: C901

--- a/roseau/load_flow/models/tests/test_line_parameters.py
+++ b/roseau/load_flow/models/tests/test_line_parameters.py
@@ -442,21 +442,6 @@ def test_sym():
     npt.assert_allclose(y_shunt, y_shunt_expected)
 
 
-def test_from_name_mv():
-    warning_msg = (
-        r"The method LineParameters.from_name_mv\(\) is deprecated and will be removed in a future "
-        r"version\. Use LineParameters\.from_coiffier\(\) instead\."
-    )
-    with pytest.warns(FutureWarning, match=warning_msg):
-        lp = LineParameters.from_name_mv("U_AL_150", max_currents=100000)
-    z_line_expected = (0.1767 + 0.1j) * np.eye(3)
-    y_shunt_expected = 0.00014106j * np.eye(3)
-
-    npt.assert_allclose(lp.z_line.m_as("ohm/km"), z_line_expected, rtol=0.01, atol=0.01, strict=True)
-    npt.assert_allclose(lp.y_shunt.m_as("S/km"), y_shunt_expected, rtol=0.01, atol=0.01, strict=True)
-    npt.assert_allclose(lp.max_currents.m_as("A"), [100000.0] * 3, strict=True)
-
-
 def test_from_coiffier_model():
     # Invalid names
     with pytest.raises(RoseauLoadFlowException) as e:


### PR DESCRIPTION
It's all in the title!