### PR TITLE
[single] Performance improvements

### DIFF
--- a/roseau/load_flow/models/core.py
+++ b/roseau/load_flow/models/core.py
@@ -105,7 +105,7 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
 
         # Recursively call this method to the elements connected to self
         for e in self._connected_elements:
-            if e.network == value:
+            if e._network == value:
                 continue
             else:
                 # Recursive call
@@ -119,11 +119,11 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
                 The elements to connect to self.
         """
         # Get the common network. May raise exception
-        network = self.network
+        network = self._network
         for element in elements:
             if network is None:
-                network = element.network
-            elif element.network is not None and element.network != network:
+                network = element._network
+            elif element._network is not None and element._network != network:
                 element._raise_several_network()
 
         # Modify objects. Append to the connected_elements
@@ -150,8 +150,8 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
 
     def _invalidate_network_results(self) -> None:
         """Invalidate the network making the result"""
-        if self.network is not None:
-            self.network._results_valid = False
+        if self._network is not None:
+            self._network._results_valid = False
 
     @abstractmethod
     def _refresh_results(self) -> None:
@@ -178,7 +178,7 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
             )
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.LOAD_FLOW_NOT_RUN)
-        if warning and self.network is not None and not self.network._results_valid:
+        if warning and self._network is not None and not self._network._results_valid:
             warnings.warn(
                 message=(
                     f"The results of {type(self).__name__} {self.id!r} may be outdated. Please re-run a load flow to "

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -94,7 +94,7 @@ class Ground(Element[CyGround]):
     #
     def _refresh_results(self) -> None:
         if self._fetch_results:
-            self._res_potential = self._cy_element.get_potentials(n=1).item()
+            self._res_potential = self._cy_element.get_port_potential(0)
 
     def _res_potential_getter(self, warning: bool) -> complex:
         self._refresh_results()
@@ -337,7 +337,7 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
     #
     def _refresh_results(self) -> None:
         if self._fetch_results:
-            self._res_current = self._cy_element.get_currents(n=1).item()
+            self._res_current = self._cy_element.get_port_current(0)
 
     def _res_current_getter(self, warning: bool) -> complex:
         self._refresh_results()

--- a/roseau/load_flow_single/models/branches.py
+++ b/roseau/load_flow_single/models/branches.py
@@ -1,8 +1,8 @@
 import logging
+import math
 import warnings
 from typing import Self
 
-import numpy as np
 from shapely.geometry.base import BaseGeometry
 from typing_extensions import TypeVar
 
@@ -83,7 +83,7 @@ class AbstractBranch(Element[_CyB_co]):
         if (
             self.bus1._nominal_voltage is not None
             and self.bus2._nominal_voltage is not None
-            and not np.isclose(self.bus1._nominal_voltage, self.bus2._nominal_voltage)
+            and not math.isclose(self.bus1._nominal_voltage, self.bus2._nominal_voltage)
         ):
             warnings.warn(
                 (
@@ -109,10 +109,14 @@ class AbstractBranch(Element[_CyB_co]):
     #
     def _refresh_results(self) -> None:
         if self._fetch_results:
-            currents1, currents2 = self._cy_element.get_side_currents(1, 1)
-            potentials1, potentials2 = self._cy_element.get_side_potentials(1, 1)
-            self._res_currents = currents1.item(0), currents2.item(0)
-            self._res_voltages = potentials1.item(0) * SQRT3, potentials2.item(0) * SQRT3
+            self._res_currents = (
+                self._cy_element.get_port_current(0),
+                self._cy_element.get_port_current(self._n),
+            )
+            self._res_voltages = (
+                self._cy_element.get_port_potential(0) * SQRT3,
+                self._cy_element.get_port_potential(self._n) * SQRT3,
+            )
 
     def _res_currents_getter(self, warning: bool) -> tuple[complex, complex]:
         self._refresh_results()

--- a/roseau/load_flow_single/models/buses.py
+++ b/roseau/load_flow_single/models/buses.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import warnings
 from collections.abc import Iterator
 from typing import Final, Self
@@ -272,7 +273,7 @@ class Bus(AbstractTerminal[CyBus]):
                     force
                     or self._nominal_voltage is None
                     or element._nominal_voltage is None
-                    or np.isclose(element._nominal_voltage, self._nominal_voltage)
+                    or math.isclose(element._nominal_voltage, self._nominal_voltage)
                 ):
                     msg = (
                         f"Cannot propagate the nominal voltage ({self._nominal_voltage} V) of bus {self.id!r} "
@@ -284,7 +285,7 @@ class Bus(AbstractTerminal[CyBus]):
                     force
                     or self._min_voltage_level is None
                     or element._min_voltage_level is None
-                    or np.isclose(element._min_voltage_level, self._min_voltage_level)
+                    or math.isclose(element._min_voltage_level, self._min_voltage_level)
                 ):
                     msg = (
                         f"Cannot propagate the minimum voltage level ({self._min_voltage_level}) of bus {self.id!r} "
@@ -296,7 +297,7 @@ class Bus(AbstractTerminal[CyBus]):
                     force
                     or self._max_voltage_level is None
                     or element._max_voltage_level is None
-                    or np.isclose(element._max_voltage_level, self._max_voltage_level)
+                    or math.isclose(element._max_voltage_level, self._max_voltage_level)
                 ):
                     msg = (
                         f"Cannot propagate the maximum voltage level ({self._max_voltage_level}) of bus {self.id!r} "

--- a/roseau/load_flow_single/models/connectables.py
+++ b/roseau/load_flow_single/models/connectables.py
@@ -54,7 +54,7 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
     def _refresh_results(self) -> None:
         if self._fetch_results:
             super()._refresh_results()
-            self._res_current = self._cy_element.get_currents(self._n).item(0)
+            self._res_current = self._cy_element.get_port_current(0)
 
     def _res_current_getter(self, warning: bool) -> complex:
         self._refresh_results()

--- a/roseau/load_flow_single/models/core.py
+++ b/roseau/load_flow_single/models/core.py
@@ -56,8 +56,10 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
         return self._network
 
     def _set_network(self, value: "ElectricalNetwork | None") -> None:
-        """Network setter with the ability to set the network to `None`. This method must not be exposed through a
-        traditional public setter. It is internally used in the `_connect` and `_disconnect` methods.
+        """Network setter with the ability to set the network to `None`.
+
+        This method must not be exposed through a traditional public setter. It is internally used
+        in the `_connect` and `_disconnect` methods.
 
         Args:
             value:
@@ -83,7 +85,7 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
 
         # Recursively call this method to the elements connected to self
         for e in self._connected_elements:
-            if e.network == value:
+            if e._network == value:
                 continue
             else:
                 # Recursive call
@@ -97,11 +99,11 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
                 The elements to connect to self.
         """
         # Get the common network. May raise exception
