### PR TITLE
Improve the performance of network results and network serialization

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`398` Improve the performance of accessing network results as dataframes by up to 20% and serializing a network
+  to a dictionary by up to 15%. The improvements are mostly noticeable for large networks or when performing many
+  simulations like in a time series analysis.
+
 - {gh-pr}`396` Allow passing a single `FlexibleParameter` object to a constant-power load to be used for all phases.
 
 - {gh-pr}`395` Improve line and bus hover information in interactive map plots. Fix an error in automatic zoom

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -888,7 +888,7 @@ def v3_to_v4_converter(data: JsonDict) -> JsonDict:  # noqa: C901
                 assert load_data["type"] == "impedance"
                 impedances = np.array([complex(*z) for z in load_data["impedances"]], dtype=np.complex128)
                 inner_currents = voltages / impedances
-            load_data["results"]["inner_currents"] = [[i.real, i.imag] for i in inner_currents]
+            load_data["results"]["inner_currents"] = [[i.real, i.imag] for i in inner_currents.tolist()]
         loads.append(load_data)
 
     results = {

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -118,7 +118,7 @@ class Bus(AbstractTerminal[CyBus]):
             msg = f"Incorrect number of potentials: {len(value)} instead of {len(self.phases)}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_POTENTIALS_SIZE)
-        self._initial_potentials = np.array(value, dtype=np.complex128)
+        self._initial_potentials: ComplexArray = np.array(value, dtype=np.complex128)
         self._invalidate_network_results()
         self._initialized = True
         self._initialized_by_the_user = True
@@ -491,7 +491,7 @@ class Bus(AbstractTerminal[CyBus]):
     def _to_dict(self, include_results: bool) -> JsonDict:
         data = super()._to_dict(include_results=include_results)
         if self._initialized_by_the_user:
-            data["initial_potentials"] = [[v.real, v.imag] for v in self._initial_potentials]
+            data["initial_potentials"] = [[v.real, v.imag] for v in self._initial_potentials.tolist()]
         if self.geometry is not None:
             data["geometry"] = self.geometry.__geo_interface__
         if self.nominal_voltage is not None:

--- a/roseau/load_flow/models/connectables.py
+++ b/roseau/load_flow/models/connectables.py
@@ -209,8 +209,8 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
             currents = self._res_currents_getter(warning=True)
             potentials = self._res_potentials_getter(warning=False)  # warn only once
             data["results"] = {
-                f"currents{self._side_suffix}": [[i.real, i.imag] for i in currents],
-                f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials],
+                f"currents{self._side_suffix}": [[i.real, i.imag] for i in currents.tolist()],
+                f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials.tolist()],
             }
         return data
 
@@ -220,14 +220,14 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
         results = {
             "id": self.id,
             f"phases{self._side_suffix}": self.phases,
-            f"currents{self._side_suffix}": [[i.real, i.imag] for i in currents],
-            f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials],
+            f"currents{self._side_suffix}": [[i.real, i.imag] for i in currents.tolist()],
+            f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials.tolist()],
         }
         if full:
             powers = potentials * currents.conjugate()
             voltages = _calculate_voltages(potentials, self.phases)
-            results[f"powers{self._side_suffix}"] = [[s.real, s.imag] for s in powers]
-            results[f"voltages{self._side_suffix}"] = [[v.real, v.imag] for v in voltages]
+            results[f"powers{self._side_suffix}"] = [[s.real, s.imag] for s in powers.tolist()]
+            results[f"voltages{self._side_suffix}"] = [[v.real, v.imag] for v in voltages.tolist()]
         return results
 
 

--- a/roseau/load_flow/models/lines/lines.py
+++ b/roseau/load_flow/models/lines/lines.py
@@ -403,12 +403,12 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
             shunt_currents1 = self._side1._res_shunt_currents_getter(warning=False)
             shunt_currents2 = self._side2._res_shunt_currents_getter(warning=False)
             loading = self._res_loading_getter(warning=False)
-            results["power_losses"] = [[s.real, s.imag] for s in power_losses]
-            results["series_currents"] = [[i.real, i.imag] for i in series_currents]
-            results["series_power_losses"] = [[s.real, s.imag] for s in series_power_losses]
-            results["shunt_currents1"] = [[i.real, i.imag] for i in shunt_currents1]
-            results["shunt_currents2"] = [[i.real, i.imag] for i in shunt_currents2]
-            results["shunt_power_losses"] = [[s.real, s.imag] for s in shunt_power_losses]
+            results["power_losses"] = [[s.real, s.imag] for s in power_losses.tolist()]
+            results["series_currents"] = [[i.real, i.imag] for i in series_currents.tolist()]
+            results["series_power_losses"] = [[s.real, s.imag] for s in series_power_losses.tolist()]
+            results["shunt_currents1"] = [[i.real, i.imag] for i in shunt_currents1.tolist()]
+            results["shunt_currents2"] = [[i.real, i.imag] for i in shunt_currents2.tolist()]
+            results["shunt_power_losses"] = [[s.real, s.imag] for s in shunt_power_losses.tolist()]
             results["loading"] = None if loading is None else loading.tolist()
         return results
 

--- a/roseau/load_flow/models/lines/parameters.py
+++ b/roseau/load_flow/models/lines/parameters.py
@@ -1561,9 +1561,9 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         if self._line_type is not None:
             data["line_type"] = self._line_type.name
         if self._materials is not None:
-            data["materials"] = [x.name for x in self._materials]
+            data["materials"] = [x.name for x in self._materials.tolist()]
         if self._insulators is not None:
-            data["insulators"] = [x.name for x in self._insulators]
+            data["insulators"] = [x.name for x in self._insulators.tolist()]
         if self._sections is not None:
             data["sections"] = self._sections.tolist()
         return data

