### PR TITLE
Improve plotting interactive map

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,8 +21,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- {gh-pr}`395` Improve line and bus hover information of interactive map. Fix automatic zoom calculation when the whole
-  network is on the same longitude or latitude.
+- {gh-pr}`395` Improve line and bus hover information in interactive map plots. Fix an error in automatic zoom
+  calculation when the whole network is on the same longitude or latitude.
 
 - {gh-pr}`394` Add support for musl linux distributions. Also add preliminary support for python 3.14 development
   version and for free-threaded python 3.13t. Full support is waiting on our dependencies to release relevant wheels.

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,9 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`395` Improve line and bus hover information of interactive map. Fix automatic zoom calculation when the whole
+  network is on the same longitude or latitude.
+
 - {gh-pr}`394` Add support for musl linux distributions. Also add preliminary support for python 3.14 development
   version and for free-threaded python 3.13t. Full support is waiting on our dependencies to release relevant wheels.
 

--- a/roseau/load_flow/plotting.py
+++ b/roseau/load_flow/plotting.py
@@ -459,7 +459,7 @@ def plot_interactive_map(  # noqa: C901
         "length": "Length (km):",
         "line_type": "Line Type:",
         "material": "Material:",
-        "insulator": "Insulator",
+        "insulator": "Insulator:",
         "section": "Section (mm²):",
         "ampacity": "Ampacity (A):",
         "max_loading": "Max loading (%):",

--- a/roseau/load_flow/tests/test_plotting.py
+++ b/roseau/load_flow/tests/test_plotting.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+import roseau.load_flow_single as rlfs
 from roseau.load_flow.models import (
     Bus,
     Line,
@@ -45,6 +46,8 @@ load._res_potentials = np.array(potentials, dtype=np.complex128)
 load._res_currents = np.array(currents, dtype=np.complex128)
 source._res_potentials = np.array(potentials, dtype=np.complex128)
 source._res_currents = np.array(-currents, dtype=np.complex128)
+bus_single = rlfs.Bus(id="Bus")
+bus_single._res_voltage = 400 + 0j
 
 
 @pytest.mark.usefixtures("mock_gca")
@@ -112,7 +115,11 @@ def test_plot_voltage_phasors_errors():
 
     # Bad side
     with pytest.raises(ValueError, match=r"The side argument is only valid for branch elements"):
-        plot_voltage_phasors(bus_abc, side="HV")
+        plot_voltage_phasors(bus_abc, side="HV")  # type: ignore
+
+    # Not a multi-phase element
+    with pytest.raises(TypeError, match=r"Only multi-phase elements can be plotted. Did you mean to use rlf.Bus\?"):
+        plot_voltage_phasors(bus_single)  # type: ignore
 
 
 @pytest.mark.usefixtures("mock_gca")
@@ -202,3 +209,7 @@ def test_plot_symmetrical_voltages():
         assert ax.scatter.call_count == 3  # 1 "a" + "b" + "c"
         assert ax.arrow.call_count == 3
         assert ax.annotate.call_count == 1
+
+    # Not a multi-phase element
+    with pytest.raises(TypeError, match=r"Only multi-phase elements can be plotted. Did you mean to use rlf.Bus\?"):
+        plot_symmetrical_voltages(bus_single)  # type: ignore

--- a/roseau/load_flow_single/__init__.py
+++ b/roseau/load_flow_single/__init__.py
@@ -31,6 +31,7 @@ from roseau.load_flow import (
     utils,
 )
 from roseau.load_flow.units import Q_, ureg
+from roseau.load_flow_single import plotting
 from roseau.load_flow_single.models import (
     AbstractBranch,
     AbstractConnectable,
@@ -65,6 +66,7 @@ __all__ = [
     "__status__",
     "__url__",
     "__version__",
+    "plotting",
     "Element",
     "Line",
     "LineParameters",

--- a/roseau/load_flow_single/plotting.py
+++ b/roseau/load_flow_single/plotting.py
@@ -1,0 +1,1 @@
+from roseau.load_flow.plotting import plot_interactive_map as plot_interactive_map

--- a/roseau/load_flow_single/tests/test_multi_compat.py
+++ b/roseau/load_flow_single/tests/test_multi_compat.py
@@ -23,8 +23,6 @@ def test_import():
         "ALPHA",
         "ALPHA2",
         "converters",
-        # Plotting
-        "plotting",
         # Symmetrical components
         "sym",
         # Underscore things


### PR DESCRIPTION
- Fix an error when plotting a network with all its geometries on the same longitude or latitude and `zoom_start` is not provided
- Add more information to the hover over lines and buses
- Emit a clear error if an rlfs element was passed to plotting functions that accept rlf elements only
- [single] Support plotting rlfs networks and add `rlfs.plotting` module