### PR TITLE
Simplify code with Python 3.11+ idioms

### DIFF
--- a/roseau/load_flow/io/tests/test_dgs.py
+++ b/roseau/load_flow/io/tests/test_dgs.py
@@ -115,8 +115,7 @@ def test_dgs_switches(dgs_special_networks_dir, tmp_path):
     path = dgs_special_networks_dir / "Switch.json"
     good_json = json.loads(path.read_bytes())
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         en = ElectricalNetwork.from_dgs_file(path)
 
     assert len(en.switches) == 1

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -185,8 +185,7 @@ def test_all_converters():
     dict_v0 = json.loads(read_json_file("network_json_v0.json"))
     net_dict = en.to_dict(include_results=False)
     expected_dict = copy.deepcopy(dict_v0)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         expected_dict = v0_to_v1_converter(expected_dict)
         expected_dict = v1_to_v2_converter(expected_dict)
         expected_dict = v2_to_v3_converter(expected_dict)
@@ -203,8 +202,7 @@ def test_from_dict_v0():
         ignore_unmatched_warnings(warn_check)
     net_dict = en.to_dict(include_results=False)
     expected_dict = copy.deepcopy(dict_v0)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         expected_dict = v0_to_v1_converter(expected_dict)
         expected_dict = v1_to_v2_converter(expected_dict)
         expected_dict = v2_to_v3_converter(expected_dict)
@@ -221,8 +219,7 @@ def test_from_dict_v1():
         ignore_unmatched_warnings(warn_check)
     net_dict = en.to_dict(include_results=True)
     expected_dict = copy.deepcopy(dict_v1)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         expected_dict = v1_to_v2_converter(expected_dict)
         expected_dict = v2_to_v3_converter(expected_dict)
         expected_dict = v3_to_v4_converter(expected_dict)
@@ -230,8 +227,7 @@ def test_from_dict_v1():
     assert_json_close(net_dict, expected_dict)
 
     # Test with `include_results=False`
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         net = ElectricalNetwork.from_dict(data=dict_v1, include_results=False)
         net_dict = net.to_dict(include_results=False)
         expected_dict_no_results = copy.deepcopy(dict_v1)
@@ -260,8 +256,7 @@ def test_from_dict_v2():
         en = ElectricalNetwork.from_dict(data=dict_v2, include_results=True)
     net_dict = en.to_dict(include_results=True)
     expected_dict = copy.deepcopy(dict_v2)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         expected_dict = v2_to_v3_converter(expected_dict)
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
@@ -281,8 +276,7 @@ def test_from_dict_v3():
         en = ElectricalNetwork.from_dict(data=dict_v3, include_results=True)
     net_dict = en.to_dict(include_results=True)
     expected_dict = copy.deepcopy(dict_v3)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
 

--- a/roseau/load_flow/models/tests/test_branches.py
+++ b/roseau/load_flow/models/tests/test_branches.py
@@ -22,8 +22,7 @@ def test_different_voltage_levels():
     bus3 = Bus(id="bus3", phases="abc")
     bus4 = Bus(id="bus4", phases="abc", nominal_voltage=400)
     lp = LineParameters(id="lp", z_line=np.eye(3, dtype=complex))
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with warnings.catch_warnings(action="error"):
         Line(id="ln good", bus1=bus1, bus2=bus2, parameters=lp, length=0.1)  # OK
         Line(id="ln good2", bus1=bus1, bus2=bus3, parameters=lp, length=0.1)  # OK
         Switch(id="sw good", bus1=bus1, bus2=bus2)  # OK

--- a/roseau/load_flow/plotting.py
+++ b/roseau/load_flow/plotting.py
@@ -301,10 +301,11 @@ def plot_interactive_map(
     try:
         import folium
     except ImportError as e:
-        raise ImportError(
+        e.add_note(
             "The `folium` library is required when using `roseau.load_flow.plotting.plot_interactive_map`."
             "Install it with `pip install folium`."
-        ) from e
+        )
+        raise
 
     map_kws = dict(map_kws) if map_kws is not None else {}
 

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -1911,8 +1911,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     reset_inputs_called = False
     assert small_network._valid
     assert not small_network._results_valid  # Results are not valid by default
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert not propagate_voltages_called  # Is not called because it was already called in the constructor
     assert not reset_inputs_called
@@ -1922,8 +1921,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     reset_inputs_called = False
     assert small_network._valid
     assert small_network._results_valid
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=False)
     assert not propagate_voltages_called
     assert reset_inputs_called
