### PR TITLE
Deprecate forgotten transformer properties from last release

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,9 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`371` Deprecate `Transformer.res_voltage_hv` and `Transformer.res_voltage_lv` properties
+  added in the last release by mistake. A simpler interface will be added later as described in
+  {gh-issue}`344`.
 - {gh-pr}`369` Add `Line.res_ground_potential` property to get the potential of the ground port of
   lines with shunt components. Update JSON file format to version 5 to store this information. Files
   created with previous versions of Roseau Load Flow will still be readable and will warn on loading.

--- a/roseau/load_flow/models/transformers/transformers.py
+++ b/roseau/load_flow/models/transformers/transformers.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from typing import Final
 
 from shapely.geometry.base import BaseGeometry
+from typing_extensions import deprecated
 
 from roseau.load_flow.converters import _calculate_voltages
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
@@ -433,14 +434,16 @@ class Transformer(AbstractBranch[CyTransformer]):
         loading = self._res_loading_getter(warning=True)
         return bool(loading > self._max_loading)
 
-    @property
+    @property  # TODO remove in version 0.14
+    @deprecated("`res_voltages_hv` will be removed in the next release, use `res_voltages[0]` instead")
     @ureg_wraps("V", (None,))
     def res_voltages_hv(self) -> Q_[ComplexArray]:
         """The load flow result of the transformer voltages on the HV side (V)."""
         potentials_hv = self._res_potentials_getter(warning=True)[0]
         return _calculate_voltages(potentials=potentials_hv, phases=self.phases_hv)
 
-    @property
+    @property  # TODO remove in version 0.14
+    @deprecated("`res_voltages_lv` will be removed in the next release, use `res_voltages[1]` instead")
     @ureg_wraps("V", (None,))
     def res_voltages_lv(self) -> Q_[ComplexArray]:
         """The load flow result of the transformer voltages on the LV side (V)."""


### PR DESCRIPTION
Fixes an oversight in #345