### PR TITLE
Add support for open switches

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`389` Add support for open switches. Pass `closed=False` to the `Switch` constructor to create an open switch.
+  Call `switch.open()` to open an existing switch and `switch.close()` to close it. `switch.closed` tells if the switch
+  is closed or not. The switch is closed by default.
+
 - {gh-pr}`388` {gh-issue}`378` Add `ElectricalNetwork.tool_data` to attach tool-specific data to the electrical network.
   The data is written to the JSON file when saving the network and is read when loading.
 

--- a/doc/models/Switch.md
+++ b/doc/models/Switch.md
@@ -28,13 +28,24 @@ align: center
 
 ## Equations
 
-The associated equations are:
+The associated equations are the following for a closed switch:
 
 ```{math}
 \left\{
     \begin{aligned}
         \underline{I_1} &= - \underline{I_2}\\
         \underline{V_1} &= \underline{V_2}\\
+    \end{aligned}
+\right.
+```
+
+and for an open switch:
+
+```{math}
+\left\{
+    \begin{aligned}
+        \underline{I_1} &= 0\\
+        \underline{I_2} &= 0\\
     \end{aligned}
 \right.
 ```
@@ -100,7 +111,7 @@ import roseau.load_flow as rlf
 bus1 = rlf.Bus(id="bus1", phases="abcn")
 bus2 = rlf.Bus(id="bus2", phases="abcn")
 
-# A line
+# A switch connecting the two buses
 switch = rlf.Switch(id="switch", bus1=bus1, bus2=bus2)
 
 # A voltage source on the first bus
