### PR TITLE
Fix the vector group regex for rlfs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.16
+    rev: 0.5.18
     hooks:
       - id: uv-lock
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: [--fix]

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -81,8 +81,7 @@ class AbstractLoad(Element, ABC):
             missing_ok = phases_not_in_bus == {"n"} and len(phases) > 2 and not connect_neutral
             if phases_not_in_bus and not missing_ok:
                 msg = (
-                    f"Phases {sorted(phases_not_in_bus)} of load {id!r} are not in bus {bus.id!r} "
-                    f"phases {bus.phases!r}"
+                    f"Phases {sorted(phases_not_in_bus)} of load {id!r} are not in bus {bus.id!r} phases {bus.phases!r}"
                 )
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -146,8 +146,7 @@ def test_transformer_parameters():
     with pytest.raises(RoseauLoadFlowException) as e:
         TransformerParameters.from_dict(data)
     assert e.value.msg == (
-        "Transformer parameters 'test' has the low voltage higher than the high voltage: "
-        "uhv=350 V and ulv=400.0045 V."
+        "Transformer parameters 'test' has the low voltage higher than the high voltage: uhv=350 V and ulv=400.0045 V."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_VOLTAGES
 

--- a/roseau/load_flow/models/transformers/parameters.py
+++ b/roseau/load_flow/models/transformers/parameters.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
     """Parameters that define electrical models of transformers."""
 
+    # Power Transformers General specification can be found in IEC 60076-1
+
     # fmt: off
     allowed_vector_groups: Final = {
         # Three-phase
@@ -1128,11 +1130,11 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
                     value=f"{value / 1000:.1f} {display_unit}",
                     name=display_name,
                     name_plural=display_name_plural,
-                    strings=catalogue_data[column_name].apply(lambda x: f"{x/1000:.1f} {display_unit}"),  # noqa: B023
+                    strings=catalogue_data[column_name].apply(lambda x: f"{x / 1000:.1f} {display_unit}"),  # noqa: B023
                     query_msg_list=query_msg_list,
                 )
             catalogue_data = catalogue_data.loc[mask, :]
-            query_msg_list.append(f"{column_name}={value/1000:.1f} {display_unit}")
+            query_msg_list.append(f"{column_name}={value / 1000:.1f} {display_unit}")
 
         return catalogue_data, ", ".join(query_msg_list)
 
@@ -1338,7 +1340,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         Returns:
             The first winding, the second winding, and the phase displacement.
         """
-        match = re.fullmatch(r"^(?P<w1>(D|Yn?|Zn?|I))(?P<w2>(d|yn?|zn?|i|ii))(?P<p>(0|1|5|6|11))$", vg, flags=re.I)
+        match = re.fullmatch(r"^(?P<w1>(D|Yn?|Zn?|I))(?P<w2>(d|yn?|zn?|i|ii))(?P<p>\d{1,2})$", vg, flags=re.I)
         if match and vg.capitalize() in cls.allowed_vector_groups:
             groups = match.groupdict()
             winding1, winding2, phase_displacement = groups["w1"].upper(), groups["w2"].lower(), int(groups["p"])

--- a/scripts/update_catalogue_networks.py
+++ b/scripts/update_catalogue_networks.py
@@ -33,9 +33,9 @@ if __name__ == "__main__":
             for bus_id in sorted(en.buses):  # we need to sort to get MVLV bus before VoltageSource bus
                 assert isinstance(bus_id, str), repr(bus_id)
                 bus = en.buses[bus_id]
-                assert (
-                    bus.phases == "abcn" if bus_id == "VoltageSource" else PHASES[feeder_type]
-                ), f"{name=}, {bus_id=}, {bus.phases=}"
+                assert bus.phases == "abcn" if bus_id == "VoltageSource" else PHASES[feeder_type], (
+                    f"{name=}, {bus_id=}, {bus.phases=}"
+                )
                 bus_type = feeder_type
                 if (feeder_type == "LV" and bus_id.startswith("MVLV")) or (
                     feeder_type == "MV" and bus_id.startswith("HVMV")


### PR DESCRIPTION
In rlfs, we support more phase displacement variations.