### PR TITLE
[single] Add conversion from rlf including for catalogue networks

### DIFF
--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -118,7 +118,7 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource | CyDeltaVoltageSourc
             msg = f"Incorrect number of voltages: {len(voltages)} instead of {self._size}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg, code=RoseauLoadFlowExceptionCode.BAD_VOLTAGES_SIZE)
-        self._voltages = voltages
+        self._voltages: ComplexArray = voltages
         self._invalidate_network_results()
         if self._cy_initialized:
             self._cy_element.update_voltages(self._voltages)

--- a/roseau/load_flow_single/io/__init__.py
+++ b/roseau/load_flow_single/io/__init__.py
@@ -7,10 +7,12 @@ corresponding methods of the :class:`~roseau.load_flow_single.ElectricalNetwork`
 
 from roseau.load_flow_single.io.dgs import network_from_dgs, network_to_dgs
 from roseau.load_flow_single.io.dict import network_from_dict, network_to_dict
+from roseau.load_flow_single.io.rlf import network_from_rlf
 
 __all__ = [
     "network_from_dict",
     "network_to_dict",
     "network_from_dgs",
     "network_to_dgs",
+    "network_from_rlf",
 ]

--- a/roseau/load_flow_single/io/rlf.py
+++ b/roseau/load_flow_single/io/rlf.py
@@ -1,0 +1,311 @@
+import cmath
+import logging
+import warnings
+from typing import Literal, TypeAlias
+
+import numpy as np
+
+import roseau.load_flow as rlf
+from roseau.load_flow.typing import ComplexArray, Id, JsonDict
+from roseau.load_flow.utils import find_stack_level
+from roseau.load_flow_single.io.common import NetworkElements
+from roseau.load_flow_single.models import (
+    AbstractLoad,
+    Bus,
+    CurrentLoad,
+    FlexibleParameter,
+    ImpedanceLoad,
+    Line,
+    LineParameters,
+    PowerLoad,
+    Switch,
+    Transformer,
+    TransformerParameters,
+    VoltageSource,
+)
+
+logger = logging.getLogger(__name__)
+
+OnIncompatibleType: TypeAlias = Literal["ignore", "warn", "raise-critical", "raise"]
+
+
+def _handle_incompatibility(msg: str, on_incompatible: OnIncompatibleType, critical: bool = True) -> None:
+    if on_incompatible == "ignore":
+        pass
+    elif on_incompatible == "warn":
+        warnings.warn(msg, UserWarning, stacklevel=find_stack_level())
+    elif on_incompatible == "raise-critical":
+        if critical:
+            raise RuntimeError(msg)
+        else:
+            warnings.warn(msg, UserWarning, stacklevel=find_stack_level())
+    elif on_incompatible == "raise":
+        raise RuntimeError(msg)
+    else:
+        raise ValueError(
+            f"Invalid value for `on_incompatible`: {on_incompatible!r}. Expected one of 'ignore', "
+            f"'warn', 'raise-critical', or 'raise'."
+        )
+
+
+def _handle_floating_neutral(element_m: rlf.AbstractConnectable, on_incompatible: OnIncompatibleType) -> None:
+    if element_m.has_floating_neutral:
+        _handle_incompatibility(
+            f"{element_m.element_type!r} {element_m.id!r} {element_m._side_desc}has a floating neutral, which is not supported.",
+            on_incompatible=on_incompatible,
+            critical=False,
+        )
+
+
+def _balance_voltages(ph: str, voltages: ComplexArray, msg: str, on_incompatible: OnIncompatibleType) -> complex:
+    """Calculate and return Vab to be used in the single-phase equivalent network."""
+    if ph in ("abc", "abcn"):  # "abc" or "abcn" (most common case)
+        if ph.endswith("n"):
+            van, vbn, vcn = voltages.tolist()
+            voltages = np.array([van - vbn, vbn - vcn, vcn - van], dtype=np.complex128)
+        voltage = voltages.item(0)
+        if not np.allclose(voltages, voltage * rlf.PositiveSequence):
+            _handle_incompatibility(msg, on_incompatible=on_incompatible)
+    elif ph in ("abn", "bcn", "can"):  # abn, bcn, can
+        v1n, v2n = voltages.tolist()
+        if ph == "abn":
+            voltage = v1n - v2n
+        elif ph == "bcn":
+            voltage = (v1n - v2n) / rlf.ALPHA2
+        elif ph == "can":
+            voltage = (v1n - v2n) / rlf.ALPHA
+        if not cmath.isclose(v2n, v1n * rlf.ALPHA2):
+            _handle_incompatibility(msg, on_incompatible=on_incompatible)
+    elif ph == "ab":
+        voltage = voltages.item(0)
+    elif ph == "bc":
+        voltage = voltages.item(0) / rlf.ALPHA2
+    elif ph == "ca":
+        voltage = voltages.item(0) / rlf.ALPHA
+    elif ph == "an":
+        van = voltages.item(0)
+        vbn = van * rlf.ALPHA2
+        voltage = van - vbn
+    elif ph == "bn":
+        vbn = voltages.item(0)
+        van = vbn / rlf.ALPHA2
+        voltage = van - vbn
+    elif ph == "cn":
+        vcn = voltages.item(0)
+        van = vcn / rlf.ALPHA
+        vbn = vcn * rlf.ALPHA
+        voltage = van - vbn
+    else:
+        raise AssertionError(ph)
+    return voltage
+
+
+def network_from_rlf(  # noqa: C901
+    en_m: rlf.ElectricalNetwork, /, *, on_incompatible: OnIncompatibleType
+) -> tuple[NetworkElements, dict[str, JsonDict]]:
+    """Convert a multi-phase electrical network to a single-phase one.
+
+    Args:
+        en_m:
+            The multi-phase electrical network. Buses and branches must be three-phase.
+
+        on_incompatible:
+            Action to take when an incompatibility is found. Options are:
+            - "ignore": Ignore incompatible elements.
+            - "warn": Issue a warning but continue processing.
+            - "raise-critical": Raise on critical incompatibilities, warn on non-critical ones.
+            - "raise": Raise an exception for all incompatibilities.
+
+    Returns:
+        A tuple containing:
+            - `NetworkElements`: The converted network elements
+            - `dict[str, JsonDict]`: Tool data for the network
+    """
+    if not isinstance(en_m, rlf.ElectricalNetwork):
+        raise TypeError(f"Expected an instance of `rlf.ElectricalNetwork`, got {type(en_m)}")
+
+    # Check grounds
+    if (n_grounds := len(en_m.grounds)) != 1:
+        _handle_incompatibility(
+            f"Expected 1 ground, found {n_grounds}", on_incompatible=on_incompatible, critical=False
+        )
+
+    # Check ground connections
+    for gc in en_m.ground_connections.values():
+        if gc.phase != "n":
+            _handle_incompatibility(
+                f"Ground connection {gc.id!r} has incompatible phases {gc.phase!r}, expected 'n'",
+                on_incompatible=on_incompatible,
+                critical=False,
+            )
+
+    # Check potential references
+    for pref in en_m.potential_refs.values():
+        if pref.phases not in ("abc", "abcn", "n", None):
+            _handle_incompatibility(
+                f"Potential ref {pref.id!r} has incompatible phases {pref.phases!r}, expected 'abc', 'abcn', or 'n'",
+                on_incompatible=on_incompatible,
+                critical=False,
+            )
+
+    # Convert buses
+    buses: dict[Id, Bus] = {}
+    for bus_m in en_m.buses.values():
+        ph = bus_m.phases
+        if "abc" not in ph:
+            raise RuntimeError(f"Bus {bus_m.id!r} is not three-phase, phases={ph!r}")
+        if bus_m._initialized_by_the_user and (init_pot := bus_m._initial_potentials) is not None:
+            pot_balanced = [*(init_pot.item(0) * rlf.PositiveSequence)]
+            if "n" in ph:
+                pot_balanced.append(0j)
+            if not (np.isclose(init_pot, pot_balanced).all()):
+                _handle_incompatibility(
+                    f"Bus {bus_m.id!r} has unbalanced initial_potentials",
+                    on_incompatible=on_incompatible,
+                    critical=False,
+                )
+            v_i = init_pot.item(0) - init_pot.item(1)  # Vab
+        else:
+            v_i = None
+
+        bus_s = Bus(
+            id=bus_m.id,
+            nominal_voltage=bus_m._nominal_voltage,
+            min_voltage_level=bus_m._min_voltage_level,
+            max_voltage_level=bus_m._max_voltage_level,
+            initial_voltage=v_i,
+            geometry=bus_m.geometry,
+        )
+        buses[bus_s.id] = bus_s
+
+    # Convert line and transformer parameters
+    ln_params_m: set[Id] = set()
+    ln_params_s: dict[Id, LineParameters] = {}
+    for ln_m in en_m.lines.values():
+        lp_m = ln_m.parameters
+        if lp_m.id in ln_params_m:
+            continue
+        ln_params_m.add(lp_m.id)
+        lp_s = LineParameters.from_roseau_load_flow(lp_m)
+        ln_params_s[lp_s.id] = lp_s
+
+    tr_params_m: set[Id] = set()
+    tr_params_s: dict[Id, TransformerParameters] = {}
+    for tr_m in en_m.transformers.values():
+        tp_m = tr_m.parameters
+        if tp_m.id in tr_params_m:
+            continue
+        tr_params_m.add(tp_m.id)
+        tp_s = TransformerParameters.from_roseau_load_flow(tp_m)
+        tr_params_s[tp_s.id] = tp_s
+
+    # Convert lines
+    lines: dict[Id, Line] = {}
+    for ln_m in en_m.lines.values():
+        if "abc" not in ln_m.phases:
+            raise RuntimeError(f"Line {ln_m.id!r} is not three-phase, phases={ln_m.phases!r}")
+        ln_s = Line(
+            id=ln_m.id,
+            bus1=buses[ln_m.side1.bus.id],
+            bus2=buses[ln_m.side2.bus.id],
+            parameters=ln_params_s[ln_m.parameters.id],
+            length=ln_m._length,
+            max_loading=ln_m._max_loading,
+            geometry=ln_m.geometry,
+        )
+        lines[ln_s.id] = ln_s
+
+    # Convert transformers
+    transformers: dict[Id, Transformer] = {}
+    for tr_m in en_m.transformers.values():
+        # Three-phase check done in parameters
+        tr_s = Transformer(
+            id=tr_m.id,
+            bus_hv=buses[tr_m.side_hv.bus.id],
+            bus_lv=buses[tr_m.side_lv.bus.id],
+            parameters=tr_params_s[tr_m.parameters.id],
+            tap=tr_m.tap,
+            max_loading=tr_m._max_loading,
+            geometry=tr_m.geometry,
+        )
+        _handle_floating_neutral(tr_m.side_hv, on_incompatible=on_incompatible)
+        _handle_floating_neutral(tr_m.side_lv, on_incompatible=on_incompatible)
+        transformers[tr_s.id] = tr_s
+
+    # Convert switches
+    switches: dict[Id, Switch] = {}
+    for sw_m in en_m.switches.values():
+        if "abc" not in sw_m.phases:
+            raise RuntimeError(f"Switch {sw_m.id!r} is not three-phase, phases={sw_m.phases!r}")
+        sw_s = Switch(
+            id=sw_m.id,
+            bus1=buses[sw_m.bus1.id],
+            bus2=buses[sw_m.bus2.id],
+            closed=sw_m.closed,
+            geometry=sw_m.geometry,
+        )
+        switches[sw_s.id] = sw_s
+
+    # Convert sources
+    sources: dict[Id, VoltageSource] = {}
+    for src_m in en_m.sources.values():
+        ph = src_m.phases
+        if "abc" not in ph:
+            _handle_incompatibility(
+                f"Source {src_m.id!r} is not three-phase, phases={ph!r}", on_incompatible=on_incompatible
+            )
+        voltage = _balance_voltages(
+            ph,
+            voltages=src_m._voltages,
+            msg=f"Source {src_m.id!r} has unbalanced voltages",
+            on_incompatible=on_incompatible,
+        )
+        _handle_floating_neutral(src_m, on_incompatible=on_incompatible)
+        src_s = VoltageSource(id=src_m.id, bus=buses[src_m.bus.id], voltage=voltage)
+        sources[src_s.id] = src_s
+
+    # Convert loads
+    loads: dict[Id, AbstractLoad] = {}
+    for ld_m in en_m.loads.values():
+        ph = ld_m.phases
+        if "abc" not in ph:
+            _handle_incompatibility(
+                f"Load {ld_m.id!r} is not three-phase, phases={ph!r}", on_incompatible=on_incompatible
+            )
+        if isinstance(ld_m, rlf.PowerLoad):
+            if np.unique_values(ld_m._powers).size != 1:
+                _handle_incompatibility(f"Load {ld_m.id!r} has unbalanced powers", on_incompatible=on_incompatible)
+            if ld_m.flexible_params is None:
+                fp_s = None
+            else:
+                if not all(fp == ld_m.flexible_params[0] for fp in ld_m.flexible_params[1:]):
+                    _handle_incompatibility(
+                        f"Load {ld_m.id!r} has unbalanced flexible parameters", on_incompatible=on_incompatible
+                    )
+                fp_s = FlexibleParameter.from_roseau_load_flow(ld_m.flexible_params[0], phases=ld_m.voltage_phases[0])
+            ld_s = PowerLoad(id=ld_m.id, bus=buses[ld_m.bus.id], power=ld_m._powers.sum(), flexible_param=fp_s)
+        elif isinstance(ld_m, rlf.CurrentLoad):
+            if np.unique_values(ld_m._currents).size != 1:
+                _handle_incompatibility(f"Load {ld_m.id!r} has unbalanced currents", on_incompatible=on_incompatible)
+            ld_s = CurrentLoad(id=ld_m.id, bus=buses[ld_m.bus.id], current=ld_m._currents.item(0))
+        elif isinstance(ld_m, rlf.ImpedanceLoad):
+            if np.unique_values(ld_m._impedances).size != 1:
+                _handle_incompatibility(f"Load {ld_m.id!r} has unbalanced impedances", on_incompatible=on_incompatible)
+            ld_s = ImpedanceLoad(id=ld_m.id, bus=buses[ld_m.bus.id], impedance=np.mean(ld_m._impedances).item())
+        else:
+            raise NotImplementedError(f"Load type {ld_m.type!r} is not implemented.")
+        _handle_floating_neutral(ld_m, on_incompatible=on_incompatible)
+        loads[ld_s.id] = ld_s
+
+    return (
+        {
+            "buses": buses,
+            "lines": lines,
+            "transformers": transformers,
+            "switches": switches,
+            "loads": loads,
+            "sources": sources,
+            "crs": en_m.crs,
+        },
+        en_m.tool_data.to_dict(),
+    )

