### PR TITLE
Improve line enumeration types and fix errors in Coiffier's model

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,9 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`311` Add French aliases to line enumeration types.
+- {gh-pr}`311` Fix `TypeError`s in the `LineParameters.from_coiffier_model`. The error message of
+  invalid models now indicates whether the line type or the conductor material is invalid.
 - {gh-pr}`310` {gh-issue}`308` Support star and zig-zag windings with non-brought out neutral. In
   earlier versions, vector groups like "Yd11" were considered identical to "YNd11".
 - {gh-pr}`307` {gh-issue}`296` Make `line.res_violated` and `bus.res_violated` return a boolean array

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -139,7 +139,7 @@ def test_to_dict():
     lp_dict = res["lines_params"][0]
     assert np.allclose(lp_dict["ampacities"], 1000)
     assert lp_dict["line_type"] == "UNDERGROUND"
-    assert lp_dict["materials"] == ["AA"] * 4
+    assert lp_dict["materials"] == ["ACSR"] * 4
     assert lp_dict["insulators"] == ["PVC"] * 4
     assert np.allclose(lp_dict["sections"], 120)
     assert "results" not in res_bus0

--- a/roseau/load_flow/tests/test_types.py
+++ b/roseau/load_flow/tests/test_types.py
@@ -1,7 +1,6 @@
 import pytest
 
 from roseau.load_flow.constants import DELTA_P, EPSILON_R, MU_R, RHO, TAN_D
-from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.types import Insulator, LineType, Material
 
 TYPES = [Material, Insulator, LineType]
@@ -27,14 +26,10 @@ def test_types_basic(t):
 
 
 def test_line_type():
-    with pytest.raises(RoseauLoadFlowException) as e:
+    with pytest.raises(ValueError, match=r"is not a valid LineType"):
         LineType("")
-    assert "cannot be converted into a LineType" in e.value.msg
-    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LINE_TYPE
-    with pytest.raises(RoseauLoadFlowException) as e:
+    with pytest.raises(ValueError, match=r"is not a valid LineType"):
         LineType("nan")
-    assert "cannot be converted into a LineType" in e.value.msg
-    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LINE_TYPE
 
     assert LineType("oVeRhEaD") == LineType.OVERHEAD
     assert LineType("o") == LineType.OVERHEAD
@@ -49,11 +44,7 @@ def test_insulator():
 
 
 def test_material():
-    with pytest.raises(RoseauLoadFlowException) as e:
+    with pytest.raises(ValueError, match=r"is not a valid Material"):
         Material("")
-    assert "cannot be converted into a Material" in e.value.msg
-    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_MATERIAL
-    with pytest.raises(RoseauLoadFlowException) as e:
+    with pytest.raises(ValueError, match=r"is not a valid Material"):
         Material("nan")
-    assert "cannot be converted into a Material" in e.value.msg
-    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_MATERIAL

--- a/roseau/load_flow/types.py
+++ b/roseau/load_flow/types.py
@@ -1,14 +1,13 @@
 import logging
 from enum import auto
 
-from roseau.load_flow._compat import StrEnum
-from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
+from roseau.load_flow.utils import CaseInsensitiveStrEnum
 
 # The local logger
 logger = logging.getLogger(__name__)
 
 
-class LineType(StrEnum):
+class LineType(CaseInsensitiveStrEnum):
     """The type of a line."""
 
     OVERHEAD = auto()
@@ -18,78 +17,55 @@ class LineType(StrEnum):
     TWISTED = auto()
     """A twisted line commonly known as Aerial Cable or Aerial Bundled Conductor (ABC) -- Fr = Torsadé."""
 
-    # aliases
+    # Short aliases
     O = OVERHEAD  # noqa: E741
     U = UNDERGROUND
     T = TWISTED
 
-    @classmethod
-    def _missing_(cls, value: object) -> "LineType | None":
-        if isinstance(value, str):
-            try:
-                return cls[value.upper()]
-            except KeyError:
-                pass
-        msg = f"{value!r} cannot be converted into a LineType."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg, RoseauLoadFlowExceptionCode.BAD_LINE_TYPE)
-
-    def code(self) -> str:
-        """A code that can be used in line type names."""
-        return self.name[0]
+    # French aliases
+    AERIEN = OVERHEAD  # Aérien
+    A = OVERHEAD  # Aérien
+    SOUTERRAIN = UNDERGROUND  # Souterrain
+    S = UNDERGROUND  # Souterrain
+    TORSADE = TWISTED  # Torsadé
 
 
-class Material(StrEnum):
+class Material(CaseInsensitiveStrEnum):
     """The type of the material of the conductor."""
