### PR TITLE
[single] Return scalar results as Python objects

### DIFF
--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -331,7 +331,7 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
     #
     def _refresh_results(self) -> None:
         if self._fetch_results:
-            self._res_current = self._cy_element.get_currents(n1=1, n2=1)[0][0]
+            self._res_current = self._cy_element.get_currents(n1=1, n2=1)[0].item()
 
     def _res_current_getter(self, warning: bool) -> complex:
         self._refresh_results()

--- a/roseau/load_flow_single/models/branches.py
+++ b/roseau/load_flow_single/models/branches.py
@@ -109,10 +109,10 @@ class AbstractBranch(Element[_CyB_co]):
     #
     def _refresh_results(self) -> None:
         if self._fetch_results:
-            current1, current2 = self._cy_element.get_currents(1, 1)
-            potential1, potential2 = self._cy_element.get_potentials(1, 1)
-            self._res_currents = current1[0], current2[0]
-            self._res_voltages = potential1[0] * SQRT3, potential2[0] * SQRT3
+            currents1, currents2 = self._cy_element.get_currents(1, 1)
+            potentials1, potentials2 = self._cy_element.get_potentials(1, 1)
+            self._res_currents = currents1.item(0), currents2.item(0)
+            self._res_voltages = potentials1.item(0) * SQRT3, potentials2.item(0) * SQRT3
 
     def _res_currents_getter(self, warning: bool) -> tuple[complex, complex]:
         self._refresh_results()

--- a/roseau/load_flow_single/models/connectables.py
+++ b/roseau/load_flow_single/models/connectables.py
@@ -54,7 +54,7 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
     def _refresh_results(self) -> None:
         if self._fetch_results:
             super()._refresh_results()
-            self._res_current = self._cy_element.get_currents(self._n)[0]
+            self._res_current = self._cy_element.get_currents(self._n).item(0)
 
     def _res_current_getter(self, warning: bool) -> complex:
         self._refresh_results()

--- a/roseau/load_flow_single/models/terminals.py
+++ b/roseau/load_flow_single/models/terminals.py
@@ -30,7 +30,7 @@ class AbstractTerminal(Element[_CyE_co], ABC):
     #
     def _refresh_results(self) -> None:
         if self._fetch_results:
-            self._res_voltage = self._cy_element.get_potentials(self._n)[0] * SQRT3
+            self._res_voltage = self._cy_element.get_potentials(self._n).item(0) * SQRT3
 
     def _res_voltage_getter(self, warning: bool) -> complex:
         self._refresh_results()


### PR DESCRIPTION
This is a purely cosmetic change to improve the readability of the results so that when we introspect the results in an interactive console like a notebook cell we see something like `(-43.17581696+81.68999335j)` instead of `np.complex128(-43.17581696+81.68999335j)` which is even more annoying when seen in the dict of a network. Performance is not affected by this change.