-        network = self.network
+        network = self._network
         for element in elements:
             if network is None:
-                network = element.network
-            elif element.network is not None and element.network != network:
+                network = element._network
+            elif element._network is not None and element._network != network:
                 element._raise_several_network()
 
         # Modify objects. Append to the connected_elements
@@ -128,8 +130,8 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
 
     def _invalidate_network_results(self) -> None:
         """Invalidate the network making the result"""
-        if self.network is not None:
-            self.network._results_valid = False
+        if self._network is not None:
+            self._network._results_valid = False
 
     @abstractmethod
     def _refresh_results(self) -> None:
@@ -156,7 +158,7 @@ class Element(ABC, Identifiable, JsonMixin, Generic[_CyE_co]):
             )
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.LOAD_FLOW_NOT_RUN)
-        if warning and self.network is not None and not self.network._results_valid:
+        if warning and self._network is not None and not self._network._results_valid:
             warnings.warn(
                 message=(
                     f"The results of {type(self).__name__} {self.id!r} may be outdated. Please re-run a load flow to "

--- a/roseau/load_flow_single/models/line_parameters.py
+++ b/roseau/load_flow_single/models/line_parameters.py
@@ -1,3 +1,4 @@
+import cmath
 import logging
 import re
 from enum import StrEnum
@@ -81,7 +82,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             self._with_shunt = False
         else:
             self._y_shunt = self._check_value(id=id, value=y_shunt, name="y_shunt")
-            self._with_shunt = bool(not np.isclose(self._y_shunt, 0))
+            self._with_shunt = not cmath.isclose(self._y_shunt, 0)
 
         # Parameters that are not used in the load flow
         self.line_type = line_type
@@ -855,7 +856,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode[f"BAD_{name.upper()}_VALUE"])
 
         # Ensure that z_line is not 0
-        if name == "z_line" and np.isclose(value, 0):
+        if name == "z_line" and cmath.isclose(value, 0):
             msg = f"The z_line value of line type {id!r} can't be zero."
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_Z_LINE_VALUE)

--- a/roseau/load_flow_single/models/terminals.py
+++ b/roseau/load_flow_single/models/terminals.py
@@ -30,7 +30,7 @@ class AbstractTerminal(Element[_CyE_co], ABC):
     #
     def _refresh_results(self) -> None:
         if self._fetch_results:
-            self._res_voltage = self._cy_element.get_potentials(self._n).item(0) * SQRT3
+            self._res_voltage = self._cy_element.get_port_potential(0) * SQRT3
 
     def _res_voltage_getter(self, warning: bool) -> complex:
         self._refresh_results()

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -993,15 +993,13 @@ class ElectricalNetwork(JsonMixin):
 
     def _get_starting_voltage(self) -> tuple[complex, VoltageSource]:
         """Compute initial voltages from the voltage sources of the network, get also the starting source."""
-        starting_source = None
-        initial_voltage = None
-        # if there are multiple voltage sources, start from the higher one (the last one in the sorted below)
-        for source in sorted(self.sources.values(), key=lambda x: np.average(np.abs(x._voltage))):
-            source_voltage = source._voltage
-            starting_source = source
-            initial_voltage = source_voltage
-
-        return initial_voltage, starting_source
+        sources = iter(self.sources.values())
+        starting_source = next(sources)
+        # if there are multiple voltage sources, start from the one with the highest voltage
+        for source in sources:
+            if abs(source._voltage) > abs(starting_source._voltage):
+                starting_source = source
+        return starting_source._voltage, starting_source
 
     #
     # Network saving/loading


### PR DESCRIPTION
Use faster methods to get scalar C++ results and a few minor improvements. This makes hosting capacity calculation from 25% faster for small networks to 300% faster for larger networks.