+
+    # AAC:    1350-H19 (Standard Round of Compact Round)
+    # AAC/TW: 1380-H19 (Trapezoidal Wire)
+    # AAAC:   Aluminum alloy 6201-T81.
+    # AAAC:   Concentric-lay-stranded
+    # AAAC:   conforms to ASTM Specification B-399
+    # AAAC:   Applications: Overhead
+    # ACSR:   Aluminum alloy 1350-H-19
+    # ACSR:   Applications: Bare overhead transmission cable and primary and secondary distribution cable
 
     CU = auto()
     """Copper -- Fr = Cuivre."""
-    AL = auto()
-    """All Aluminum Conductor (AAC) -- Fr = Aluminium."""
-    AM = auto()
-    """All Aluminum Alloy Conductor (AAAC) -- Fr = Almélec."""
-    AA = auto()
-    """Aluminum Conductor Steel Reinforced (ACSR) -- Fr = Alu-Acier."""
-    LA = auto()
-    """Aluminum Alloy Conductor Steel Reinforced (AACSR) -- Fr = Almélec-Acier."""
+    AAC = auto()
+    """All Aluminum Conductor (AAC) -- Fr = Aluminium (AL)."""
+    AAAC = auto()
+    """All Aluminum Alloy Conductor (AAAC) -- Fr = Almélec (AM, AMC)."""
+    ACSR = auto()
+    """Aluminum Conductor Steel Reinforced (ACSR) -- Fr = Alu-Acier (AA)."""
+    AACSR = auto()
+    """Aluminum Alloy Conductor Steel Reinforced (AACSR) -- Fr = Almélec-Acier (LA)."""
 
-    # Aliases
-    AAC = AL  # 1350-H19 (Standard Round of Compact Round)
-    """All Aluminum Conductor (AAC) -- Fr = Aluminium."""
-    # AAC/TW  # 1380-H19 (Trapezoidal Wire)
-
-    AAAC = AM
-    """All Aluminum Alloy Conductor (AAAC) -- Fr = Almélec."""
-    # Aluminum alloy 6201-T81.
-    # Concentric-lay-stranded
-    # conforms to ASTM Specification B-399
-    # Applications: Overhead
-
-    ACSR = AA
-    """Aluminum Conductor Steel Reinforced (ACSR) -- Fr = Alu-Acier."""
-    # Aluminum alloy 1350-H-19
-    # Applications: Bare overhead transmission cable and primary and secondary distribution cable
-
-    AACSR = LA
-    """Aluminum Alloy Conductor Steel Reinforced (AACSR) -- Fr = Almélec-Acier."""
-
-    @classmethod
-    def _missing_(cls, value: object) -> "Material":
-        if isinstance(value, str):
-            try:
-                return cls[value.upper()]
-            except KeyError:
-                pass
-        msg = f"{value!r} cannot be converted into a Material."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg, RoseauLoadFlowExceptionCode.BAD_MATERIAL)
-
-    def code(self) -> str:
-        """A code that can be used in conductor type names."""
-        return self.name
+    # French aliases
+    CUC = CU  # Cuivre Câble
+    CUF = CU  # Cuivre Fil
+    AL = AAC  # Aluminium
+    AM = AAAC  # Almélec
+    AMC = AAAC  # Almélec
+    AA = ACSR  # Aluminium Acier
+    AR = ACSR  # Aluminium Acier Renforcé
+    LA = AACSR  # Almélec Acier
+    LR = AACSR  # Almélec Acier Renforcé
 
 
-class Insulator(StrEnum):
+class Insulator(CaseInsensitiveStrEnum):
     """The type of the insulator for a wire."""
 
     NONE = auto()
@@ -111,23 +87,84 @@ class Insulator(StrEnum):
     IP = auto()
     """Impregnated Paper (IP) insulation."""
 
-    # Aliases
+    # French aliases
     PEX = XLPE
-    """Alias -- Cross-linked polyethylene (XLPE) insulation."""
     PE = MDPE
-    """Alias -- Medium-Density PolyEthylene (MDPE) insulation."""
 
-    @classmethod
-    def _missing_(cls, value: object) -> "Insulator":
-        if isinstance(value, str):
-            try:
-                return cls[value.upper()]
-            except KeyError:
-                pass
-        msg = f"{value!r} cannot be converted into a Insulator."
-        logger.error(msg)
-        raise RoseauLoadFlowException(msg, RoseauLoadFlowExceptionCode.BAD_INSULATOR)
 
