### PR TITLE
Return multi-graph from `en.to_graph`

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`391` {gh-issue}`390` `ElectricalNetwork.to_graph` now returns a multi-graph to preserve parallel edges.
+
 - {gh-pr}`389` Add support for open switches. Pass `closed=False` to the `Switch` constructor to create an open switch.
   Call `switch.open()` to open an existing switch and `switch.close()` to close it. `switch.closed` tells if the switch
   is closed or not. The switch is closed by default.

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,7 +21,9 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- {gh-pr}`391` {gh-issue}`390` `ElectricalNetwork.to_graph` now returns a multi-graph to preserve parallel edges.
+- {gh-pr}`391` {gh-issue}`390` `ElectricalNetwork.to_graph` now returns a multi-graph to preserve parallel edges. It
+  also gained a `respect_switches` parameter that can be set to `False` to include open switches in the graph. The
+  default value is `True`, which means that open switches are not included in the graph.
 
 - {gh-pr}`389` Add support for open switches. Pass `closed=False` to the `Switch` constructor to create an open switch.
   Call `switch.open()` to open an existing switch and `switch.close()` to close it. `switch.closed` tells if the switch

--- a/doc/usage/Extras.md
+++ b/doc/usage/Extras.md
@@ -19,7 +19,7 @@ myst:
 ## Graph theory
 
 {meth}`ElectricalNetwork.to_graph() <roseau.load_flow.ElectricalNetwork.to_graph>` can be used to get a
-{class}`networkx.Graph` object from the electrical network.
+{class}`networkx.MultiGraph` object from the electrical network.
 
 The graph contains the geometries of the buses in the nodes data and the geometries and branch types in the edges data.
 

--- a/doc/usage/Plotting.md
+++ b/doc/usage/Plotting.md
@@ -95,8 +95,8 @@ network:
 
 If the network does not have geometries defined for its elements, the `plot_interactive_map` function will not work. In
 this case, you can use the {meth}`~roseau.load_flow.ElectricalNetwork.to_graph` method to convert the network to a
