### PR TITLE
Rename BaseClasses to AbstractClasses end export them

### DIFF
--- a/roseau/load_flow/__init__.py
+++ b/roseau/load_flow/__init__.py
@@ -25,7 +25,9 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.license import License, activate_license, deactivate_license, get_license
 from roseau.load_flow.models import (
     AbstractBranch,
+    AbstractConnectable,
     AbstractLoad,
+    AbstractTerminal,
     Bus,
     Control,
     CurrentLoad,
@@ -70,11 +72,13 @@ __all__ = [
     "ElectricalNetwork",
     # Buses
     "Bus",
-    # Core
+    # Core models
     "Element",
     "Ground",
     "PotentialRef",
     "AbstractBranch",
+    "AbstractTerminal",
+    "AbstractConnectable",
     # Lines
     "Switch",
     "Line",

--- a/roseau/load_flow/models/__init__.py
+++ b/roseau/load_flow/models/__init__.py
@@ -7,7 +7,7 @@ Equations, diagrams, and examples can be found in the :doc:`/models/index` page.
 
 from roseau.load_flow.models.branches import AbstractBranch
 from roseau.load_flow.models.buses import Bus
-from roseau.load_flow.models.connectables import BaseConnectable
+from roseau.load_flow.models.connectables import AbstractConnectable
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.models.grounds import Ground
 from roseau.load_flow.models.lines import Line, LineParameters
@@ -23,7 +23,7 @@ from roseau.load_flow.models.loads import (
 from roseau.load_flow.models.potential_refs import PotentialRef
 from roseau.load_flow.models.sources import VoltageSource
 from roseau.load_flow.models.switches import Switch
-from roseau.load_flow.models.terminals import BaseTerminal
+from roseau.load_flow.models.terminals import AbstractTerminal
 from roseau.load_flow.models.transformers import Transformer, TransformerParameters
 
 __all__ = [
@@ -32,8 +32,8 @@ __all__ = [
     "PotentialRef",
     "Ground",
     "AbstractBranch",
-    "BaseTerminal",
-    "BaseConnectable",
+    "AbstractTerminal",
+    "AbstractConnectable",
     # Buses
     "Bus",
     # Lines

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -11,7 +11,7 @@ from typing_extensions import Self, deprecated
 from roseau.load_flow.constants import SQRT3
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.core import Element
-from roseau.load_flow.models.terminals import BaseTerminal
+from roseau.load_flow.models.terminals import AbstractTerminal
 from roseau.load_flow.sym import phasor_to_sym
 from roseau.load_flow.typing import BoolArray, ComplexArray, ComplexArrayLike1D, FloatArray, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from roseau.load_flow.models.grounds import Ground
 
 
-class Bus(BaseTerminal[CyBus]):
+class Bus(AbstractTerminal[CyBus]):
     """A multi-phase electrical bus."""
 
     element_type: Final = "bus"

--- a/roseau/load_flow/models/connectables.py
+++ b/roseau/load_flow/models/connectables.py
@@ -9,20 +9,20 @@ from roseau.load_flow.converters import _calculate_voltages
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import _CyE_co
-from roseau.load_flow.models.terminals import BaseTerminal
+from roseau.load_flow.models.terminals import AbstractTerminal
 from roseau.load_flow.typing import ComplexArray, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
 
 logger = logging.getLogger(__name__)
 
 
-class BaseConnectable(BaseTerminal[_CyE_co], ABC):
+class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
     """A base class for connectable elements in the network (loads, sources, etc.)."""
 
     type: ClassVar[str]
 
     def __init__(self, id: Id, bus: Bus, *, phases: str | None = None, connect_neutral: bool | None = None) -> None:
-        """BaseConnectable constructor.
+        """AbstractConnectable constructor.
 
         Args:
             id:
@@ -45,8 +45,8 @@ class BaseConnectable(BaseTerminal[_CyE_co], ABC):
                 neutral. If the bus does not have a neutral, the element's neutral is left floating
                 by default. To override the default behavior, pass an explicit ``True`` or ``False``.
         """
-        if type(self) is BaseConnectable:
-            raise TypeError("Can't instantiate abstract class BaseConnectable")
+        if type(self) is AbstractConnectable:
+            raise TypeError("Can't instantiate abstract class AbstractConnectable")
 
         if phases is None:
             phases = bus.phases

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -7,7 +7,7 @@ from typing_extensions import TypeVar
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.buses import Bus
-from roseau.load_flow.models.connectables import BaseConnectable
+from roseau.load_flow.models.connectables import AbstractConnectable
 from roseau.load_flow.models.loads.flexible_parameters import FlexibleParameter
 from roseau.load_flow.typing import ComplexArray, ComplexScalarOrArrayLike1D, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 _CyL_co = TypeVar("_CyL_co", bound=CyLoad, default=CyLoad, covariant=True)
 
 
-class AbstractLoad(BaseConnectable[_CyL_co], ABC):
+class AbstractLoad(AbstractConnectable[_CyL_co], ABC):
     """An abstract class of an electric load.
 
     The subclasses of this class can be used to model:

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -6,7 +6,7 @@ from typing_extensions import Self
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.buses import Bus
-from roseau.load_flow.models.connectables import BaseConnectable
+from roseau.load_flow.models.connectables import AbstractConnectable
 from roseau.load_flow.sym import PositiveSequence
 from roseau.load_flow.typing import ComplexArray, ComplexScalarOrArrayLike1D, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
@@ -15,7 +15,7 @@ from roseau.load_flow_engine.cy_engine import CyDeltaVoltageSource, CyVoltageSou
 logger = logging.getLogger(__name__)
 
 
-class VoltageSource(BaseConnectable[CyVoltageSource | CyDeltaVoltageSource]):
+class VoltageSource(AbstractConnectable[CyVoltageSource | CyDeltaVoltageSource]):
     """A voltage source fixes the voltages on the phases of the bus it is connected to.
 
     The source can be connected in a wye or star configuration (i.e with a neutral) or in a delta

--- a/roseau/load_flow/models/terminals.py
+++ b/roseau/load_flow/models/terminals.py
@@ -13,7 +13,7 @@ from roseau.load_flow.units import Q_, ureg_wraps
 logger = logging.getLogger(__name__)
 
 
-class BaseTerminal(Element[_CyE_co], ABC):
+class AbstractTerminal(Element[_CyE_co], ABC):
     """A base class for all the terminals (buses, load, sources, etc.) of the network."""
 
     allowed_phases: Final = frozenset({"ab", "bc", "ca", "an", "bn", "cn", "abn", "bcn", "can", "abc", "abcn"})
@@ -25,7 +25,7 @@ class BaseTerminal(Element[_CyE_co], ABC):
     """
 
     def __init__(self, id: Id, *, phases: str) -> None:
-        """BaseTerminal constructor.
+        """AbstractTerminal constructor.
 
         Args:
             id:
@@ -36,8 +36,8 @@ class BaseTerminal(Element[_CyE_co], ABC):
                 phases is important. For a full list of supported phases, see the class attribute
                 :attr:`.allowed_phases`.
         """
-        if type(self) is BaseTerminal:
-            raise TypeError("Can't instantiate abstract class BaseTerminal")
+        if type(self) is AbstractTerminal:
+            raise TypeError("Can't instantiate abstract class AbstractTerminal")
 
         super().__init__(id)
         self._check_phases(id, phases=phases)

--- a/roseau/load_flow/plotting.py
+++ b/roseau/load_flow/plotting.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from roseau.load_flow.converters import _calculate_voltages
-from roseau.load_flow.models import AbstractBranch, BaseTerminal
+from roseau.load_flow.models import AbstractBranch, AbstractTerminal
 from roseau.load_flow.network import ElectricalNetwork
 from roseau.load_flow.sym import phasor_to_sym
 from roseau.load_flow.typing import Complex, ComplexArray, Float
@@ -78,9 +78,9 @@ def _draw_voltage_phasor(ax: "Axes", potential1: Complex, potential2: Complex, c
 
 
 def _get_phases_and_potentials(
-    element: BaseTerminal | AbstractBranch, side: Literal[1, 2, "HV", "LV"] | None
+    element: AbstractTerminal | AbstractBranch, side: Literal[1, 2, "HV", "LV"] | None
 ) -> tuple[str, ComplexArray]:
-    if isinstance(element, BaseTerminal):
+    if isinstance(element, AbstractTerminal):
         return element.phases, element.res_potentials.m
     if side in (1, "HV"):
         return element.phases1, element.res_potentials[0].m
@@ -97,7 +97,10 @@ def _get_phases_and_potentials(
 # Phasor plotting functions
 #
 def plot_voltage_phasors(
-    element: BaseTerminal | AbstractBranch, *, side: Literal[1, 2, "HV", "LV"] | None = None, ax: "Axes | None" = None
+    element: AbstractTerminal | AbstractBranch,
+    *,
+    side: Literal[1, 2, "HV", "LV"] | None = None,
+    ax: "Axes | None" = None,
 ) -> "Axes":
     """Plot the voltage phasors of a terminal element or a branch element.
 
@@ -149,7 +152,10 @@ def plot_voltage_phasors(
 
 
 def plot_symmetrical_voltages(
-    element: BaseTerminal | AbstractBranch, *, side: Literal[1, 2, "HV", "LV"] | None = None, ax: "Axes | None" = None
+    element: AbstractTerminal | AbstractBranch,
+    *,
+    side: Literal[1, 2, "HV", "LV"] | None = None,
+    ax: "Axes | None" = None,
 ) -> "Axes":
     """Plot the symmetrical voltages of a terminal element or a branch element.
 

--- a/roseau/load_flow_single/__init__.py
+++ b/roseau/load_flow_single/__init__.py
@@ -31,7 +31,9 @@ from roseau.load_flow import (
 from roseau.load_flow.units import Q_, ureg
 from roseau.load_flow_single.models import (
     AbstractBranch,
+    AbstractConnectable,
     AbstractLoad,
+    AbstractTerminal,
     Bus,
     Control,
     CurrentLoad,
@@ -77,6 +79,8 @@ __all__ = [
     "Projection",
     "Control",
     "AbstractBranch",
+    "AbstractTerminal",
+    "AbstractConnectable",
     # Other imports from RLF to have the same interface
     # utils
     "Insulator",

--- a/roseau/load_flow_single/models/__init__.py
+++ b/roseau/load_flow_single/models/__init__.py
@@ -1,7 +1,7 @@
 from roseau.load_flow import Projection
 from roseau.load_flow_single.models.branches import AbstractBranch
 from roseau.load_flow_single.models.buses import Bus
-from roseau.load_flow_single.models.connectables import BaseConnectable
+from roseau.load_flow_single.models.connectables import AbstractConnectable
 from roseau.load_flow_single.models.core import Element
 from roseau.load_flow_single.models.flexible_parameters import Control, FlexibleParameter
 from roseau.load_flow_single.models.line_parameters import LineParameters
@@ -9,7 +9,7 @@ from roseau.load_flow_single.models.lines import Line
 from roseau.load_flow_single.models.loads import AbstractLoad, CurrentLoad, ImpedanceLoad, PowerLoad
 from roseau.load_flow_single.models.sources import VoltageSource
 from roseau.load_flow_single.models.switches import Switch
-from roseau.load_flow_single.models.terminals import BaseTerminal
+from roseau.load_flow_single.models.terminals import AbstractTerminal
 from roseau.load_flow_single.models.transformer_parameters import TransformerParameters
 from roseau.load_flow_single.models.transformers import Transformer
 
@@ -17,8 +17,8 @@ __all__ = [
     # Core
     "Element",
     "AbstractBranch",
-    "BaseTerminal",
-    "BaseConnectable",
+    "AbstractTerminal",
+    "AbstractConnectable",
     # Buses
     "Bus",
     # Lines

--- a/roseau/load_flow_single/models/buses.py
+++ b/roseau/load_flow_single/models/buses.py
@@ -14,12 +14,12 @@ from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import find_stack_level
 from roseau.load_flow_engine.cy_engine import CyBus
 from roseau.load_flow_single.models.core import Element
-from roseau.load_flow_single.models.terminals import BaseTerminal
+from roseau.load_flow_single.models.terminals import AbstractTerminal
 
 logger = logging.getLogger(__name__)
 
 
-class Bus(BaseTerminal[CyBus]):
+class Bus(AbstractTerminal[CyBus]):
     """An electrical bus."""
 
     element_type: Final = "bus"

--- a/roseau/load_flow_single/models/connectables.py
+++ b/roseau/load_flow_single/models/connectables.py
@@ -7,18 +7,18 @@ from roseau.load_flow.typing import Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow_single.models.buses import Bus
 from roseau.load_flow_single.models.core import _CyE_co
-from roseau.load_flow_single.models.terminals import BaseTerminal
+from roseau.load_flow_single.models.terminals import AbstractTerminal
 
 logger = logging.getLogger(__name__)
 
 
-class BaseConnectable(BaseTerminal[_CyE_co], ABC):
+class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
     """A base class for connectable elements in the network (loads, sources, etc.)."""
 
     type: ClassVar[str]
 
     def __init__(self, id: Id, bus: Bus) -> None:
-        """BaseConnectable constructor.
+        """AbstractConnectable constructor.
 
         Args:
             id:
@@ -27,8 +27,8 @@ class BaseConnectable(BaseTerminal[_CyE_co], ABC):
             bus:
                 The bus to connect the element to.
         """
-        if type(self) is BaseConnectable:
-            raise TypeError("Can't instantiate abstract class BaseConnectable")
+        if type(self) is AbstractConnectable:
+            raise TypeError("Can't instantiate abstract class AbstractConnectable")
         super().__init__(id)
         self._connect(bus)
         self._bus = bus

--- a/roseau/load_flow_single/models/loads.py
+++ b/roseau/load_flow_single/models/loads.py
@@ -10,7 +10,7 @@ from roseau.load_flow.typing import Complex, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow_engine.cy_engine import CyAdmittanceLoad, CyCurrentLoad, CyFlexibleLoad, CyLoad, CyPowerLoad
 from roseau.load_flow_single.models.buses import Bus
-from roseau.load_flow_single.models.connectables import BaseConnectable
+from roseau.load_flow_single.models.connectables import AbstractConnectable
 from roseau.load_flow_single.models.flexible_parameters import FlexibleParameter
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 _CyL_co = TypeVar("_CyL_co", bound=CyLoad, default=CyLoad, covariant=True)
 
 
-class AbstractLoad(BaseConnectable[_CyL_co], ABC):
+class AbstractLoad(AbstractConnectable[_CyL_co], ABC):
     """An abstract class of an electric load."""
 
     element_type: Final = "load"

--- a/roseau/load_flow_single/models/sources.py
+++ b/roseau/load_flow_single/models/sources.py
@@ -9,12 +9,12 @@ from roseau.load_flow.typing import Complex, Id, JsonDict
 from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow_engine.cy_engine import CyVoltageSource
 from roseau.load_flow_single.models.buses import Bus
-from roseau.load_flow_single.models.connectables import BaseConnectable
+from roseau.load_flow_single.models.connectables import AbstractConnectable
 
 logger = logging.getLogger(__name__)
 
 
-class VoltageSource(BaseConnectable[CyVoltageSource]):
+class VoltageSource(AbstractConnectable[CyVoltageSource]):
     """A voltage source fixes the voltages of the bus it is connected to.
 
     See Also:

--- a/roseau/load_flow_single/models/terminals.py
+++ b/roseau/load_flow_single/models/terminals.py
@@ -9,18 +9,18 @@ from roseau.load_flow_single.models.core import Element, _CyE_co
 logger = logging.getLogger(__name__)
 
 
-class BaseTerminal(Element[_CyE_co], ABC):
+class AbstractTerminal(Element[_CyE_co], ABC):
     """A base class for all the terminals (buses, load, sources, etc.) of the network."""
 
     def __init__(self, id: Id) -> None:
-        """BaseTerminal constructor.
+        """AbstractTerminal constructor.
 
         Args:
             id:
                 A unique ID of the terminal in its dictionary of the network.
         """
-        if type(self) is BaseTerminal:
-            raise TypeError("Can't instantiate abstract class BaseTerminal")
+        if type(self) is AbstractTerminal:
+            raise TypeError("Can't instantiate abstract class AbstractTerminal")
         super().__init__(id)
         self._n = 2
         self._res_voltage: complex | None = None


### PR DESCRIPTION
For consistency with `AbstractBranch` and `AbstractLoad`