-    def code(self) -> str:
-        """A code that can be used in insulator type names."""
-        return self.name
+class TransformerCooling(CaseInsensitiveStrEnum):
+    """IEC Designations and Descriptions of the Cooling Classes Used in Power Transformers."""
+
+    # TODO add to the catalogue
+
+    ONAN = auto()
+    """Oil Natural/Air Natural.
+
+    Oil-air (self-cooled).
+
+    Previous designation (1993): OA or ONS
+    """
+    ONAF = auto()
+    """Oil Natural/Air Forced, Forced-air
+
+    Previous designation (1993): FA or ONF
+    """
+    ONAN_ONAF_ONAF = auto()
+    """Oil Natural Air Natural/Oil Natural Air Forced/Oil Natural Air Forced.
+
+    Oil-air (self-cooled), followed by two stages of forced-air cooling (fans).
+
+    Previous designation (1993): OA/FA/FA
+    """
+    ONAN_ONAF_OFAF = auto()
+    """Oil Natural Air Natural/Oil Natural Air Forced/Oil Forced Air Forced.
+
+    Oil-air (self-cooled), followed by one stage of forced-air cooling (fans), followed by 1 stage
+    of forced oil (oil pumps).
+
+    Previous designation (1993): OA/FA/FOA
+    """
+    ONAF_ODAF = auto()
+    """Oil Natural Air Forced/Oil Direct Air Forced.
+
+    Oil-air (self-cooled), followed by one stage of directed oil flow pumps (with fans).
+
+    Previous designation (1993): OA/FOA
+    """
+    ONAF_ODAF_ODAF = auto()
+    """Oil Natural Air Forced/Oil Direct Air Forced/Oil Direct Air Forced.
+
+    Oil-air (self-cooled), followed by two stages of directed oil flow pumps (with fans).
+
+    Previous designation (1993): OA/FOA/FOA
+    """
+    OFAF = auto()
+    """Oil Forced Air Forced.
+
+    Forced oil/air (with fans) rating only -- no self-cooled rating.
+
+    Previous designation (1993): FOA
+    """
+    OFWF = auto()
+    """Oil Forced Water Forced.
+
+    Forced oil/water cooled rating only (oil/water heat exchanger with oil and water pumps) -- no
+    self-cooled rating.
+
+    Previous designation (1993): FOW
+    """
+    ODAF = auto()
+    """Oil Direct Air Forced
+
+    Forced oil/air cooled rating only with directed oil flow pumps and fans -- no self-cooled rating.
+
+    Previous designation (1993): FOA
+    """
+    ODWF = auto()
+    """Oil Direct Water Forced
+
+    Forced oil/water cooled rating only (oil/water heat exchanger with directed oil flow pumps and
+    water pumps) --  no self-cooled rating.
+
+    Previous designation (1993): FOW
+    """

--- a/roseau/load_flow/utils/__init__.py
+++ b/roseau/load_flow/utils/__init__.py
@@ -11,7 +11,7 @@ from roseau.load_flow.utils.dtypes import (
     VoltagePhaseDtype,
 )
 from roseau.load_flow.utils.exceptions import find_stack_level
-from roseau.load_flow.utils.helpers import count_repr
+from roseau.load_flow.utils.helpers import CaseInsensitiveStrEnum, count_repr
 from roseau.load_flow.utils.log import set_logging_config
 from roseau.load_flow.utils.mixins import CatalogueMixin, Identifiable, JsonMixin
 from roseau.load_flow.utils.versions import show_versions
@@ -36,6 +36,8 @@ __all__ = [
     "set_logging_config",
     # General purpose
     "count_repr",
+    # Enums
+    "CaseInsensitiveStrEnum",
 ]
 
 

--- a/roseau/load_flow/utils/helpers.py
+++ b/roseau/load_flow/utils/helpers.py
@@ -1,5 +1,7 @@
 from collections.abc import Sized
 
+from roseau.load_flow._compat import StrEnum
+
 
 def count_repr(items: Sized, /, singular: str, plural: str | None = None) -> str:
     """Singular/plural count representation: `1 bus` or `2 buses`."""
@@ -7,3 +9,16 @@ def count_repr(items: Sized, /, singular: str, plural: str | None = None) -> str
     if n == 1:
         return f"{n} {singular}"
     return f"{n} {plural if plural is not None else singular + 's'}"
+
+
+class CaseInsensitiveStrEnum(StrEnum):
+    """A case-insensitive string enumeration."""
+
+    @classmethod
+    def _missing_(cls, value: object) -> object:
+        if isinstance(value, str):
+            try:
+                return cls[value.upper()]
+            except KeyError:
+                pass
+        return None


### PR DESCRIPTION
- Add French aliases to line enumeration types.
- Fix `TypeError`s in the `LineParameters.from_coiffier_model`. The error message of invalid models now indicates whether the line type or the conductor material is invalid.
- Add `TransformerCooling` enumeration. It is not currently used but the plan is to include it in the catalogue as this information is included in the catalogues we have.