### PR TITLE
Improve the support of the network CRS

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -23,24 +23,27 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 - The following columns have been renamed in `ElectricalNetwork.transformers_frame`:
 
-  - `bus1_id` -> `bus_hv_id`
-  - `bus2_id` -> `bus_lv_id`
-  - `phases1` -> `phases_hv`
-  - `phases2` -> `phases_lv`
+  - `bus1_id`, `bus2_id` -> `bus_hv_id`, `bus_lv_id`
+  - `phases1`, `phases2` -> `phases_hv`, `phases_lv`
 
   and the following columns have been renamed in `ElectricalNetwork.res_transformers`:
 
-  - `current1` -> `current_hv`
-  - `current2` -> `current_lv`
-  - `potential1` -> `potential_hv`
-  - `potential2` -> `potential_lv`
-  - `voltage1` -> `voltage_hv`
-  - `voltage2` -> `voltage_lv`
-  - `power1` -> `power_hv`
-  - `power2` -> `power_lv`
+  - `current1`, `current2` -> `current_hv`, `current_lv`
+  - `potential1`, `potential2` -> `potential_hv`, `potential_lv`
+  - `voltage1`, `voltage2` -> `voltage_hv`, `voltage_lv`
+  - `power1`, `power2` -> `power_hv`, `power_lv`
+
+- The `ElectricalNetwork.crs` now defaults to `None` (no CRS) instead of `"EPSG:4326"`. The attribute
+  is also no longer normalized to a `pyproj.CRS` object but is stored as is. Use `CRS(en.crs)` to
+  always get a `pyproj.CRS` object.
 
 ### Detailed changes
 
+- {gh-pr}`351` {gh-issue}`332` Improved support of the network's Coordinate Reference System (CRS).
+  - The `CRS` will now default to `None` (no CRS) instead of `"EPSG:4326"` if not provided.
+  - The `ElectricalNetwork.crs` attribute is no longer normalized to a `pyproj.CRS` object.
+  - The `CRS` can be set when creating a network with the `ElectricalNetwork.from_element` method.
+  - The `CRS` is now correctly stored in the JSON file and is read when loading the network.
 - {gh-pr}`350` {gh-issue}`349` Fix invalid transformer parameters with no leakage inductance when
   created from open and short circuit tests.
 - {gh-pr}`348` The load classes have two new properties: `res_inner_currents` and `res_inner_powers`.

--- a/roseau/load_flow/io/common.py
+++ b/roseau/load_flow/io/common.py
@@ -11,7 +11,7 @@ from roseau.load_flow.models import (
     Transformer,
     VoltageSource,
 )
-from roseau.load_flow.typing import Id
+from roseau.load_flow.typing import CRSLike, Id
 
 
 @final
@@ -27,3 +27,4 @@ class NetworkElements(TypedDict):
     grounds: dict[Id, Ground]
     potential_refs: dict[Id, PotentialRef]
     ground_connections: dict[Id, GroundConnection]
+    crs: CRSLike | None

--- a/roseau/load_flow/io/dgs/__init__.py
+++ b/roseau/load_flow/io/dgs/__init__.py
@@ -179,6 +179,7 @@ def network_from_dgs(filename: StrPath, use_name_as_id: bool = False) -> Network
         "grounds": grounds,
         "potential_refs": potential_refs,
         "ground_connections": ground_connections,
+        "crs": None,  # TODO check if the CRS can be stored in the DGS file
     }
 
 

--- a/roseau/load_flow/typing.py
+++ b/roseau/load_flow/typing.py
@@ -85,6 +85,12 @@ Union Input Types (Wide)
 
     A scalar or a 1D array-like of floating numbers or a quantity thereof.
 
+.. class:: CRSLike
+
+    Any type accepted by :class:`pyproj.CRS`. This can be a string (PROJ, JSON WKT, authority),
+    an integer (EPSG code), a dictionary (PROJ parameters), a tuple (authority name and code), an
+    object with a `to_wkt` method, or a CRS class.
+
 Numpy Output Types (Narrow)
 ---------------------------
 
@@ -111,14 +117,20 @@ Numpy Output Types (Narrow)
 
 import os
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, TypeAlias, TypeVar
+from typing import Any, Literal, Protocol, TypeAlias, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
+from pyproj import CRS
 
 from roseau.load_flow.units import Q_
 
 T = TypeVar("T", bound=Any)