@@ -146,6 +157,21 @@ en.res_buses_voltages[["voltage"]].transform([np.abs, ft.partial(np.angle, deg=T
 # | ('bus2', 'an') |                    230.94 |                      0 |
 # | ('bus2', 'bn') |                    230.94 |                   -120 |
 # | ('bus2', 'cn') |                    230.94 |                    120 |
+
+# The switch is closed by default. Let's open it and add a line
+
+switch.open()
+lp = rlf.LineParameters(id="LP", z_line=(0.1 + 0.1j) * np.eye(4))
+rlf.Line(id="line", bus1=bus1, bus2=bus2, length=0.1, parameters=lp)
+en.solve_load_flow()
+# No current flows through the switch now
+en.res_switches[["current1"]].transform([np.abs, ft.partial(np.angle, deg=True)])
+# |                 |   ('current1', 'absolute') |   ('current1', 'angle') |
+# |:----------------|---------------------------:|------------------------:|
+# | ('switch', 'a') |                          0 |                       0 |
+# | ('switch', 'b') |                          0 |                       0 |
+# | ('switch', 'c') |                          0 |                       0 |
+# | ('switch', 'n') |                          0 |                       0 |
 ```
 
 ## API Reference

--- a/roseau/load_flow/conftest.py
+++ b/roseau/load_flow/conftest.py
@@ -43,6 +43,7 @@ _CY_CLASSES_WITH_BASES = {
     "CySimplifiedLine": ("CyBranch",),
     "CyShuntLine": ("CyBranch",),
     "CySwitch": ("CyBranch",),
+    "CyOpenSwitch": ("CyBranch",),
     "CyTransformer": ("CyBranch",),
     "CyThreePhaseTransformer": ("CyTransformer",),
     "CySingleTransformer": ("CyTransformer",),

--- a/roseau/load_flow/conftest.py
+++ b/roseau/load_flow/conftest.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import os
+from itertools import chain
 from pathlib import Path
 
 import pytest
@@ -80,8 +81,7 @@ for class_name, bases in _CY_CLASSES_WITH_BASES.items():
     _PATCHED_CY_CLASSES[class_name] = type(class_name, bases, {})
 
 
-@pytest.fixture(autouse=True)
-def patch_engine(request):
+def patch_engine_impl(request: pytest.FixtureRequest, extra_dir: Path | None = None):
     mpatch = pytest.MonkeyPatch()
 
     if "no_patch_engine" in request.keywords:
@@ -98,7 +98,11 @@ def patch_engine(request):
         # Get all roseau.load_flow submodules
         rlf_directory_path = Path(roseau.load_flow.__file__).parent
         relative_to = Path(roseau.load_flow.__file__).parents[2]
-        for dirpath, _, filenames in os.walk(rlf_directory_path):  # TODO In Python 3.12 use rlf_directory_path.walk()
+        dirs = [rlf_directory_path]
+        if extra_dir:
+            dirs.append(extra_dir)
+        for dirpath, _, filenames in chain.from_iterable(os.walk(d) for d in dirs):
+            # TODO In Python 3.12 use rlf_directory_path.walk()
             dirpath = Path(dirpath)  # TODO Useless in Python 3.12
             for p in dirpath.parts:
                 if p in {"tests", "__pycache__", "data"}:
@@ -125,6 +129,11 @@ def patch_engine(request):
 
     yield mpatch
     mpatch.undo()
+
+
+@pytest.fixture(autouse=True)
+def patch_engine(request):
+    yield from patch_engine_impl(request)
 
 
 @pytest.fixture(params=["impedance", "power"], ids=["impedance", "power"])

--- a/roseau/load_flow/io/dgs/switches.py
+++ b/roseau/load_flow/io/dgs/switches.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import pandas as pd
 import shapely
@@ -7,7 +6,6 @@ import shapely
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models import Bus, Switch
 from roseau.load_flow.typing import Id
-from roseau.load_flow.utils import find_stack_level
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +46,7 @@ def elm_coup_to_switches(
         geometry = (
             shapely.Point(elm_coup.at[switch_id, "GPSlon"], elm_coup.at[switch_id, "GPSlat"]) if has_geometry else None
         )
-        on_off = elm_coup.at[switch_id, "on_off"]
-        if not on_off:
-            warnings.warn(
-                f"Switch {switch_id!r} is open but switches are always closed in roseau-load-flow.",
-                stacklevel=find_stack_level(),
-            )
-        switches[switch_id] = Switch(id=switch_id, phases=phases, bus1=bus1, bus2=bus2, geometry=geometry)
+        closed = bool(elm_coup.at[switch_id, "on_off"])
+        switches[switch_id] = Switch(
+            id=switch_id, phases=phases, bus1=bus1, bus2=bus2, closed=closed, geometry=geometry
+        )

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -939,6 +939,12 @@ def v4_to_v5_converter(data: JsonDict) -> JsonDict:
                 pass
         lines.append(line_data)
 
+    switches = []
+    for switch_data in data["switches"]:
+        # Add closed parameter
+        switch_data["closed"] = True
+        switches.append(switch_data)
+
     results = {
         "version": 5,
         "is_multiphase": data["is_multiphase"],  # Unchanged
@@ -947,7 +953,7 @@ def v4_to_v5_converter(data: JsonDict) -> JsonDict:
         "potential_refs": data["potential_refs"],  # Unchanged
         "buses": data["buses"],  # Unchanged
         "lines": lines,
-        "switches": data["switches"],  # Unchanged
+        "switches": switches,
         "transformers": data["transformers"],  # Unchanged
         "loads": data["loads"],  # Unchanged
         "sources": data["sources"],  # Unchanged

--- a/roseau/load_flow/models/switches.py
+++ b/roseau/load_flow/models/switches.py
@@ -99,7 +99,11 @@ class Switch(AbstractBranch["SwitchSide", CySwitch | CyOpenSwitch]):
             element = elements.pop(-1)
             visited_1.add(element)
             for e in element._connected_elements:
-                if e not in visited_1 and e is not self and (isinstance(e, Bus) or isinstance(e, Switch) and e.closed):
+                if (
+                    e not in visited_1
+                    and e is not self
+                    and ((isinstance(e, Switch) and e.closed) or isinstance(e, Bus))
+                ):
                     elements.append(e)
         visited_2: set[Element] = set()
         elements = [self.bus2]
@@ -107,7 +111,11 @@ class Switch(AbstractBranch["SwitchSide", CySwitch | CyOpenSwitch]):
             element = elements.pop(-1)
             visited_2.add(element)
             for e in element._connected_elements:
-                if e not in visited_2 and e is not self and (isinstance(e, Bus) or isinstance(e, Switch) and e.closed):
+                if (
+                    e not in visited_2
+                    and e is not self
+                    and ((isinstance(e, Switch) and e.closed) or isinstance(e, Bus))
+                ):
                     elements.append(e)
         if loop_switches := visited_1.intersection(visited_2):
             other_switches, _ = one_or_more_repr(

--- a/roseau/load_flow/models/tests/test_switches.py
+++ b/roseau/load_flow/models/tests/test_switches.py
@@ -10,25 +10,54 @@ def test_switch_loop():
     bus2 = Bus(id="bus2", phases="abcn")
     bus3 = Bus(id="bus3", phases="abcn")
 
-    Switch(id="switch1", bus1=bus1, bus2=bus2, phases="abcn")
+    Switch(id="sw1", bus1=bus1, bus2=bus2, phases="abcn")
     lp = LineParameters(id="test", z_line=np.eye(4, dtype=complex))
-    Line(id="line", bus1=bus1, bus2=bus3, phases="abcn", parameters=lp, length=10)
+    Line(id="ln", bus1=bus1, bus2=bus3, phases="abcn", parameters=lp, length=10)
 
     with pytest.raises(RoseauLoadFlowException) as e:
-        Switch(id="switch2", bus1=bus1, bus2=bus2, phases="abcn")
-    assert "There is a loop of switch" in e.value.msg
+        Switch(id="sw2", bus1=bus1, bus2=bus2)
+    assert e.value.msg == (
+        "Connecting switch 'sw2' between buses 'bus1' and 'bus2' creates a loop with switch 'sw1'. "
+        "Current flow in several switch-only branches between buses cannot be computed."
+    )
     assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
 
     with pytest.raises(RoseauLoadFlowException) as e:
-        Switch(id="switch3", bus1=bus2, bus2=bus1, phases="abcn")
-    assert "There is a loop of switch" in e.value.msg
+        Switch(id="sw3", bus1=bus2, bus2=bus1)
+    assert e.value.msg == (
+        "Connecting switch 'sw3' between buses 'bus2' and 'bus1' creates a loop with switch 'sw1'. "
+        "Current flow in several switch-only branches between buses cannot be computed."
+    )
     assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
 
-    Switch(id="switch4", bus1=bus2, bus2=bus3, phases="abcn")
+    sw4 = Switch(id="sw4", bus1=bus2, bus2=bus3)
     with pytest.raises(RoseauLoadFlowException) as e:
-        Switch(id="switch5", bus1=bus1, bus2=bus3, phases="abcn")
-    assert "There is a loop of switch" in e.value.msg
+        Switch(id="sw5", bus1=bus1, bus2=bus3)
+    assert e.value.msg == (
+        "Connecting switch 'sw5' between buses 'bus1' and 'bus3' creates a loop with switches "
+        "['sw1', 'sw4']. Current flow in several switch-only branches between buses cannot be "
+        "computed."
+    )
     assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
+
+    # OK if the switch is open
+    Switch(id="sw6", bus1=bus1, bus2=bus2, closed=False)
+    Switch(id="sw7", bus1=bus2, bus2=bus3, closed=False)
+    sw8 = Switch(id="sw8", bus1=bus1, bus2=bus3, closed=False)
+
+    # Trying to close it raises an error
+    with pytest.raises(RoseauLoadFlowException) as e:
+        sw8.close()
+    assert e.value.msg == (
+        "Closing switch 'sw8' between buses 'bus1' and 'bus3' creates a loop with switches "
+        "['sw1', 'sw4']. Current flow in several switch-only branches between buses cannot be "
+        "computed. Open the other switches first."
+    )
+    assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
+
+    # Opening the other switch first allows closing the switch
+    sw4.open()
+    sw8.close()  # OK
 
 
 def test_switch_connection():

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -1119,6 +1119,9 @@ class ElectricalNetwork(AbstractNetwork[Element], CatalogueMixin[JsonDict]):
             if isinstance(element, Bus) and not element._initialized:
                 element.initial_potentials = np.array([potentials[p] for p in element.phases], dtype=np.complex128)
                 element._initialized_by_the_user = False  # only used for serialization
+            elif isinstance(element, Switch) and not element.closed:
+                #  Do not propagate voltages through open switches
+                continue
             if not isinstance(element, Ground):  # Do not go from ground to buses/branches
                 for e in element._connected_elements:
                     if e not in visited:

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -1138,14 +1138,19 @@ class ElectricalNetwork(AbstractNetwork[Element], CatalogueMixin[JsonDict]):
                             new_potentials = potentials
                         elements.append((e, new_potentials, element))
                         visited.add(e)
-                    elif parent != e and not isinstance(e, Ground):
+                    elif (
+                        not self._has_loop  # Save some checks if we already found a loop
+                        and parent != e
+                        and not isinstance(e, Ground)
+                        and (not isinstance(e, Switch) or e.closed)
+                    ):
                         self._has_loop = True
             else:
                 for e in element._connected_elements:
                     if e not in visited and isinstance(e, PotentialRef):
                         elements.append((e, potentials, element))
                         visited.add(e)
-        self._check_connectivity(visited)
+        self._check_connectivity(visited, starting_source)
 
     def _get_starting_potentials(self, all_phases: set[str]) -> tuple[dict[str, complex], VoltageSource]:
         """Compute the initial potentials from the voltage sources of the network and get the starting source."""

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -465,7 +465,7 @@ def test_poorly_connected_elements():
         ElectricalNetwork.from_element(initial_bus=bus1)
     assert (
         e.value.msg
-        == "The elements [\"Bus('b4'), Bus('b3'), Line('l2')\"] are not electrically connected to a voltage source."
+        == "The elements [Bus('b4'), Bus('b3'), Line('l2')] are not electrically connected to a voltage source."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT
 

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -463,9 +463,25 @@ def test_poorly_connected_elements():
     PotentialRef(id="pr1", element=ground)
     with pytest.raises(RoseauLoadFlowException) as e:
         ElectricalNetwork.from_element(initial_bus=bus1)
-    assert (
-        e.value.msg
-        == "The elements [Bus('b4'), Bus('b3'), Line('l2')] are not electrically connected to a voltage source."
+    assert e.value.msg == (
+        "The elements [Bus('b4'), Bus('b3'), Line('l2')] are not electrically connected to a voltage source."
+    )
+    assert e.value.code == RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT
+
+    # Poorly connected because of open switch
+    bus1 = Bus(id="Bus1", phases="abc")
+    bus2 = Bus(id="Bus2", phases="abc")
+    VoltageSource(id="Source", bus=bus1, voltages=20e3)
+    switch = Switch(id="Switch", bus1=bus1, bus2=bus2, closed=False)
+    VoltageSource(id="Source2", bus=bus2, voltages=400)
+    PotentialRef(id="PRef", element=bus1)
+
+    assert not switch.closed
+    with pytest.raises(RoseauLoadFlowException) as e:
+        ElectricalNetwork.from_element(initial_bus=bus1)
+    assert e.value.msg == (
+        "The elements [Bus('Bus2'), VoltageSource('Source2')] are not electrically connected to the "
+        "main voltage source 'Source'. Separate subnetworks are not supported."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT
 

--- a/roseau/load_flow/utils/mixins.py
+++ b/roseau/load_flow/utils/mixins.py
@@ -961,10 +961,10 @@ class AbstractNetwork(RLFObject, JsonMixin, Generic[_E_co]):
                 for e in elements.values()
                 if e not in visited_elements
             ]
-            printable_elements = textwrap.wrap(
+            printable_elements = textwrap.shorten(
                 ", ".join(f"{type(e).__name__}({e.id!r})" for e in unconnected_elements), 500
             )
-            msg = f"The elements {printable_elements} are not electrically connected to a voltage source."
+            msg = f"The elements [{printable_elements}] are not electrically connected to a voltage source."
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT)
 

--- a/roseau/load_flow/utils/mixins.py
+++ b/roseau/load_flow/utils/mixins.py
@@ -952,7 +952,7 @@ class AbstractNetwork(RLFObject, JsonMixin, Generic[_E_co]):
         """Propagate the sources voltages to set uninitialized potentials of buses and compute self._elements."""
         raise NotImplementedError
 
-    def _check_connectivity(self, visited_elements: Collection[_E_co]) -> None:
+    def _check_connectivity(self, visited_elements: Collection[_E_co], starting_source: AbstractElement[Self]) -> None:
         """Check that all the elements are connected to a voltage source."""
         if len(visited_elements) < sum(map(len, self._elements_by_type.values())):
             unconnected_elements = [
@@ -961,10 +961,17 @@ class AbstractNetwork(RLFObject, JsonMixin, Generic[_E_co]):
                 for e in elements.values()
                 if e not in visited_elements
             ]
+            unconnected_source = next(
+                (e for e in self._elements_by_type["source"].values() if e not in visited_elements), None
+            )
             printable_elements = textwrap.shorten(
                 ", ".join(f"{type(e).__name__}({e.id!r})" for e in unconnected_elements), 500
             )
-            msg = f"The elements [{printable_elements}] are not electrically connected to a voltage source."
+            msg = f"The elements [{printable_elements}] are not electrically connected to "
+            if unconnected_source is None:
+                msg += "a voltage source."
+            else:
+                msg += f"the main voltage source {starting_source.id!r}. Separate subnetworks are not supported."
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT)
 

--- a/roseau/load_flow_single/conftest.py
+++ b/roseau/load_flow_single/conftest.py
@@ -1,13 +1,9 @@
-import importlib
-import inspect
-import os
 from pathlib import Path
 
 import pytest
 
-import roseau.load_flow
 import roseau.load_flow_single
-from roseau.load_flow.utils.log import set_logging_config
+from roseau.load_flow.conftest import patch_engine_impl
 
 HERE = Path(__file__).parent.expanduser().absolute()
 TEST_ALL_NETWORKS_DATA_FOLDER = HERE / "tests" / "data" / "networks"
@@ -59,65 +55,5 @@ def three_phases_transformer_type(request) -> str:
 
 
 @pytest.fixture(autouse=True)
-def patch_engine(request):  # noqa: C901
-    mpatch = pytest.MonkeyPatch()
-
-    if "no_patch_engine" in request.keywords:
-        # A load flow must be solved in the test
-        # Skip if no license key in the environment
-        if os.getenv("ROSEAU_LOAD_FLOW_LICENSE_KEY") is None:  # pragma: no-cover
-            pytest.skip(
-                reason="This test requires a license key. Please set ROSEAU_LOAD_FLOW_LICENSE_KEY in your environment."
-            )
-
-        # Activate logging
-        set_logging_config("debug")
-    else:
-        # Patch the engine
-
-        class Foo:
-            def __init__(self, *args, **kwargs):  # Accept all constructor parameters
-                pass
-
-            def __getattr__(self, attr):  # Accept all methods
-                if attr.startswith("__array"):  # Let numpy interface
-                    return object.__getattr__(self, attr)
-                else:
-                    return self.foo
-
-            def foo(self, *args, **kwargs):
-                pass
-
-        def bar(*args, **kwargs):  # pragma: no-cover
-            pass
-
-        # Get all roseau.load_flow_single and roseau.load_flow submodules
-        for dp in (Path(roseau.load_flow_single.__file__).parent, Path(roseau.load_flow.__file__).parent):
-            relative_to = dp.parents[1]
-            for dirpath, _, filenames in os.walk(dp):  # TODO In Python 3.12 use rlf_directory_path.walk()
-                dirpath = Path(dirpath)  # TODO Useless in Python 3.12
-                for p in dirpath.parts:
-                    if p in {"tests", "__pycache__", "data"}:
-                        break
-                else:
-                    base_module = str(dirpath.relative_to(relative_to)).replace("/", ".")
-                    for f in filenames:
-                        if not f.endswith(".py"):
-                            continue
-                        if f in ("constants.py", "types.py") and base_module == "roseau.load_flow.utils":
-                            continue  # TODO Remove when these deprecated files are removed
-                        module = importlib.import_module(f"{base_module}.{f.removesuffix('.py')}")
-                        for _, klass in inspect.getmembers(
-                            module,
-                            lambda member: inspect.isclass(member)
-                            and "load_flow_engine." in member.__module__
-                            and member.__name__.startswith("Cy")
-                            and member.__name__ != "CyLicense",  # Test of the static methods of this class
-                        ):
-                            mpatch.setattr(f"{module.__name__}.{klass.__name__}", Foo)
-
-        # Also patch the activate license function of the _solvers module
-        mpatch.setattr("roseau.load_flow.license.cy_activate_license", bar)
-
-    yield mpatch
-    mpatch.undo()
+def patch_engine(request):
+    yield from patch_engine_impl(request, extra_dir=Path(roseau.load_flow_single.__file__).parent)

--- a/roseau/load_flow_single/io/dict.py
+++ b/roseau/load_flow_single/io/dict.py
@@ -339,6 +339,11 @@ def v3_to_v4_converter(data: JsonDict) -> JsonDict:
 def v4_to_v5_converter(data: JsonDict) -> JsonDict:
     assert data["version"] == 4, data["version"]
 
+    switches = []
+    for switch_data in data["switches"]:
+        switch_data["closed"] = True
+        switches.append(switch_data)
+
     results = {
         "version": 5,
         "is_multiphase": data["is_multiphase"],  # Unchanged
@@ -346,7 +351,7 @@ def v4_to_v5_converter(data: JsonDict) -> JsonDict:
         "buses": data["buses"],  # Unchanged
         "lines": data["lines"],  # Unchanged
         "transformers": data["transformers"],  # Unchanged
-        "switches": data["switches"],  # Unchanged
+        "switches": switches,
         "loads": data["loads"],  # Unchanged
         "sources": data["sources"],  # Unchanged
         "lines_params": data["lines_params"],  # <---- Unchanged

--- a/roseau/load_flow_single/io/tests/test_dgs.py
+++ b/roseau/load_flow_single/io/tests/test_dgs.py
@@ -65,7 +65,7 @@ def test_to_from_dgs_roundtrip():
 
     lp = rlfs.LineParameters.from_catalogue("U_AL_240")
     rlfs.Line(
-        "MV Line",
+        "LV Line",
         bus1=bus1_lv,
         bus2=bus2_lv,
         parameters=lp,
@@ -79,6 +79,14 @@ def test_to_from_dgs_roundtrip():
                 (5.738531306019317, 45.18776131177264),
             ]
         ),
+    )
+
+    rlfs.Switch(
+        "LV Switch",
+        bus1=bus1_lv,
+        bus2=bus2_lv,
+        closed=False,  # Open switch
+        geometry=shapely.Point(5.741095497645757, 45.18848721409608),
     )
 
     rlfs.VoltageSource("MV Grid", bus=bus_mv, voltage=21e3 * np.exp(1j * np.pi / 6))

--- a/roseau/load_flow_single/models/switches.py
+++ b/roseau/load_flow_single/models/switches.py
@@ -1,11 +1,12 @@
 import logging
-from typing import Final
+from typing import Final, Literal
 
 from shapely.geometry.base import BaseGeometry
 
 from roseau.load_flow import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
-from roseau.load_flow.typing import Id
-from roseau.load_flow_engine.cy_engine import CySwitch
+from roseau.load_flow.typing import Id, JsonDict
+from roseau.load_flow.utils import id_sort_key, one_or_more_repr
+from roseau.load_flow_engine.cy_engine import CyOpenSwitch, CySwitch
 from roseau.load_flow_single.models.branches import AbstractBranch, AbstractBranchSide
 from roseau.load_flow_single.models.buses import Bus
 from roseau.load_flow_single.models.core import Element
@@ -14,12 +15,14 @@ from roseau.load_flow_single.models.sources import VoltageSource
 logger = logging.getLogger(__name__)
 
 
-class Switch(AbstractBranch["SwitchSide", CySwitch]):
+class Switch(AbstractBranch["SwitchSide", CySwitch | CyOpenSwitch]):
     """A general purpose switch branch."""
 
     element_type: Final = "switch"
 
-    def __init__(self, id: Id, bus1: Bus, bus2: Bus, *, geometry: BaseGeometry | None = None) -> None:
+    def __init__(
+        self, id: Id, bus1: Bus, bus2: Bus, *, closed: bool = True, geometry: BaseGeometry | None = None
+    ) -> None:
         """Switch constructor.
 
         Args:
@@ -32,20 +35,35 @@ class Switch(AbstractBranch["SwitchSide", CySwitch]):
             bus2:
                 Second bus to connect to the switch.
 
+            closed:
+                Whether the switch is closed or not. If ``True`` (default), the switch is closed and
+                the current can flow through it. If ``False``, the switch is open and no current can
+                flow through it.
+
             geometry:
                 The geometry of the switch.
         """
         super().__init__(id=id, bus1=bus1, bus2=bus2, n=1, geometry=geometry)
         self._side1 = SwitchSide(branch=self, side=1, bus=bus1)
         self._side2 = SwitchSide(branch=self, side=2, bus=bus2)
+        self._closed = closed
         self._check_elements()
-        self._check_loop()
+        if closed:
+            self._check_loop(operation="connecting")
         self._check_same_voltage_level()
-        self._cy_element = CySwitch(1)
+        self._cy_element = CySwitch(1) if closed else CyOpenSwitch(1)
         self._cy_connect()
         self._connect(bus1, bus2)
 
-    def _check_loop(self) -> None:
+    def __repr__(self) -> str:
+        parts = [
+            f"bus1={self._side1.bus.id!r}",
+            f"bus2={self._side2.bus.id!r}",
+            f"closed={self.closed}",
+        ]
+        return f"<{type(self).__name__}: {', '.join(parts)}>"
+
+    def _check_loop(self, operation: Literal["connecting", "closing"]) -> None:
         """Check that there are no switch loops, raise an exception if it is the case."""
         visited_1: set[Element] = set()
         elements: list[Element] = [self.bus1]
@@ -53,7 +71,11 @@ class Switch(AbstractBranch["SwitchSide", CySwitch]):
             element = elements.pop(-1)
             visited_1.add(element)
             for e in element._connected_elements:
-                if e not in visited_1 and (isinstance(e, (Bus, Switch))) and e != self:
+                if (
+                    e not in visited_1
+                    and e is not self
+                    and ((isinstance(e, Switch) and e.closed) or isinstance(e, Bus))
+                ):
                     elements.append(e)
         visited_2: set[Element] = set()
         elements = [self.bus2]
@@ -61,14 +83,28 @@ class Switch(AbstractBranch["SwitchSide", CySwitch]):
             element = elements.pop(-1)
             visited_2.add(element)
             for e in element._connected_elements:
-                if e not in visited_2 and (isinstance(e, (Bus, Switch))) and e != self:
+                if (
+                    e not in visited_2
+                    and e is not self
+                    and ((isinstance(e, Switch) and e.closed) or isinstance(e, Bus))
+                ):
                     elements.append(e)
-        if visited_1.intersection(visited_2):
-            msg = (
-                f"Connecting switch {self.id!r} between buses {self.bus1.id!r} and {self.bus2.id!r} "
-                f"creates a switch loop. Current flow in several switch-only branches between buses "
-                f"cannot be computed."
+        if loop_switches := visited_1.intersection(visited_2):
+            other_switches, _ = one_or_more_repr(
+                sorted(
+                    (e.id for e in loop_switches if isinstance(e, Switch)),
+                    key=lambda eid: id_sort_key({"id": eid}),
+                ),
+                "switch",
+                "switches",
             )
+            msg = (
+                f"{operation.capitalize()} switch {self.id!r} between buses {self.bus1.id!r} and "
+                f"{self.bus2.id!r} creates a loop with {other_switches}. Current flow in several "
+                f"switch-only branches between buses cannot be computed."
+            )
+            if operation == "closing":
+                msg += " Open the other switches first."
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.SWITCHES_LOOP)
 
@@ -83,6 +119,39 @@ class Switch(AbstractBranch["SwitchSide", CySwitch]):
             )
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES_SOURCES_CONNECTION)
+
+    @property
+    def closed(self) -> bool:
+        """Whether the switch is closed or not."""
+        return self._closed
+
+    def open(self) -> None:
+        """Open the switch."""
+        if self.closed:
+            self._invalidate_network_results()
+            if self._network is not None:
+                self._network._valid = False
+            self._cy_element.disconnect()
+            self._cy_element = CyOpenSwitch(1)
+            self._cy_connect()
+        self._closed = False
+
+    def close(self) -> None:
+        """Close the switch."""
+        if not self.closed:
+            self._check_loop(operation="closing")
+            self._invalidate_network_results()
+            if self._network is not None:
+                self._network._valid = False
+            self._cy_element.disconnect()
+            self._cy_element = CySwitch(1)
+            self._cy_connect()
+        self._closed = True
+
+    def _to_dict(self, include_results: bool) -> JsonDict:
+        data = super()._to_dict(include_results)
+        data["closed"] = self._closed
+        return data
 
 
 class SwitchSide(AbstractBranchSide):

--- a/roseau/load_flow_single/models/tests/test_switches.py
+++ b/roseau/load_flow_single/models/tests/test_switches.py
@@ -11,28 +11,54 @@ def test_switch_loop():
     bus2 = Bus(id="bus2")
     bus3 = Bus(id="bus3")
 
-    Switch(id="switch1", bus1=bus1, bus2=bus2)
+    Switch(id="sw1", bus1=bus1, bus2=bus2)
     lp = LineParameters(id="test", z_line=1.0)
     Line(id="line", bus1=bus1, bus2=bus3, parameters=lp, length=10)
 
     with pytest.raises(RoseauLoadFlowException) as e:
-        Switch(id="switch2", bus1=bus1, bus2=bus2)
+        Switch(id="sw2", bus1=bus1, bus2=bus2)
     assert e.value.msg == (
-        "Connecting switch 'switch2' between buses 'bus1' and 'bus2' creates a switch loop. Current "
-        "flow in several switch-only branches between buses cannot be computed."
+        "Connecting switch 'sw2' between buses 'bus1' and 'bus2' creates a loop with switch 'sw1'. "
+        "Current flow in several switch-only branches between buses cannot be computed."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
 
     with pytest.raises(RoseauLoadFlowException) as e:
-        Switch(id="switch3", bus1=bus2, bus2=bus1)
-    assert "Connecting switch 'switch3' between buses 'bus2' and 'bus1' creates a switch loop." in e.value.msg
+        Switch(id="sw3", bus1=bus2, bus2=bus1)
+    assert e.value.msg == (
+        "Connecting switch 'sw3' between buses 'bus2' and 'bus1' creates a loop with switch 'sw1'. "
+        "Current flow in several switch-only branches between buses cannot be computed."
+    )
     assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
 
-    Switch(id="switch4", bus1=bus2, bus2=bus3)
+    sw4 = Switch(id="sw4", bus1=bus2, bus2=bus3)
     with pytest.raises(RoseauLoadFlowException) as e:
-        Switch(id="switch5", bus1=bus1, bus2=bus3)
-    assert "Connecting switch 'switch5' between buses 'bus1' and 'bus3' creates a switch loop." in e.value.msg
+        Switch(id="sw5", bus1=bus1, bus2=bus3)
+    assert e.value.msg == (
+        "Connecting switch 'sw5' between buses 'bus1' and 'bus3' creates a loop with switches "
+        "['sw1', 'sw4']. Current flow in several switch-only branches between buses cannot be "
+        "computed."
+    )
     assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
+
+    # OK if the switch is open
+    Switch(id="sw6", bus1=bus1, bus2=bus2, closed=False)
+    Switch(id="sw7", bus1=bus2, bus2=bus3, closed=False)
+    sw8 = Switch(id="sw8", bus1=bus1, bus2=bus3, closed=False)
+
+    # Trying to close it raises an error
+    with pytest.raises(RoseauLoadFlowException) as e:
+        sw8.close()
+    assert e.value.msg == (
+        "Closing switch 'sw8' between buses 'bus1' and 'bus3' creates a loop with switches "
+        "['sw1', 'sw4']. Current flow in several switch-only branches between buses cannot be "
+        "computed. Open the other switches first."
+    )
+    assert e.value.code == RoseauLoadFlowExceptionCode.SWITCHES_LOOP
+
+    # Opening the other switch first allows closing the switch
+    sw4.open()
+    sw8.close()  # OK
 
 
 def test_switch_connection():

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -624,9 +624,13 @@ class ElectricalNetwork(AbstractNetwork[Element]):
                         element_voltage = initial_voltage
                     elements.append((e, element_voltage, element))
                     visited.add(e)
-                elif parent != e:
+                elif (
+                    not self._has_loop  # Save some checks if we already found a loop
+                    and parent != e
+                    and (not isinstance(e, Switch) or e.closed)
+                ):
                     self._has_loop = True
-        self._check_connectivity(visited)
+        self._check_connectivity(visited, starting_source)
 
     def _get_starting_voltage(self) -> tuple[complex, VoltageSource]:
         """Compute the initial voltages from the voltage sources of the network and get the starting source."""

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -608,6 +608,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             if isinstance(element, Bus) and not element._initialized:
                 element.initial_voltage = initial_voltage
                 element._initialized_by_the_user = False  # only used for serialization
+            elif isinstance(element, Switch) and not element.closed:
+                # Do not propagate voltages through open switches
+                continue
             for e in element._connected_elements:
                 if e not in visited:
                     if isinstance(element, Transformer):

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -302,7 +302,7 @@ def test_poorly_connected_elements():
         )
     assert (
         e.value.msg
-        == "The elements [\"Bus('b3'), Bus('b4'), Line('l2')\"] are not electrically connected to a voltage source."
+        == "The elements [Bus('b3'), Bus('b4'), Line('l2')] are not electrically connected to a voltage source."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT
 

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -300,9 +300,24 @@ def test_poorly_connected_elements():
             loads={},
             sources=[vs],
         )
-    assert (
-        e.value.msg
-        == "The elements [Bus('b3'), Bus('b4'), Line('l2')] are not electrically connected to a voltage source."
+    assert e.value.msg == (
+        "The elements [Bus('b3'), Bus('b4'), Line('l2')] are not electrically connected to a voltage source."
+    )
+    assert e.value.code == RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT
+
+    # Poorly connected because of open switch
+    bus1 = Bus(id="Bus1")
+    bus2 = Bus(id="Bus2")
+    VoltageSource(id="Source", bus=bus1, voltage=400)
+    switch = Switch(id="Switch", bus1=bus1, bus2=bus2, closed=False)
+    VoltageSource(id="Source2", bus=bus2, voltage=399)
+
+    assert not switch.closed
+    with pytest.raises(RoseauLoadFlowException) as e:
+        ElectricalNetwork.from_element(initial_bus=bus1)
+    assert e.value.msg == (
+        "The elements [Bus('Bus2'), VoltageSource('Source2')] are not electrically connected to the "
+        "main voltage source 'Source'. Separate subnetworks are not supported."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.POORLY_CONNECTED_ELEMENT
 


### PR DESCRIPTION
Add support for open switches. Pass `closed=False` to the `Switch` constructor to create an open switch. Call `switch.open()` to open an existing switch and `switch.close()` to close it. `switch.closed` tells if the switch is closed or not. The switch is closed by default.