-networkx `Graph` and plot it using the `networkx` library. In the following example we plot the graph of the network
-`MVFeeder210` from the previous example:
+networkx `MultiGraph` and plot it using the `networkx` library. In the following example we plot the graph of the
+network `MVFeeder210` from the previous example:
 
 ```pycon
 >>> import networkx as nx

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -49,7 +49,7 @@ from roseau.load_flow.utils import (
 )
 
 if TYPE_CHECKING:
-    from networkx import Graph
+    from networkx import MultiGraph
 
 logger = logging.getLogger(__name__)
 
@@ -367,8 +367,8 @@ class ElectricalNetwork(AbstractNetwork[Element], CatalogueMixin[JsonDict]):
     #
     # Helpers to analyze the network
     #
-    def to_graph(self) -> "Graph":
-        """Create a networkx graph from this electrical network.
+    def to_graph(self) -> "MultiGraph":
+        """Create a networkx multi-graph from this electrical network.
 
         The graph contains the geometries of the buses in the nodes data and the geometries and
         branch types in the edges data.
@@ -378,7 +378,7 @@ class ElectricalNetwork(AbstractNetwork[Element], CatalogueMixin[JsonDict]):
             extra if you are using pip: ``pip install "roseau-load-flow[graph]"``.
         """
         nx = optional_deps.networkx
-        graph = nx.Graph()
+        graph = nx.MultiGraph()
         for bus in self.buses.values():
             graph.add_node(bus.id, geom=bus.geometry)
         for line in self.lines.values():

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -2076,6 +2076,14 @@ def test_to_graph(all_element_network: ElectricalNetwork):
     assert graph.edges[bus1.id, bus2.id, 0]["id"] == tr1.id
     assert graph.edges[bus1.id, bus2.id, 1]["id"] == tr2.id
 
+    # Test open switch
+    sw = Switch(id="Switch", bus1=bus1, bus2=bus2)
+    assert en.to_graph().edges[bus1.id, bus2.id, 2]["id"] == sw.id
+    assert en.to_graph(respect_switches=False).edges[bus1.id, bus2.id, 2]["id"] == sw.id
+    sw.open()
+    assert (bus1.id, bus2.id, 2) not in en.to_graph().edges  # not included by default
+    assert en.to_graph(respect_switches=False).edges[bus1.id, bus2.id, 2]["id"] == sw.id
+
 
 def test_serialization(all_element_network, all_element_network_with_results):
     def assert_results(en_dict: dict, included: bool):

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -31,7 +31,7 @@ from roseau.load_flow_single.models import (
 )
 
 if TYPE_CHECKING:
-    from networkx import Graph
+    from networkx import MultiGraph
 
 logger = logging.getLogger(__name__)
 
@@ -246,8 +246,8 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     #
     # Helpers to analyze the network
     #
-    def to_graph(self) -> "Graph":
-        """Create a networkx graph from this electrical network.
+    def to_graph(self) -> "MultiGraph":
+        """Create a networkx multi-graph from this electrical network.
 
         The graph contains the geometries of the buses in the nodes data and the geometries and
         branch types in the edges data.
@@ -257,7 +257,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             extra if you are using pip: ``pip install "roseau-load-flow[graph]"``.
         """
         nx = optional_deps.networkx
-        graph = nx.Graph()
+        graph = nx.MultiGraph()
         for bus in self.buses.values():
             graph.add_node(bus.id, geom=bus.geometry)
         for line in self.lines.values():

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -246,7 +246,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     #
     # Helpers to analyze the network
     #
-    def to_graph(self) -> "MultiGraph":
+    def to_graph(self, *, respect_switches: bool = True) -> "MultiGraph":
         """Create a networkx multi-graph from this electrical network.
 
         The graph contains the geometries of the buses in the nodes data and the geometries and
@@ -255,6 +255,14 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         Note:
             This method requires *networkx* to be installed. You can install it with the ``"graph"``
             extra if you are using pip: ``pip install "roseau-load-flow[graph]"``.
+
+        Args:
+            respect_switches:
+                Respect the switch state. If ``True`` (default), open switches are not included in
+                the graph. If ``False``, all switches are included regardless of their state.
+
+        Returns:
+            A networkx multi-graph representing the electrical network.
         """
         nx = optional_deps.networkx
         graph = nx.MultiGraph()
@@ -283,7 +291,14 @@ class ElectricalNetwork(AbstractNetwork[Element]):
                 geom=transformer.geometry,
             )
         for switch in self.switches.values():
-            graph.add_edge(switch.bus1.id, switch.bus2.id, id=switch.id, type="switch", geom=switch.geometry)
+            if not respect_switches or switch.closed:
+                graph.add_edge(
+                    switch.bus1.id,
+                    switch.bus2.id,
+                    id=switch.id,
+                    type="switch",
+                    geom=switch.geometry,
+                )
         return graph
 
     #

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -968,6 +968,14 @@ def test_to_graph(small_network: ElectricalNetwork):
     assert graph.edges[bus1.id, bus2.id, 0]["id"] == tr1.id
     assert graph.edges[bus1.id, bus2.id, 1]["id"] == tr2.id
 
+    # Test open switch
+    sw = Switch(id="Switch", bus1=bus1, bus2=bus2)
+    assert en.to_graph().edges[bus1.id, bus2.id, 2]["id"] == sw.id
+    assert en.to_graph(respect_switches=False).edges[bus1.id, bus2.id, 2]["id"] == sw.id
+    sw.open()
+    assert (bus1.id, bus2.id, 2) not in en.to_graph().edges  # not included by default
+    assert en.to_graph(respect_switches=False).edges[bus1.id, bus2.id, 2]["id"] == sw.id
+
 
 def test_serialization(all_elements_network, all_elements_network_with_results):
     def assert_results(en_dict: dict, included: bool):

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -909,10 +909,10 @@ def test_propagate_voltages():
 
 def test_to_graph(small_network: ElectricalNetwork):
     g = small_network.to_graph()
-    assert isinstance(g, nx.Graph)
+    assert isinstance(g, nx.MultiGraph)
     assert sorted(g.nodes) == sorted(small_network.buses)
     assert sorted(g.edges) == sorted(
-        (b.bus1.id, b.bus2.id)
+        (b.bus1.id, b.bus2.id, 0)
         for b in it.chain(
             small_network.lines.values(), small_network.transformers.values(), small_network.switches.values()
         )
@@ -923,7 +923,7 @@ def test_to_graph(small_network: ElectricalNetwork):
         assert node_data["geom"] == bus.geometry
 
     for line in small_network.lines.values():
-        edge_data = g.edges[line.bus1.id, line.bus2.id]
+        edge_data = g.edges[line.bus1.id, line.bus2.id, 0]
         ampacity = ampacity.m if (ampacity := line.parameters.ampacity) is not None else None
         assert edge_data == {
             "id": line.id,
@@ -935,7 +935,7 @@ def test_to_graph(small_network: ElectricalNetwork):
         }
 
     for transformer in small_network.transformers.values():
-        edge_data = g.edges[transformer.bus1.id, transformer.bus2.id]
+        edge_data = g.edges[transformer.bus1.id, transformer.bus2.id, 0]
         assert edge_data == {
             "id": transformer.id,
             "type": "transformer",
@@ -946,8 +946,27 @@ def test_to_graph(small_network: ElectricalNetwork):
         }
 
     for switch in small_network.switches.values():
-        edge_data = g.edges[switch.bus1.id, switch.bus2.id]
+        edge_data = g.edges[switch.bus1.id, switch.bus2.id, 0]
         assert edge_data == {"id": switch.id, "type": "switch", "geom": switch.geometry}
+
+    # Test parallel branches
+    bus1 = Bus(id="Bus1")
+    bus2 = Bus(id="Bus2")
+    tp = TransformerParameters.from_open_and_short_circuit_tests(
+        id="TP", vg="Dyn11", uhv=20000, ulv=400, sn=160 * 1e3, p0=460, i0=2.3 / 100, psc=2350, vsc=4 / 100
+    )
+    tr1 = Transformer(id="Tr1", bus_hv=bus1, bus_lv=bus2, parameters=tp)
+    tr2 = Transformer(id="Tr2", bus_hv=bus1, bus_lv=bus2, parameters=tp)  # parallel to tr1
+    src = VoltageSource(id="Source", bus=bus1, voltage=20e3)
+    en = ElectricalNetwork(buses=[bus1, bus2], transformers=[tr1, tr2], sources=[src], lines=[], switches=[], loads=[])
+    graph = en.to_graph()
+    assert sorted(graph.nodes) == [bus1.id, bus2.id]
+    assert sorted(graph.edges) == [
+        (bus1.id, bus2.id, 0),  # Transformer Tr1
+        (bus1.id, bus2.id, 1),  # Transformer Tr2
+    ]
+    assert graph.edges[bus1.id, bus2.id, 0]["id"] == tr1.id
+    assert graph.edges[bus1.id, bus2.id, 1]["id"] == tr2.id
 
 
 def test_serialization(all_elements_network, all_elements_network_with_results):


### PR DESCRIPTION
Fixes #390 

- Return a multi-graph from the `en.to_graph` method to preserve parallel branches
- Add a `respect_switches` parameter that permits the inclusion of open switches in the graph when set to False. By default open switches are *not* included in the graph.