--- a/roseau/load_flow_single/io/tests/test_rlf.py
+++ b/roseau/load_flow_single/io/tests/test_rlf.py
@@ -1,0 +1,277 @@
+import cmath
+import warnings
+
+import numpy as np
+import pytest
+from shapely import LineString, Point
+
+import roseau.load_flow as rlf
+import roseau.load_flow_single as rlfs
+from roseau.load_flow_single.io.rlf import _balance_voltages
+
+
+def test_from_rlf():  # noqa: C901
+    gnd = rlf.Ground(id="Gnd")
+    bus1_m = rlf.Bus(
+        id="Bus1",
+        phases="abc",
+        nominal_voltage=20e3,
+        min_voltage_level=0.95,
+        max_voltage_level=1.05,
+        geometry=Point(0.0, 1.0),
+        initial_potentials=15e3 / rlf.SQRT3 * rlf.PositiveSequence,  # 15 kV not 20 kV
+    )
+    bus2_m = rlf.Bus(
+        id="Bus2",
+        phases="abc",
+        nominal_voltage=20e3,
+        min_voltage_level=0.95,
+        max_voltage_level=1.05,
+        geometry=Point(0.0, 2.0),
+    )
+    bus3_m = rlf.Bus(
+        id="Bus3",
+        phases="abcn",
+        nominal_voltage=400,
+        max_voltage_level=1.1,
+        geometry=Point(0.0, 2.0),
+    )
+    bus4_m = rlf.Bus(
+        id="Bus4",
+        phases="abcn",
+        nominal_voltage=400,
+        min_voltage_level=0.9,
+        max_voltage_level=1.1,
+    )
+    bus5_m = rlf.Bus(
+        id="Bus5",
+        phases="abcn",
+        nominal_voltage=400,
+        min_voltage_level=0.9,
+        geometry=Point(0.0, 4.0),
+    )
+    lp_m = rlf.LineParameters.from_catalogue("U_AL_150")
+    ln_m = rlf.Line(
+        id="Ln",
+        bus1=bus1_m,
+        bus2=bus2_m,
+        parameters=lp_m,
+        length=0.5,
+        geometry=LineString([(0.0, 1.0), (0.0, 2.0)]),
+        max_loading=0.8,
+        ground=gnd,
+    )
+    tp_m = rlf.TransformerParameters.from_open_and_short_circuit_tests(
+        id="TP", vg="Dyn11", uhv=20e3, ulv=400, sn=160e3, p0=460, i0=2.3 / 100, psc=2350, vsc=4 / 100
+    )
+    tr_m = rlf.Transformer(
+        id="Tr",
+        bus_hv=bus2_m,
+        bus_lv=bus3_m,
+        parameters=tp_m,
+        tap=1.025,
+        max_loading=0.9,
+        geometry=Point(0.0, 2.0),
+    )
+    sw_m = rlf.Switch(
+        id="Sw",
+        bus1=bus3_m,
+        bus2=bus4_m,
+        closed=True,
+        geometry=LineString([(0.0, 2.0), (0.0, 3.0)]),
+    )
+    rlf.Switch(id="Sw2", bus1=bus3_m, bus2=bus4_m, closed=False)
+    lp2_m = rlf.LineParameters(id="LP2", z_line=(0.01 + 0.01j) * np.eye(4), insulators=rlf.Insulator.XLPE)
+    rlf.Line(id="Ln2", bus1=bus4_m, bus2=bus5_m, parameters=lp2_m, length=0.1)
+
+    src_m = rlf.VoltageSource(id="Src", bus=bus1_m, voltages=20e3)
+    rlf.PowerLoad(id="PL", bus=bus2_m, powers=20e3)  # 60 kW MV load
+
+    rlf.GroundConnection(ground=gnd, element=bus3_m)
+    rlf.PotentialRef(id="PRef", element=gnd)
+    en_m = rlf.ElectricalNetwork.from_element(bus1_m)
+
+    with warnings.catch_warnings(action="error"):
+        en_s = rlfs.ElectricalNetwork.from_rlf(en_m, on_incompatible="ignore")
+
+    assert len(en_s.buses) == len(en_m.buses)
+    assert len(en_s.lines) == len(en_m.lines)
+    assert len(en_s.transformers) == len(en_m.transformers)
+    assert len(en_s.switches) == len(en_m.switches)
+    assert len(en_s.loads) == len(en_m.loads)
+    assert len(en_s.sources) == len(en_m.sources)
+
+    # Buses
+    for bus_id, bus_s in en_s.buses.items():
+        bus_m = en_m.buses[bus_id]
+        assert bus_s.id == bus_m.id
+        assert bus_s.nominal_voltage == bus_m.nominal_voltage
+        assert bus_s.min_voltage_level == bus_m.min_voltage_level
+        assert bus_s.max_voltage_level == bus_m.max_voltage_level
+        assert bus_s.geometry == bus_m.geometry
+        if bus_m.initial_potentials is None:
+            assert bus_s.initial_voltage is None
+        else:
+            assert bus_s.initial_voltage is not None
+            assert np.isclose(
+                bus_s.initial_voltage.m,
+                rlf.converters.calculate_voltages(bus_m.initial_potentials.m[:3], bus_m.phases[:3]).m.item(0),
+            )
+
+    # Line parameters
+    ln_params_done = set()
+    for ln_id, ln_s in en_s.lines.items():
+        lp_s = ln_s.parameters
+        if lp_s.id in ln_params_done:
+            continue
+        ln_params_done.add(lp_s.id)
+        lp_m = en_m.lines[ln_id].parameters
+        assert lp_s.id == lp_m.id
+        assert lp_s.line_type == lp_m.line_type
+        if lp_m.materials is None:
+            assert lp_s.material is None
+        else:
+            assert lp_s.material == lp_m.materials.item(0)
+        if lp_m.insulators is None:
+            assert lp_s.insulator is None
+        else:
+            assert lp_s.insulator == lp_m.insulators.item(0)
+        if lp_m.sections is None:
+            assert lp_s.section is None
+        else:
+            assert lp_s.section is not None
+            assert lp_s.section.m == lp_m.sections.m.item(0)
+        # Actual line parameters conversion is tested in test_line_parameters.py
+        assert np.allclose(lp_s.z_line.m, lp_m.z_line.m.item((0, 0)))
+        assert np.allclose(lp_s.y_shunt.m, lp_m.y_shunt.m.item((0, 0)))
+
+    # Transformer parameters
+    tr_params_done = set()
+    for tr_id, tr_s in en_s.transformers.items():
+        tp_s = tr_s.parameters
+        if tp_s.id in tr_params_done:
+            continue
+        tr_params_done.add(tp_s.id)
+        tp_m = en_m.transformers[tr_id].parameters
+        assert tp_s.id == tp_m.id
+        assert tp_s.vg == tp_m.vg
+        assert tp_s.cooling == tp_m.cooling
+        assert tp_s.insulation == tp_m.insulation
+        assert tp_s.fn == tp_m.fn
+        assert tp_s.efficiency == tp_m.efficiency
+        assert tp_s.manufacturer == tp_m.manufacturer
+        assert tp_s.range == tp_m.range
+        assert np.isclose(tp_s.uhv.m, tp_m.uhv.m)
+        assert np.isclose(tp_s.ulv.m, tp_m.ulv.m)
+        assert np.isclose(tp_s.sn.m, tp_m.sn.m)
+        assert np.isclose(tp_s.z2.m, tp_m.z2.m)
+        assert np.isclose(tp_s.ym.m, tp_m.ym.m)
+        assert np.isclose(tp_s.p0.m, tp_m.p0.m)
+        assert np.isclose(tp_s.i0.m, tp_m.i0.m)
+        assert np.isclose(tp_s.psc.m, tp_m.psc.m)
+        assert np.isclose(tp_s.vsc.m, tp_m.vsc.m)
+
+    # Lines
+    for ln_id, ln_s in en_s.lines.items():
+        ln_m = en_m.lines[ln_id]
+        assert ln_s.id == ln_m.id
+        assert ln_s.bus1.id == ln_m.bus1.id
+        assert ln_s.bus2.id == ln_m.bus2.id
+        assert ln_s.parameters.id == ln_m.parameters.id
+        assert np.isclose(ln_s.length.m, ln_m.length.m)
+        assert np.isclose(ln_s.max_loading.m, ln_m.max_loading.m)
+        assert ln_s.geometry == ln_m.geometry
+
+    # Transformers
+    for tr_id, tr_s in en_s.transformers.items():
+        tr_m = en_m.transformers[tr_id]
+        assert tr_s.id == tr_m.id
+        assert tr_s.bus_hv.id == tr_m.bus_hv.id
+        assert tr_s.bus_lv.id == tr_m.bus_lv.id
+        assert tr_s.parameters.id == tr_m.parameters.id
+        assert np.isclose(tr_s.tap, tr_m.tap)
+        assert np.isclose(tr_s.max_loading.m, tr_m.max_loading.m)
+        assert tr_s.geometry == tr_m.geometry
+
+    # Switches
+    for sw_id, sw_s in en_s.switches.items():
+        sw_m = en_m.switches[sw_id]
+        assert sw_s.id == sw_m.id
+        assert sw_s.bus1.id == sw_m.bus1.id
+        assert sw_s.bus2.id == sw_m.bus2.id
+        assert sw_s.closed == sw_m.closed
+        assert sw_s.geometry == sw_m.geometry
+
+    # Sources
+    for src_id, src_s in en_s.sources.items():
+        src_m = en_m.sources[src_id]
+        assert src_s.id == src_m.id
+        assert src_s.bus.id == src_m.bus.id
+        assert np.isclose(src_s.voltage.m, src_m.voltages.m.item(0))
+
+    # Loads
+    for load_id, load_s in en_s.loads.items():
+        load_m = en_m.loads[load_id]
+        assert load_s.id == load_m.id
+        assert load_s.bus.id == load_m.bus.id
+        if isinstance(load_m, rlf.PowerLoad):
+            assert isinstance(load_s, rlfs.PowerLoad)
+            assert np.isclose(load_s.power.m, load_m.powers.m.sum())
+            if load_m.flexible_params is None:
+                assert load_s.flexible_param is None
+            else:
+                fp_s = load_s.flexible_param
+                for fp_m in load_m.flexible_params:
+                    assert fp_s.control_p.u_min == fp_m.control_p.u_min
+                    assert fp_s.control_p.u_down == fp_m.control_p.u_down
+                    assert fp_s.control_p.u_up == fp_m.control_p.u_up
+                    assert fp_s.control_p.u_max == fp_m.control_p.u_max
+                    assert fp_s.control_p.alpha == fp_m.control_p.alpha
+                    assert fp_s.control_p.epsilon == fp_m.control_p.epsilon
+                    assert fp_s.control_q.u_min == fp_m.control_q.u_min
+                    assert fp_s.control_q.u_down == fp_m.control_q.u_down
+                    assert fp_s.control_q.u_up == fp_m.control_q.u_up
+                    assert fp_s.control_q.u_max == fp_m.control_q.u_max
+                    assert fp_s.control_q.alpha == fp_m.control_q.alpha
+                    assert fp_s.control_q.epsilon == fp_m.control_q.epsilon
+                    assert fp_s.projection.type == fp_m.projection.type
+                    assert fp_s.projection.alpha == fp_m.projection.alpha
+                    assert fp_s.projection.epsilon == fp_m.projection.epsilon
+        elif isinstance(load_m, rlf.CurrentLoad):
+            assert isinstance(load_s, rlfs.CurrentLoad)
+            assert np.isclose(load_s.current.m, load_m.currents.m.mean())
+        elif isinstance(load_m, rlf.ImpedanceLoad):
+            assert isinstance(load_s, rlfs.ImpedanceLoad)
+            assert np.isclose(load_s.impedance.m, load_m.impedances.m.mean())
+
+
+def test_source_voltage():
+    potentials = cmath.rect(400 / rlf.SQRT3, cmath.pi / 3) * np.array([*rlf.PositiveSequence, 0], dtype=np.complex128)
+    v_exp = cmath.rect(400, cmath.pi / 6 + cmath.pi / 3)
+
+    v_abcn = rlf.converters.calculate_voltages(potentials, "abcn").m
+    v_abc = rlf.converters.calculate_voltages(potentials[:3], "abc").m
+    assert np.isclose(v_exp, v_abc.item(0))
+
+    assert np.isclose(_balance_voltages("abcn", v_abcn, "abcn", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("abc", v_abc, "abc", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("abn", v_abcn[:2], "abn", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("bcn", v_abcn[1:], "bcn", on_incompatible="raise"), v_exp)
+    v_can = np.array([v_abcn[2], v_abcn[0]], dtype=np.complex128)
+    assert np.isclose(_balance_voltages("can", v_can, "can", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("ab", v_abc[0:1], "ab", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("bc", v_abc[1:2], "bc", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("ca", v_abc[2:3], "ca", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("an", v_abcn[0:1], "an", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("bn", v_abcn[1:2], "bn", on_incompatible="raise"), v_exp)
+    assert np.isclose(_balance_voltages("cn", v_abcn[2:3], "cn", on_incompatible="raise"), v_exp)
+
+    # Unbalanced voltages
+    with pytest.raises(RuntimeError, match=r"abcn"):
+        _balance_voltages("abcn", rlf.NegativeSequence, "abcn", on_incompatible="raise")
+    with pytest.raises(RuntimeError, match=r"abc"):
+        _balance_voltages("abc", rlf.NegativeSequence, "abc angle", on_incompatible="raise")
+    with pytest.raises(RuntimeError, match=r"abn angle"):
+        _balance_voltages("abn", rlf.NegativeSequence[:2], "abn angle", on_incompatible="raise")
+    with pytest.raises(RuntimeError, match=r"abn mag"):
+        _balance_voltages("abn", [1, 1.2] * rlf.PositiveSequence[:2], "abn mag", on_incompatible="raise")

--- a/roseau/load_flow_single/models/tests/test_line_parameters.py
+++ b/roseau/load_flow_single/models/tests/test_line_parameters.py
@@ -568,8 +568,8 @@ def test_from_roseau_load_flow():
         LineParameters.from_roseau_load_flow(lp_m_bad)
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LINE_MODEL
     assert e.value.msg == (
-        "Only three-phase line parameters can be converted to `rlfs.LineParameters`. "
-        "`rlf.LineParameters` with id 'Bad LP' has 2 phases."
+        "Multi-phase line parameters with id 'Bad LP' and 2 phases cannot be converted to "
+        "`rlfs.LineParameters`. It must be three-phase."
     )
 
 

--- a/roseau/load_flow_single/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow_single/models/tests/test_transformer_parameters.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from roseau.load_flow import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
+from roseau.load_flow import TransformerParameters as MultiTransformerParameters
+from roseau.load_flow_single.models import TransformerParameters
+
+
+def test_from_roseau_load_flow():
+    lp_m = MultiTransformerParameters.from_open_and_short_circuit_tests(
+        id="TP", vg="Yzn11", sn=50e3, uhv=20e3, ulv=400, p0=145, i0=0.018, psc=1350, vsc=0.04
+    )
+    lp_s = TransformerParameters.from_roseau_load_flow(lp_m)
+    assert np.isclose(lp_s.z2.m, lp_m.z2.m)
+    assert np.isclose(lp_s.ym.m, lp_m.ym.m)
+    assert lp_s.vg == lp_m.vg
+    assert lp_s.id == lp_m.id
+    assert np.isclose(lp_s.sn.m, lp_m.sn.m)
+    assert np.isclose(lp_s.uhv.m, lp_m.uhv.m)
+    assert np.isclose(lp_s.ulv.m, lp_m.ulv.m)
+    assert np.isclose(lp_s.p0.m, lp_m.p0.m)
+    assert np.isclose(lp_s.i0.m, lp_m.i0.m)
+    assert np.isclose(lp_s.psc.m, lp_m.psc.m)
+    assert np.isclose(lp_s.vsc.m, lp_m.vsc.m)
+
+    lp_m_bad = MultiTransformerParameters.from_open_and_short_circuit_tests(
+        id="Bad TP", vg="Ii0", sn=10e3, uhv=230, ulv=230, p0=90, i0=0.001, psc=280, vsc=0.028
+    )
+    with pytest.raises(RoseauLoadFlowException) as e:
+        TransformerParameters.from_roseau_load_flow(lp_m_bad)
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LINE_MODEL
+    assert e.value.msg == (
+        "Multi-phase transformer parameters with id 'Bad TP' and vector group 'Ii0' cannot be "
+        "converted to `rlfs.TransformerParameters`. It must be three-phase."
+    )

--- a/roseau/load_flow_single/models/transformer_parameters.py
+++ b/roseau/load_flow_single/models/transformer_parameters.py
@@ -1,7 +1,11 @@
-from typing import Final
+import logging
+from typing import Final, Self
 
+from roseau.load_flow import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow import TransformerParameters as MultiTransformerParameters
 from roseau.load_flow.constants import CLOCK_PHASE_SHIFT
+
+logger = logging.getLogger(__name__)
 
 
 class TransformerParameters(MultiTransformerParameters):
@@ -40,3 +44,18 @@ class TransformerParameters(MultiTransformerParameters):
     def ymd(self) -> complex:
         """The positive-sequence (direct-system) magnetizing admittance of the transformer."""
         return self._ym * 3.0 if self.winding1[0] == "D" else self._ym
+
+    @classmethod
+    def from_roseau_load_flow(cls, tp_m: MultiTransformerParameters, /) -> Self:
+        """Create an instance from a multi-phase `rlf.TransformerParameters` object."""
+        if not isinstance(tp_m, MultiTransformerParameters):
+            raise TypeError(f"Expected an rlf.TransformerParameters object, got {type(tp_m)}.")
+        if tp_m.vg not in TransformerParameters.allowed_vector_groups:
+            msg = (
+                f"Multi-phase transformer parameters with id {tp_m.id!r} and vector group {tp_m.vg!r} "
+                f"cannot be converted to `rlfs.TransformerParameters`. It must be three-phase."
+            )
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINE_MODEL)
+        tp_dict = tp_m.to_dict(include_results=False)
+        return cls.from_dict(tp_dict, include_results=False)


### PR DESCRIPTION
- Add `rlfs.ElectricalNetwork.from_rlf`
- Add `rlfs.ElectricalNetwork` catalogue methods that reuse `rlfs.ElectricalNetwork.from_rlf`
- Add conversion of transformer and flexible params from rlf to rlfs similar to line params