+
+
+class _SupportsToWkt(Protocol):
+    def to_wkt(self) -> str: ...
+
 
 # RLF Helpers
 Id: TypeAlias = int | str
@@ -144,6 +156,24 @@ ComplexArrayLike2D: TypeAlias = (
 )
 FloatArrayLike1D: TypeAlias = QtyOrMag[NDArray[np.floating | np.integer] | Sequence[Float]] | Sequence[QtyOrMag[Float]]
 FloatScalarOrArrayLike1D: TypeAlias = FloatArrayLike1D | QtyOrMag[Float]
+CRSLike: TypeAlias = (
+    # The following are documented in the pyproj.CRS class
+    # - PROJ string
+    # - JSON string with PROJ parameters
+    # - CRS WKT string
+    # - An authority string [i.e. 'epsg:4326']
+    str
+    # - An EPSG integer code [i.e. 4326]
+    | int
+    # - Dictionary of PROJ parameters
+    | dict[str, Any]
+    # - A tuple of ("auth_name": "auth_code") [i.e ('epsg', '4326')]
+    | tuple[str, str]
+    # - An object with a `to_wkt` method
+    | _SupportsToWkt
+    # - A CRS class
+    | CRS
+)
 
 # Numpy Output Types (Narrow)
 ComplexMatrix: TypeAlias = np.ndarray[tuple[int, int], np.dtype[np.complex128]]  # 2D
@@ -173,6 +203,7 @@ __all__ = [
     "FloatArrayLike1D",
     "ComplexScalarOrArrayLike1D",
     "FloatScalarOrArrayLike1D",
+    "CRSLike",
     # Numpy narrow output types
     "BoolArray",
     "FloatArray",

--- a/roseau/load_flow/typing.py
+++ b/roseau/load_flow/typing.py
@@ -87,7 +87,7 @@ Union Input Types (Wide)
 
 .. class:: CRSLike
 
-    Any type accepted by :class:`pyproj.CRS`. This can be a string (PROJ, JSON WKT, authority),
+    Any type accepted by :class:`pyproj.CRS`. This can be a string (PROJ, JSON, WKT, authority),
     an integer (EPSG code), a dictionary (PROJ parameters), a tuple (authority name and code), an
     object with a `to_wkt` method, or a CRS class.
 

--- a/roseau/load_flow_single/io/common.py
+++ b/roseau/load_flow_single/io/common.py
@@ -1,6 +1,6 @@
 from typing import TypedDict, final
 
-from roseau.load_flow.typing import Id
+from roseau.load_flow.typing import CRSLike, Id
 from roseau.load_flow_single.models import AbstractLoad, Bus, Line, Switch, Transformer, VoltageSource
 
 
@@ -14,3 +14,4 @@ class NetworkElements(TypedDict):
     lines: dict[Id, Line]
     transformers: dict[Id, Transformer]
     switches: dict[Id, Switch]
+    crs: CRSLike | None

--- a/roseau/load_flow_single/io/dgs/__init__.py
+++ b/roseau/load_flow_single/io/dgs/__init__.py
@@ -167,6 +167,7 @@ def network_from_dgs(data: Mapping[str, Any], /, use_name_as_id: bool = False) -
         "switches": switches,
         "loads": loads,
         "sources": sources,
+        "crs": None,  # TODO check if the CRS can be stored in the DGS file
     }
 
 
@@ -273,4 +274,5 @@ def network_to_dgs(en: "ElectricalNetwork") -> JsonDict:
         "ElmTr2": elm_tr2,
         "ElmXnet": elm_xnet,
         "ElmLod": elm_lod,
+        # TODO check if the CRS can be stored in the DGS file
     }


### PR DESCRIPTION
Fixes #332 

- The `CRS` will now default to `None` (no CRS) instead of `"EPSG:4326"` if not provided.
- The `ElectricalNetwork.crs` attribute is no longer normalized to a `pyproj.CRS` object.
- The `CRS` can be set when creating a network with the `ElectricalNetwork.from_element` method.
- The `CRS` is now correctly stored in the JSON file and is read when loading the network.