@@ -1933,8 +1931,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     reset_inputs_called = False
     assert small_network._valid
     assert small_network._results_valid
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert not propagate_voltages_called
     assert not reset_inputs_called
@@ -1945,8 +1942,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     load.powers = load.powers + Q_(1 + 1j, "VA")
     assert small_network._valid
     assert not small_network._results_valid
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert not propagate_voltages_called
     assert not reset_inputs_called
@@ -1958,10 +1954,9 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     assert new_load.network is small_network
     assert not small_network._valid
     assert not small_network._results_valid
-    with warnings.catch_warnings():
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         # We could warn here that the user requested warm start but the network is not valid
         # but this will be disruptive for the user especially that warm start is the default
-        warnings.simplefilter("error")  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert propagate_voltages_called
     assert not reset_inputs_called

--- a/roseau/load_flow_single/io/tests/test_dict.py
+++ b/roseau/load_flow_single/io/tests/test_dict.py
@@ -145,8 +145,7 @@ def test_all_converters():
     net_dict = en.to_dict(include_results=False)
     expected_dict = copy.deepcopy(dict_v3)
     remove_results(expected_dict)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
     assert_json_close(net_dict, expected_dict)
@@ -159,8 +158,7 @@ def test_from_dict_v3():
         en = rlfs.ElectricalNetwork.from_dict(data=dict_v3, include_results=True)
     net_dict = en.to_dict(include_results=True)
     expected_dict = copy.deepcopy(dict_v3)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with warnings.catch_warnings(action="ignore"):
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
     assert_json_close(net_dict, expected_dict)

--- a/roseau/load_flow_single/models/tests/test_lines.py
+++ b/roseau/load_flow_single/models/tests/test_lines.py
@@ -249,8 +249,7 @@ def test_different_voltage_levels():
     bus3 = Bus(id="bus3")
     bus4 = Bus(id="bus4", nominal_voltage=400)
     lp = LineParameters(id="lp", z_line=1)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with warnings.catch_warnings(action="error"):
         Line(id="ln good", bus1=bus1, bus2=bus2, parameters=lp, length=0.1)  # OK
         Line(id="ln good2", bus1=bus1, bus2=bus3, parameters=lp, length=0.1)  # OK
     with pytest.warns(

--- a/roseau/load_flow_single/models/tests/test_switches.py
+++ b/roseau/load_flow_single/models/tests/test_switches.py
@@ -53,8 +53,7 @@ def test_different_voltage_levels():
     bus2 = Bus(id="bus2", nominal_voltage=240)
     bus3 = Bus(id="bus3")
     bus4 = Bus(id="bus4", nominal_voltage=400)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with warnings.catch_warnings(action="error"):
         Switch(id="sw good", bus1=bus1, bus2=bus2)  # OK
         Switch(id="sw good2", bus1=bus1, bus2=bus3)  # OK
     with pytest.warns(

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -943,8 +943,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     reset_inputs_called = False
     assert small_network._valid
     assert not small_network._results_valid  # Results are not valid by default
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert not propagate_voltages_called  # Is not called because it was already called in the constructor
     assert not reset_inputs_called
@@ -954,8 +953,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     reset_inputs_called = False
     assert small_network._valid
     assert small_network._results_valid
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=False)
     assert not propagate_voltages_called
     assert reset_inputs_called
@@ -965,8 +963,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     reset_inputs_called = False
     assert small_network._valid
     assert small_network._results_valid
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert not propagate_voltages_called
     assert not reset_inputs_called
@@ -977,8 +974,7 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     load.power = load.power + Q_(1 + 1j, "VA")
     assert small_network._valid
     assert not small_network._results_valid
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Make sure there is no warning
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert not propagate_voltages_called
     assert not reset_inputs_called
@@ -990,10 +986,9 @@ def test_solver_warm_start(small_network: ElectricalNetwork, monkeypatch):
     assert new_load.network is small_network
     assert not small_network._valid
     assert not small_network._results_valid
-    with warnings.catch_warnings():
+    with warnings.catch_warnings(action="error"):  # Make sure there is no warning
         # We could warn here that the user requested warm start but the network is not valid
         # but this will be disruptive for the user especially that warm start is the default
-        warnings.simplefilter("error")  # Make sure there is no warning
         small_network.solve_load_flow(warm_start=True)
     assert propagate_voltages_called
     assert not reset_inputs_called


### PR DESCRIPTION
Internal changes only:
- Simplify warnings filtering by applying `action` directly in `catch_warnings`
- Simplify `ImportError` traceback with exception notes instead of chaining exceptions