### PR TITLE
Fix disconnecting loads and sources

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,11 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`392` Disconnect a ground connection of a load or source when the load or source is disconnected from the
+  network. Add `is_disconnected` property to loads, sources and ground connections to check if the element is
+  disconnected. In the future, accessing the bus of a disconnected load or source will return the original bus instead
+  of `None`, use `is_disconnected` to check if the load or source is disconnected.
+
 - {gh-pr}`391` {gh-issue}`390` `ElectricalNetwork.to_graph` now returns a multi-graph to preserve parallel edges. It
   also gained a `respect_switches` parameter that can be set to `False` to include open switches in the graph. The
   default value is `True`, which means that open switches are not included in the graph.

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -344,10 +344,16 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
         # Connect the ground to the second side of the ground connection.
         self._ground._cy_element.connect(self._cy_element, [(0, 1)])
 
+    @property
+    def is_disconnected(self) -> bool:
+        """Is this ground connection disconnected from the network?"""
+        return self._is_disconnected
+
     #
     # Results
     #
     def _refresh_results(self) -> None:
+        self._raise_disconnected_error()
         if self._fetch_results:
             self._res_current = self._cy_element.get_port_current(0)
 
@@ -377,6 +383,7 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
         return self
 
     def _to_dict(self, include_results: bool) -> JsonDict:
+        self._raise_disconnected_error()
         data: JsonDict = {
             "id": self.id,
             "ground": self._ground.id,
@@ -392,6 +399,7 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
         return data
 
     def _results_to_dict(self, warning: bool, full: bool) -> JsonDict:
+        self._raise_disconnected_error()
         current = self._res_current_getter(warning)
         results: JsonDict = {"id": self.id, "current": [current.real, current.imag]}
         return results

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -73,8 +73,9 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
         return False
 
     def _refresh_results(self) -> None:
-        if self._fetch_results:
-            super()._refresh_results()
+        fetch_results = self._fetch_results
+        super()._refresh_results()
+        if fetch_results:
             self._res_inner_currents = self._cy_element.get_inner_currents(self._size)
 
     def _res_inner_currents_getter(self, warning: bool) -> ComplexArray:
@@ -339,10 +340,10 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyDeltaPowerLoad | CyFlexibleLoad | C
             self._cy_element.update_powers(self._powers)
 
     def _refresh_results(self) -> None:
-        if self._fetch_results:
-            super()._refresh_results()
-            if self.is_flexible:
-                self._res_flexible_powers = self._cy_element.get_powers(self._n)
+        fetch_results = self._fetch_results
+        super()._refresh_results()
+        if fetch_results and self.is_flexible:
+            self._res_flexible_powers = self._cy_element.get_powers(self._n)
 
     def _res_flexible_powers_getter(self, warning: bool) -> ComplexArray:
         self._refresh_results()

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -118,10 +118,28 @@ def test_connect_and_disconnect():
     # Disconnection of a load
     assert load.network == en
     load.disconnect()
+    assert load.is_disconnected
     assert load.network is None
-    assert load.bus is None
+    with pytest.warns(
+        UserWarning,
+        match=(
+            r"Accessing the bus of the disconnected load 'power load' will change in the future to "
+            r"return the bus it was connected to before disconnection instead of None. If you rely "
+            r"on this behavior to check if the element is disconnected, please use `is_disconnected` "
+            r"instead"
+        ),
+    ):
+        assert load.bus is None
     with pytest.raises(RoseauLoadFlowException) as e:
         load.to_dict()
+    assert e.value.msg == "The load 'power load' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        load.results_to_dict()
+    assert e.value.msg == "The load 'power load' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        _ = load.res_currents
     assert e.value.msg == "The load 'power load' is disconnected and cannot be used anymore."
     assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
     new_load = PowerLoad(id="power load", phases="abcn", bus=load_bus, powers=[100 + 0j, 100 + 0j, 100 + 0j])
@@ -130,11 +148,39 @@ def test_connect_and_disconnect():
     # Disconnection of a source
     assert vs.network == en
     vs.disconnect()
+    assert vs.is_disconnected
     assert vs.network is None
-    assert vs.bus is None
+    with pytest.warns(
+        UserWarning,
+        match=(
+            r"Accessing the bus of the disconnected source 'vs' will change in the future to "
+            r"return the bus it was connected to before disconnection instead of None. If you rely "
+            r"on this behavior to check if the element is disconnected, please use `is_disconnected` "
+            r"instead"
+        ),
+    ):
+        assert vs.bus is None
     with pytest.raises(RoseauLoadFlowException) as e:
         vs.to_dict()
     assert e.value.msg == "The source 'vs' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        vs.results_to_dict()
+    assert e.value.msg == "The source 'vs' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        _ = vs.res_currents
+    assert e.value.msg == "The source 'vs' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+
+    # Disconnection of an element with a ground connection
+    gc = GroundConnection(ground=ground, element=new_load, id="gc")
+    assert not gc.is_disconnected
+    new_load.disconnect()
+    assert gc.is_disconnected
+    with pytest.raises(RoseauLoadFlowException) as e:
+        _ = gc.res_current
+    assert e.value.msg == "The ground connection 'gc' is disconnected and cannot be used anymore."
     assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
 
     # Bad key

--- a/roseau/load_flow_single/models/connectables.py
+++ b/roseau/load_flow_single/models/connectables.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import ClassVar
 
-from roseau.load_flow import SQRT3, RoseauLoadFlowException, RoseauLoadFlowExceptionCode
+from roseau.load_flow import SQRT3
 from roseau.load_flow.typing import Id, JsonDict, Side
 from roseau.load_flow.units import Q_, ureg_wraps
 from roseau.load_flow.utils import abstractattrs
@@ -43,7 +43,7 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
         self._res_current: complex | None = None
 
     def __repr__(self) -> str:
-        args = [f"id={self.id!r}", f"bus={repr(self.bus.id) if self.bus is not None else '<disconnected>'}"]
+        args = [f"id={self.id!r}", f"bus={self.bus.id!r}"]
         side = f"-{self._side_value}" if self._side_value is not None else ""
         return f"<{type(self).__name__}{side}: {', '.join(args)}>"
 
@@ -127,17 +127,18 @@ class AbstractDisconnectable(AbstractConnectable[_CyE_co], ABC):
 
     type: ClassVar[str]
 
+    @property
+    def is_disconnected(self) -> bool:
+        """Is this element disconnected from the network?"""
+        return self._is_disconnected
+
     def disconnect(self) -> None:
         """Disconnect this element from the network. It cannot be used afterwards."""
         self._disconnect()
-        self._bus = None
 
-    def _raise_disconnected_error(self) -> None:
-        """Raise an error if the element is disconnected."""
-        if self._bus is None:
-            msg = f"The {self.element_type} {self.id!r} is disconnected and cannot be used anymore."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT)
+    def _refresh_results(self) -> None:
+        self._raise_disconnected_error()
+        super()._refresh_results()
 
     def _to_dict(self, include_results: bool) -> JsonDict:
         self._raise_disconnected_error()
