### PR TITLE
Fix voltage propagation when traversing step-up transformer

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,9 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`382` Improve load flow convergence for networks with step-up transformers by improving the initial guesses for
+  the voltages of the buses.
+
 - {gh-pr}`380` {gh-issue}`379` Fix error when neutral ampacity is not passed to `LineParameters.from_geometry`.
 
 - {gh-pr}`374` Rename the `from_dgs` method of `rlf.ElectricalNetwork` to `from_dgs_file` and add a new `from_dgs_dict`

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -1119,7 +1119,12 @@ class ElectricalNetwork(AbstractNetwork[Element], CatalogueMixin[JsonDict]):
                         if isinstance(element, Transformer):
                             phase_shift = CLOCK_PHASE_SHIFT[element.parameters.phase_displacement]
                             kd = element.parameters._ulv / element.parameters._uhv * phase_shift
-                            new_potentials = {key: p * kd * element.tap for key, p in potentials.items()}
+                            if element.bus_hv in visited:
+                                # Traversing from HV side to LV side
+                                new_potentials = {key: p * (kd * element.tap) for key, p in potentials.items()}
+                            else:
+                                # Traversing from LV side to HV side
+                                new_potentials = {key: p / (kd * element.tap) for key, p in potentials.items()}
                         else:
                             new_potentials = potentials
                         elements.append((e, new_potentials, element))

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -1,3 +1,4 @@
+import cmath
 import contextlib
 import itertools as it
 import json
@@ -31,6 +32,7 @@ from roseau.load_flow.models import (
     VoltageSource,
 )
 from roseau.load_flow.network import ElectricalNetwork
+from roseau.load_flow.sym import PositiveSequence
 from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import LoadTypeDtype, PhaseDtype, SourceTypeDtype, VoltagePhaseDtype
 
@@ -2564,6 +2566,24 @@ def test_results_to_json(small_network_with_results, tmp_path):
         res_network = json.load(fp)
 
     assert res_network == res_network_expected
+
+
+def test_propagate_voltages_step_up_transformers():
+    # Source is located at the LV side of the transformer
+    bus1 = Bus(id="Bus1", phases="abcn")
+    bus2 = Bus(id="Bus2", phases="abc")
+    PotentialRef(id="Pref1", element=bus1)
+    PotentialRef(id="Pref2", element=bus2)
+    VoltageSource(id="Source", bus=bus1, voltages=400 / np.sqrt(3))  # LV source
+    tp = TransformerParameters.from_open_and_short_circuit_tests(
+        id="TP", vg="Dyn11", sn=160000, uhv=20000.0, ulv=400.0, i0=0.023, p0=460.0, psc=2350.0, vsc=0.04
+    )
+    Transformer(id="Tr", bus_lv=bus1, bus_hv=bus2, parameters=tp)
+    ElectricalNetwork.from_element(bus1)  # propagate the voltages
+    expected_lv_ini = 400 / np.sqrt(3) * np.array([*PositiveSequence, 0])
+    expected_hv_ini = cmath.rect(20e3 / np.sqrt(3), -np.pi / 6) * PositiveSequence  # Dyn11 shifts by -30°
+    npt.assert_allclose(bus1.initial_potentials.m, expected_lv_ini)
+    npt.assert_allclose(bus2.initial_potentials.m, expected_hv_ini)
 
 
 def test_propagate_voltages_center_transformers():

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -1,5 +1,4 @@
 import cmath
-import contextlib
 import itertools as it
 import json
 import re
@@ -2597,9 +2596,7 @@ def test_propagate_voltages_center_transformers():
     bus2 = Bus(id="bus2", phases="abn")
     PotentialRef(id="pref2", element=bus2)
     Transformer(id="transfo", bus_hv=bus1, bus_lv=bus2, parameters=tp)
-    en = ElectricalNetwork.from_element(bus2)
-    with contextlib.suppress(TypeError):  # cython solve_load_flow method has been patched
-        en.solve_load_flow()  # propagate the potentials
+    ElectricalNetwork.from_element(bus2)  # propagate the voltages
     npt.assert_allclose(bus2.initial_potentials.m_as("V"), np.array([200, -200, 0], dtype=np.complex128))
 
 

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -605,7 +605,12 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             for e in element._connected_elements:
                 if e not in visited:
                     if isinstance(element, Transformer):
-                        element_voltage = initial_voltage * element.parameters.kd * element._tap
+                        if element.bus_hv in visited:
+                            # Traversing from HV side to LV side
+                            element_voltage = initial_voltage * (element.parameters.kd * element._tap)
+                        else:
+                            # Traversing from LV side to HV side
+                            element_voltage = initial_voltage / (element.parameters.kd * element._tap)
                     else:
                         element_voltage = initial_voltage
                     elements.append((e, element_voltage, element))


### PR DESCRIPTION
This fixes the propagation of voltages when the "main" voltage source is connected to the LV side of a step-up transformer. This could cause the Newton algorithm to not converge at all or to converge to a bad solution.