### PR TITLE
Make the graph data of the network json serializable

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,12 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`402` Improve the `en.to_graph` method.
+
+  - Add nominal voltage and min/max voltage levels as node attributes.
+  - Change the `geom` attribute to be a GeoJSON-like dictionary instead of a shapely geometry object. This makes the
+    graph data JSON-serializable and compatible with pyviz plotting.
+
 - {gh-pr}`401` Rename some internal models modules. The models classes are always available as `rlf.<model_name>`.
 
 - {gh-pr}`400` Add `LineParameters.to_sym` method to convert three-phase line parameters to symmetrical components. The

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -42,6 +42,7 @@ from roseau.load_flow.utils import (
     SourceTypeDtype,
     VoltagePhaseDtype,
     count_repr,
+    geom_mapping,
     optional_deps,
 )
 
@@ -384,7 +385,13 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         nx = optional_deps.networkx
         graph = nx.MultiGraph()
         for bus in self.buses.values():
-            graph.add_node(bus.id, geom=bus.geometry)
+            graph.add_node(
+                bus.id,
+                nominal_voltage=bus._nominal_voltage,
+                min_voltage_level=bus._min_voltage_level,
+                max_voltage_level=bus._max_voltage_level,
+                geom=geom_mapping(bus.geometry),
+            )
         for line in self.lines.values():
             if (ampacities := line.parameters._ampacities) is not None:
                 ampacities = ampacities.tolist()
@@ -398,7 +405,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
                 length=line._length,
                 max_loading=line._max_loading,
                 ampacities=ampacities,
-                geom=line.geometry,
+                geom=geom_mapping(line.geometry),
             )
         for transformer in self.transformers.values():
             graph.add_edge(
@@ -411,7 +418,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
                 parameters_id=transformer.parameters.id,
                 max_loading=transformer._max_loading,
                 sn=transformer.parameters._sn,
-                geom=transformer.geometry,
+                geom=geom_mapping(transformer.geometry),
             )
         for switch in self.switches.values():
             if not respect_switches or switch.closed:
@@ -421,7 +428,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
                     id=switch.id,
                     type="switch",
                     phases=switch.phases,
-                    geom=switch.geometry,
+                    geom=geom_mapping(switch.geometry),
                 )
         return graph
 

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -2066,7 +2066,12 @@ def test_to_graph(all_element_network: ElectricalNetwork):
 
     for bus in all_element_network.buses.values():
         node_data = g.nodes[bus.id]
-        assert node_data["geom"] == bus.geometry
+        assert node_data == {
+            "nominal_voltage": bus._nominal_voltage,
+            "min_voltage_level": bus._min_voltage_level,
+            "max_voltage_level": bus._max_voltage_level,
+            "geom": bus.geometry.__geo_interface__ if bus.geometry is not None else None,
+        }
 
     for line in all_element_network.lines.values():
         edge_data = g.edges[line.bus1.id, line.bus2.id, 0]
@@ -2079,7 +2084,7 @@ def test_to_graph(all_element_network: ElectricalNetwork):
             "parameters_id": line.parameters.id,
             "ampacities": ampacities,
             "max_loading": line._max_loading,
-            "geom": line.geometry,
+            "geom": line.geometry.__geo_interface__ if line.geometry is not None else None,
         }
 
     for transformer in all_element_network.transformers.values():
@@ -2093,12 +2098,17 @@ def test_to_graph(all_element_network: ElectricalNetwork):
             "parameters_id": transformer.parameters.id,
             "max_loading": max_loading,
             "sn": transformer.sn.magnitude,
-            "geom": transformer.geometry,
+            "geom": transformer.geometry.__geo_interface__ if transformer.geometry is not None else None,
         }
 
     for switch in all_element_network.switches.values():
         edge_data = g.edges[switch.bus1.id, switch.bus2.id, 0]
-        assert edge_data == {"id": switch.id, "type": "switch", "phases": switch.phases, "geom": switch.geometry}
+        assert edge_data == {
+            "id": switch.id,
+            "type": "switch",
+            "phases": switch.phases,
+            "geom": switch.geometry.__geo_interface__ if switch.geometry is not None else None,
+        }
 
     # Test parallel branches
     bus1 = Bus(id="Bus1", phases="abc")
@@ -2137,6 +2147,10 @@ def test_to_graph(all_element_network: ElectricalNetwork):
     sw.open()
     assert (bus1.id, bus2.id, 2) not in en.to_graph().edges  # not included by default
     assert en.to_graph(respect_switches=False).edges[bus1.id, bus2.id, 2]["id"] == sw.id
+
+    # Test serialization to JSON
+    json_data = nx.node_link_data(g, edges="edges")
+    json.dumps(json_data, ensure_ascii=False)
 
 
 def test_serialization(all_element_network, all_element_network_with_results):

--- a/roseau/load_flow/utils/__init__.py
+++ b/roseau/load_flow/utils/__init__.py
@@ -26,6 +26,7 @@ from roseau.load_flow.utils.helpers import (
     abstractattrs,
     count_repr,
     ensure_startsupper,
+    geom_mapping,
     id_sort_key,
     one_or_more_repr,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "one_or_more_repr",
     "id_sort_key",
     "ensure_startsupper",
+    "geom_mapping",
     # Enums
     "CaseInsensitiveStrEnum",
     # Decorators

--- a/roseau/load_flow/utils/helpers.py
+++ b/roseau/load_flow/utils/helpers.py
@@ -3,6 +3,8 @@ from collections.abc import Callable, Collection, Sized
 from enum import StrEnum
 from typing import Final, TypeVar
 
+from shapely.geometry.base import BaseGeometry
+
 from roseau.load_flow.typing import Side
 
 SIDE_INDEX: Final[dict[Side | None, int]] = {"HV": 0, "LV": 1, 1: 0, 2: 1, None: 0}
@@ -42,6 +44,13 @@ def ensure_startsupper(s: str, /) -> str:
 def id_sort_key(x: dict, /) -> tuple[str, str]:
     """Sorting key function for objects with an 'id' key."""
     return type(x["id"]).__name__, str(x["id"])
+
+
+def geom_mapping(geom: BaseGeometry | None) -> dict[str, object] | None:
+    """Return a GeoJSON-like mapping of the geometry or None if the geometry is None."""
+    if geom is None:
+        return None
+    return geom.__geo_interface__
 
 
 class CaseInsensitiveStrEnum(StrEnum):


### PR DESCRIPTION
I am getting a `TypeError: Object of type Point is not JSON serializable` when trying to plot the graph of the network with pyviz. This is because we store the geometries as shapely objects in the graph. This PR changes the geometries to geojson-like format so that they are JSON serializable for better compatibility with the networkx ecosystem. I also noticed that the buses were missing some data so I added them.