### PR TITLE
Update biome to 2.1 and use it to format html

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.7.6
+    rev: 0.7.20
     hooks:
       - id: uv-lock
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.0
+    rev: 0.33.2
     hooks:
       - id: check-github-workflows
       - id: check-dependabot
@@ -26,11 +26,11 @@ repos:
       - id: typos
         args: [--force-exclude]
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.8.0
+    rev: v1.11.0
     hooks:
       - id: zizmor
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.12.2
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -55,21 +55,20 @@ repos:
           - mdformat-deflist
         exclude: ^.github/.*\.md$
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.5.3
+    rev: v3.6.2
     hooks:
       - id: prettier
         args: ["--print-width", "120"]
         require_serial: true
-        types_or: [html, yaml]
+        types_or: [yaml]
   - repo: https://github.com/cmhughes/latexindent.pl
     rev: V3.24.5
     hooks:
       - id: latexindent
         args: [-l, -m, -s, -wd]
   - repo: https://github.com/biomejs/pre-commit
-    rev: v1.9.4
+    rev: v2.1.1
     hooks:
       - id: biome-check
-        # TODO add yaml when biome supports it
-        # TODO html formatter is available in v2.0 beta, replace prettier when v2.0 is released
-        types_or: [json]
+        types_or: [json, html, css]
+        files: ".*" # Override default files regex that excludes html, rely on `types_or` instead

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,12 +17,12 @@
   },
   // Prettier
   "prettier.printWidth": 120,
-  "[yaml][html][css]": {
+  "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
   },
   // Json
