### PR TITLE
[single] Fix segfault when adding a shunt line to existing network

### DIFF
--- a/roseau/load_flow_single/models/branches.py
+++ b/roseau/load_flow_single/models/branches.py
@@ -50,7 +50,6 @@ class AbstractBranch(Element[_CyB_co]):
         self._bus2 = bus2
         self._n = n
         self.geometry = self._check_geometry(geometry)
-        self._connect(bus1, bus2)
         self._res_currents: tuple[complex, complex] | None = None
         self._res_voltages: tuple[complex, complex] | None = None
         self._sides_suffixes = ("_hv", "_lv") if self.element_type == "transformer" else ("1", "2")

--- a/roseau/load_flow_single/models/lines.py
+++ b/roseau/load_flow_single/models/lines.py
@@ -82,6 +82,7 @@ class Line(AbstractBranch[CyShuntLine | CySimplifiedLine]):
         else:
             self._cy_element = CySimplifiedLine(n=1, z_line=np.array([self._z_line], dtype=np.complex128))
         self._cy_connect()
+        self._connect(bus1, bus2)
 
     def _update_internal_parameters(self) -> None:
         """Update the internal parameters of the line."""

--- a/roseau/load_flow_single/models/switches.py
+++ b/roseau/load_flow_single/models/switches.py
@@ -41,6 +41,7 @@ class Switch(AbstractBranch[CySwitch]):
         self._check_same_voltage_level()
         self._cy_element = CySwitch(1)
         self._cy_connect()
+        self._connect(bus1, bus2)
 
     def _check_loop(self) -> None:
         """Check that there are no switch loops, raise an exception if it is the case."""

--- a/roseau/load_flow_single/models/transformers.py
+++ b/roseau/load_flow_single/models/transformers.py
@@ -75,6 +75,7 @@ class Transformer(AbstractBranch[CySingleTransformer]):
 
         self._cy_element = CySingleTransformer(z2=z2, ym=ym, k=k * self._tap)
         self._cy_connect()
+        self._connect(bus_hv, bus_lv)
 
     @property
     def bus_hv(self) -> Bus:

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -1320,3 +1320,13 @@ def test_results_to_json(small_network_with_results, tmp_path):
         res_network = json.load(fp)
 
     assert_json_close(res_network, res_network_expected)
+
+
+def test_add_shunt_line_to_existing_network_no_segfault():
+    # https://github.com/RoseauTechnologies/Roseau_Load_Flow/issues/346
+    bus = Bus("Bus")
+    VoltageSource("Source", bus=bus, voltage=20e3)
+    ElectricalNetwork.from_element(bus)
+    bus_new = Bus("New Bus")
+    lp = LineParameters("LP with shunt", z_line=0.1 + 0.1j, y_shunt=0.01j)
+    Line("New Line", bus1=bus, bus2=bus_new, parameters=lp, length=0.1)  # <- used to segfault here


### PR DESCRIPTION
Turns out the fix was simple: defer the connection to the network until the element initialization is finished.
Fixes #346 