--- a/roseau/load_flow/models/loads/loads.py
+++ b/roseau/load_flow/models/loads/loads.py
@@ -178,31 +178,31 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
     def _to_dict(self, include_results: bool) -> JsonDict:
         complex_array = getattr(self, f"_{self.type}s")
         data = super()._to_dict(include_results=include_results)
-        data[f"{self.type}s"] = [[value.real, value.imag] for value in complex_array]
+        data[f"{self.type}s"] = [[value.real, value.imag] for value in complex_array.tolist()]
         if self.is_flexible:
             assert isinstance(self, PowerLoad), "Only PowerLoad can be flexible"
             assert self.flexible_params is not None, "Flexible load must have flexible parameters"
             data["flexible_params"] = [fp.to_dict(include_results=include_results) for fp in self.flexible_params]
             if include_results:
                 flexible_powers = self._res_flexible_powers_getter(warning=False)  # warn only once
-                data["results"]["flexible_powers"] = [[s.real, s.imag] for s in flexible_powers]
+                data["results"]["flexible_powers"] = [[s.real, s.imag] for s in flexible_powers.tolist()]
         if include_results:
             inner_currents = self._res_inner_currents_getter(warning=False)
-            data["results"]["inner_currents"] = [[i.real, i.imag] for i in inner_currents]
+            data["results"]["inner_currents"] = [[i.real, i.imag] for i in inner_currents.tolist()]
             data["results"] = data.pop("results")  # move results to the end
         return data
 
     def _results_to_dict(self, warning: bool, full: bool) -> JsonDict:
         results = super()._results_to_dict(warning=warning, full=full)
         inner_currents = self._res_inner_currents_getter(warning=False)
-        results["inner_currents"] = [[i.real, i.imag] for i in inner_currents]
+        results["inner_currents"] = [[i.real, i.imag] for i in inner_currents.tolist()]
         if full:
             inner_powers = self._res_inner_powers_getter(warning=False)
-            results["inner_powers"] = [[i.real, i.imag] for i in inner_powers]
+            results["inner_powers"] = [[i.real, i.imag] for i in inner_powers.tolist()]
         if self.is_flexible:
             assert isinstance(self, PowerLoad), "Only PowerLoad can be flexible"
             flexible_powers = self._res_flexible_powers_getter(warning=False)  # warn only once
-            results["flexible_powers"] = [[s.real, s.imag] for s in flexible_powers]
+            results["flexible_powers"] = [[s.real, s.imag] for s in flexible_powers.tolist()]
         return results
 
 

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -140,7 +140,7 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource | CyDeltaVoltageSourc
 
     def _to_dict(self, include_results: bool) -> JsonDict:
         source_dict = super()._to_dict(include_results=include_results)
-        source_dict["voltages"] = [[v.real, v.imag] for v in self._voltages]
+        source_dict["voltages"] = [[v.real, v.imag] for v in self._voltages.tolist()]
         if include_results:
             source_dict["results"] = source_dict.pop("results")  # move results to the end
         return source_dict

--- a/roseau/load_flow/models/terminals.py
+++ b/roseau/load_flow/models/terminals.py
@@ -227,7 +227,7 @@ class AbstractTerminal(Element[_CyE_co], ABC):
         data = {"id": self.id, f"phases{self._side_suffix}": self.phases}
         if include_results:
             potentials = self._res_potentials_getter(warning=True)
-            data["results"] = {f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials]}
+            data["results"] = {f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials.tolist()]}
         return data
 
     def _results_to_dict(self, warning: bool, full: bool) -> JsonDict:
@@ -235,9 +235,9 @@ class AbstractTerminal(Element[_CyE_co], ABC):
         results = {
             "id": self.id,
             f"phases{self._side_suffix}": self.phases,
-            f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials],
+            f"potentials{self._side_suffix}": [[v.real, v.imag] for v in potentials.tolist()],
         }
         if full:
             voltages = _calculate_voltages(potentials, self.phases)
-            results[f"voltages{self._side_suffix}"] = [[v.real, v.imag] for v in voltages]
+            results[f"voltages{self._side_suffix}"] = [[v.real, v.imag] for v in voltages.tolist()]
         return results

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -192,7 +192,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             data["bus1_id"].append(line.bus1.id)
             data["bus2_id"].append(line.bus2.id)
             data["parameters_id"].append(line.parameters.id)
-            data["length"].append(line.length.m)
+            data["length"].append(line._length)
             data["max_loading"].append(line._max_loading)
             data["geometry"].append(line.geometry)
         return gpd.GeoDataFrame(data=data, index=pd.Index(index, name="id"), geometry="geometry", crs=self.crs)


### PR DESCRIPTION
This PR brings many performance improvements for results access on the network and for network serialization. The optimization is mainly based on looping over lists instead of numpy arrays which is much more performant for small sized arrays like in our case.

Iterating over a small list, of say voltages, is 4X faster than iterating over an array:

```ipy
[In]:  %%timeit
       [[v.real, v.imag] for v in voltages]
[Out]: 1.62 μs ± 32 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
vs
```ipy
[In]:  %%timeit
       [[v.real, v.imag] for v in voltages.tolist()]
[Out]: 429 ns ± 6.77 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

Similarly, computing the complex power in a list is 2X faster than using array multiplication.

This resulted in a measured speedup of 20% when accessing `en.res_buses`, `en.res_buses_voltages`, `en.res_lines`, `en.res_transformers` and `en.res_loads` in an MV feeder with 351 buses, 318 lines, 31 transformers and 498 loads. The same network showed a 15% speedup when serialized to a dict with the results.