-  "[json]": {
+  "[json][html][css]": {
     "editor.defaultFormatter": "biomejs.biome",
     "editor.formatOnSave": true,
     "editor.indentSize": 2,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
   },
-  // Json
+  // Biome
   "[json][html][css]": {
     "editor.defaultFormatter": "biomejs.biome",
     "editor.formatOnSave": true,

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": []
+    "maxSize": 2097152 // 2 MiB to accommodate the networks Catalogue.html file (1.6 MiB)
   },
   "formatter": {
     "enabled": true,
@@ -15,9 +15,6 @@
     "indentWidth": 2,
     "lineWidth": 120,
     "lineEnding": "lf"
-  },
-  "organizeImports": {
-    "enabled": true
   },
   "linter": {
     "enabled": true,
@@ -28,6 +25,19 @@
   "javascript": {
     "formatter": {
       "quoteStyle": "double"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "html": {
+    "formatter": {
+      "enabled": true  // Enable experimental HTML formatting
     }
   }
 }

--- a/doc/_static/Network/Catalogue.html
+++ b/doc/_static/Network/Catalogue.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <style>
       readthedocs-flyout {
         visibility: hidden;
@@ -12,13 +12,13 @@
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
 
     <script>
       L_NO_TOUCH = false;
@@ -46,25 +46,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_06abbe370899e0574791a45a40f07f8d {
         position: relative;
@@ -108,7 +110,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <div class="folium-map" id="map_06abbe370899e0574791a45a40f07f8d"></div>

--- a/doc/_static/Network/LVFeeder00939.html
+++ b/doc/_static/Network/LVFeeder00939.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 00939</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_f488d512e5d25115ef7c9b641582d56d {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 00939</h1>

--- a/doc/_static/Network/LVFeeder02639.html
+++ b/doc/_static/Network/LVFeeder02639.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 02639</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_fbafd48490182f7d7761146da6f06063 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 02639</h1>

--- a/doc/_static/Network/LVFeeder04790.html
+++ b/doc/_static/Network/LVFeeder04790.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 04790</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_038bba1832c0fc43e6dd61cc70964cf7 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 04790</h1>

--- a/doc/_static/Network/LVFeeder06713.html
+++ b/doc/_static/Network/LVFeeder06713.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 06713</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_217b93a23dd8d47d0f65b15d3871bd2e {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 06713</h1>

--- a/doc/_static/Network/LVFeeder06926.html
+++ b/doc/_static/Network/LVFeeder06926.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 06926</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_dd5c62f0ff3658a0a5f35800c2816cda {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 06926</h1>

--- a/doc/_static/Network/LVFeeder06975.html
+++ b/doc/_static/Network/LVFeeder06975.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 06975</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_49591e3bca33afdfee37aab32f12fa8e {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 06975</h1>

--- a/doc/_static/Network/LVFeeder18498.html
+++ b/doc/_static/Network/LVFeeder18498.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 18498</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_c761e249a7b296ac6461f9bb97f8d65f {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 18498</h1>

--- a/doc/_static/Network/LVFeeder18769.html
+++ b/doc/_static/Network/LVFeeder18769.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 18769</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_d6ada35887746495f0b19a229856b3d2 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 18769</h1>

--- a/doc/_static/Network/LVFeeder19558.html
+++ b/doc/_static/Network/LVFeeder19558.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 19558</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_a689533789caebeffe654b9ff38932fd {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 19558</h1>

--- a/doc/_static/Network/LVFeeder20256.html
+++ b/doc/_static/Network/LVFeeder20256.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 20256</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_74d5793e228597a3c516e11881e8a6ff {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 20256</h1>

--- a/doc/_static/Network/LVFeeder23832.html
+++ b/doc/_static/Network/LVFeeder23832.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 23832</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_ebd123b27935ed9a08eb63c5e9d4324e {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 23832</h1>

--- a/doc/_static/Network/LVFeeder24400.html
+++ b/doc/_static/Network/LVFeeder24400.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 24400</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_0e4b9078ede3bb8b641e8bee254138dc {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 24400</h1>

--- a/doc/_static/Network/LVFeeder27429.html
+++ b/doc/_static/Network/LVFeeder27429.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 27429</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_6a2bcddb4d05723a6e7fe812dcf41d31 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 27429</h1>

--- a/doc/_static/Network/LVFeeder27681.html
+++ b/doc/_static/Network/LVFeeder27681.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 27681</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_834028842a7b0f3d568f08779dc77ada {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 27681</h1>

--- a/doc/_static/Network/LVFeeder30216.html
+++ b/doc/_static/Network/LVFeeder30216.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 30216</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_471f268f25b07bc859ef3da0e6aba189 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 30216</h1>

--- a/doc/_static/Network/LVFeeder31441.html
+++ b/doc/_static/Network/LVFeeder31441.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 31441</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_20323055db7879b3567511274a5ed481 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 31441</h1>

--- a/doc/_static/Network/LVFeeder36284.html
+++ b/doc/_static/Network/LVFeeder36284.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 36284</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_64b47a141974e238242ed6227aae3e24 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 36284</h1>

--- a/doc/_static/Network/LVFeeder36360.html
+++ b/doc/_static/Network/LVFeeder36360.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 36360</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_b10e9d5298a3cb707a71a7d7a617a578 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 36360</h1>

--- a/doc/_static/Network/LVFeeder37263.html
+++ b/doc/_static/Network/LVFeeder37263.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 37263</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_76825ffa7652f9e8a6ed9ef772dd0ec7 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 37263</h1>

--- a/doc/_static/Network/LVFeeder38211.html
+++ b/doc/_static/Network/LVFeeder38211.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>LV Feeder 38211</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_edd1edc51b21bdccf78139a5afe9bdff {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>LV Feeder 38211</h1>

--- a/doc/_static/Network/MVFeeder004.html
+++ b/doc/_static/Network/MVFeeder004.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 004</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_51f7ce834423f62fc9760dad2117b08f {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 004</h1>

--- a/doc/_static/Network/MVFeeder011.html
+++ b/doc/_static/Network/MVFeeder011.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 011</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_bd7ea1b4c749b95f87618f9de0a5fff0 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 011</h1>

--- a/doc/_static/Network/MVFeeder015.html
+++ b/doc/_static/Network/MVFeeder015.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 015</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_be45b073fbebd7d778cba714aeba6372 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 015</h1>

--- a/doc/_static/Network/MVFeeder032.html
+++ b/doc/_static/Network/MVFeeder032.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 032</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_78f24beb1e20b4749d7b1a9186dcd8cc {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 032</h1>

--- a/doc/_static/Network/MVFeeder041.html
+++ b/doc/_static/Network/MVFeeder041.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 041</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_549d697a651533247e4f3a7d1f806b42 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 041</h1>

--- a/doc/_static/Network/MVFeeder063.html
+++ b/doc/_static/Network/MVFeeder063.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 063</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_30cb64fe102c83e86885360f69444aac {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 063</h1>

--- a/doc/_static/Network/MVFeeder078.html
+++ b/doc/_static/Network/MVFeeder078.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 078</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_8b2572c38247b2dfe4461dc6fbd0ee61 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 078</h1>

--- a/doc/_static/Network/MVFeeder115.html
+++ b/doc/_static/Network/MVFeeder115.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 115</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_c0df055412a41017c02658c0efc868f1 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 115</h1>

--- a/doc/_static/Network/MVFeeder128.html
+++ b/doc/_static/Network/MVFeeder128.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 128</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_bac66234891d7f12527377dfd390868e {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 128</h1>

--- a/doc/_static/Network/MVFeeder151.html
+++ b/doc/_static/Network/MVFeeder151.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 151</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_c4175704dc3eac3dfa1496ae7679bdb5 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 151</h1>

--- a/doc/_static/Network/MVFeeder159.html
+++ b/doc/_static/Network/MVFeeder159.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 159</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_281b3097ea5b241a523be799234c93c4 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 159</h1>

--- a/doc/_static/Network/MVFeeder176.html
+++ b/doc/_static/Network/MVFeeder176.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 176</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_35d352d339a9a6bed00abc6177ba13ed {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 176</h1>

--- a/doc/_static/Network/MVFeeder210.html
+++ b/doc/_static/Network/MVFeeder210.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 210</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_caf1e7a1955f8478fc3df8f252b44cf1 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 210</h1>

--- a/doc/_static/Network/MVFeeder217.html
+++ b/doc/_static/Network/MVFeeder217.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 217</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_826bbf07b69044ae68e443ea61c39ecd {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 217</h1>

--- a/doc/_static/Network/MVFeeder232.html
+++ b/doc/_static/Network/MVFeeder232.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 232</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_46323177515ec70db6f1d5f031fbf710 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 232</h1>

--- a/doc/_static/Network/MVFeeder251.html
+++ b/doc/_static/Network/MVFeeder251.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 251</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_b45c481aac2f2b8841634e167684baa6 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 251</h1>

--- a/doc/_static/Network/MVFeeder290.html
+++ b/doc/_static/Network/MVFeeder290.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 290</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_a16ad8294de0891a41924cfc32e7742d {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 290</h1>

--- a/doc/_static/Network/MVFeeder312.html
+++ b/doc/_static/Network/MVFeeder312.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 312</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_80e0c946230ade201e7d75041b00e4fe {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 312</h1>

--- a/doc/_static/Network/MVFeeder320.html
+++ b/doc/_static/Network/MVFeeder320.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 320</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_d5acc358815c48aaa637ffe7afe26294 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 320</h1>

--- a/doc/_static/Network/MVFeeder339.html
+++ b/doc/_static/Network/MVFeeder339.html
@@ -2,19 +2,19 @@
 <html lang="en">
   <head>
     <title>MV Feeder 339</title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta
       content="The Roseau Load Flow solver includes 40 medium and low voltage distribution networks."
       lang="en"
       name="description"
       xml:lang="en"
-    />
+    >
     <meta
       content="distribution grid, network data, lv network, mv network, free"
       lang="en"
       name="keywords"
       xml:lang="en"
-    />
+    >
     <style>
       h1 {
         text-align: center;
@@ -47,25 +47,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_901bd44692a2e77956b8169ba5dae441 {
         position: relative;
@@ -109,7 +111,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="../css/custom.css" />
+    <link rel="stylesheet" href="../css/custom.css">
   </head>
   <body>
     <h1>MV Feeder 339</h1>

--- a/doc/_static/Plotting/MVFeeder210.html
+++ b/doc/_static/Plotting/MVFeeder210.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
     <script>
       L_NO_TOUCH = false;
@@ -29,25 +29,27 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"
+    ></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css">
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"
-    />
+    >
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"
-    />
+    >
 
     <meta
       name="viewport"
       content="width=device-width,
                 initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    >
     <style>
       #map_95d9d20c55b1c9698bbf1e19d4754eb8 {
         position: relative;

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -197,7 +197,7 @@ def test_all_converters():
 def test_from_dict_v0():
     dict_v0 = json.loads(read_json_file("network_json_v0.json"))
 
-    with pytest.warns(UserWarning, match=r"Got an outdated network file \(version 0\)") as warn_check:
+    with pytest.warns(UserWarning, match=r"Got an outdated network file \(version 0\)") as warn_check:  # noqa: PT031
         en = ElectricalNetwork.from_dict(data=dict_v0, include_results=False)
         ignore_unmatched_warnings(warn_check)
     net_dict = en.to_dict(include_results=False)
@@ -214,7 +214,7 @@ def test_from_dict_v0():
 def test_from_dict_v1():
     dict_v1 = json.loads(read_json_file("network_json_v1.json"))
 
-    with pytest.warns(UserWarning, match=r"Got an outdated network file \(version 1\)") as warn_check:
+    with pytest.warns(UserWarning, match=r"Got an outdated network file \(version 1\)") as warn_check:  # noqa: PT031
         en = ElectricalNetwork.from_dict(data=dict_v1, include_results=True)
         ignore_unmatched_warnings(warn_check)
     net_dict = en.to_dict(include_results=True)


### PR DESCRIPTION
- Update biome to 2.1
- Format html with biome instead of prettier
- Rename biome.json to biome.jsonc (JSON with Comments) to be able to use comments in the configuration file
- Change biome's pre-commit hook to work with html as their support is still experimental
- Change biome's file size limit to 2 megabytes (default is 1 MB) because one of our html files is 1.6 MB