@@ -146,7 +147,6 @@ class AbstractDisconnectable(AbstractConnectable[_CyE_co], ABC):
         return results
 
     def _results_to_dict(self, warning: bool, full: bool) -> JsonDict:
-        self._raise_disconnected_error()
         results = super()._results_to_dict(warning, full=full)
         results["type"] = self.type
         return results

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -88,10 +88,19 @@ def test_connect_and_disconnect():
     # Disconnection of a load
     assert load.network == en
     load.disconnect()
+    assert load.is_disconnected
     assert load.network is None
-    assert load.bus is None
+    assert load.bus is load_bus
     with pytest.raises(RoseauLoadFlowException) as e:
         load.to_dict()
+    assert e.value.msg == "The load 'power load' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        load.results_to_dict()
+    assert e.value.msg == "The load 'power load' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        _ = load.res_current
     assert e.value.msg == "The load 'power load' is disconnected and cannot be used anymore."
     assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
     new_load = PowerLoad(id="power load", bus=load_bus, power=100 + 0j)
@@ -100,10 +109,19 @@ def test_connect_and_disconnect():
     # Disconnection of a source
     assert vs.network == en
     vs.disconnect()
+    assert vs.is_disconnected
     assert vs.network is None
-    assert vs.bus is None
+    assert vs.bus is source_bus
     with pytest.raises(RoseauLoadFlowException) as e:
         vs.to_dict()
+    assert e.value.msg == "The source 'vs' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        vs.results_to_dict()
+    assert e.value.msg == "The source 'vs' is disconnected and cannot be used anymore."
+    assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
+    with pytest.raises(RoseauLoadFlowException) as e:
+        _ = vs.res_current
     assert e.value.msg == "The source 'vs' is disconnected and cannot be used anymore."
     assert e.value.code == RoseauLoadFlowExceptionCode.DISCONNECTED_ELEMENT
 


### PR DESCRIPTION
The following changes are made:
- Disconnect a ground connection of a load or source when the load or source is disconnected from the network
- Raise a clear error message when accessing any result of a disconnected element
- Add `is_disconnected` property to loads, sources and ground connections to check if the element is disconnected
- In the future, accessing the bus of a disconnected load or source will return the original bus instead of `None`. Use `is_disconnected` to check if the load or source is disconnected.

About changing the bus to no longer be `None` for disconnected elements, I find myself needing to access the bus in many cases mainly to connect another element to it. The new behavior works well as it guarantees a clear error message when the user tries to access the results of a disconnected element while keeping access to its bus.