### PR TITLE
[single] Performance improvements of setters

### DIFF
--- a/roseau/load_flow_single/models/lines.py
+++ b/roseau/load_flow_single/models/lines.py
@@ -94,13 +94,10 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
         if self._cy_initialized:
             if self._parameters.with_shunt:
                 assert isinstance(self._cy_element, CyShuntLine)
-                self._cy_element.update_line_parameters(
-                    y_shunt=np.array([self._y_shunt], dtype=np.complex128),
-                    z_line=np.array([self._z_line], dtype=np.complex128),
-                )
+                self._cy_element.update_single_line_parameters(y_shunt=self._y_shunt, z_line=self._z_line)
             else:
                 assert isinstance(self._cy_element, CySimplifiedLine)
-                self._cy_element.update_line_parameters(z_line=np.array([self._z_line], dtype=np.complex128))
+                self._cy_element.update_single_line_parameters(z_line=self._z_line)
 
     @property
     @ureg_wraps("km", (None,))

--- a/roseau/load_flow_single/models/loads.py
+++ b/roseau/load_flow_single/models/loads.py
@@ -178,7 +178,7 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyFlexibleLoad]):
         self._power = value
         self._invalidate_network_results()
         if self._cy_initialized:
-            self._cy_element.update_powers(np.array([self._power / 3.0], dtype=np.complex128))
+            self._cy_element.update_power(self._power / 3.0)
 
     #
     # Json Mixin interface
@@ -240,7 +240,7 @@ class CurrentLoad(AbstractLoad[CyCurrentLoad]):
         self._current = self._validate_value(value)
         self._invalidate_network_results()
         if self._cy_initialized:
-            self._cy_element.update_currents(np.array([self._current], dtype=np.complex128))
+            self._cy_element.update_current(self._current)
 
 
 class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad]):
@@ -292,4 +292,4 @@ class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad]):
         self._impedance = self._validate_value(value)
         self._invalidate_network_results()
         if self._cy_initialized:
-            self._cy_element.update_admittances(np.array([1.0 / self._impedance], dtype=np.complex128))
+            self._cy_element.update_admittance(1.0 / self._impedance)

--- a/roseau/load_flow_single/models/sources.py
+++ b/roseau/load_flow_single/models/sources.py
@@ -57,7 +57,7 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource]):
         self._voltage = complex(value)
         self._invalidate_network_results()
         if self._cy_initialized:
-            self._cy_element.update_voltages(np.array([self._voltage / SQRT3], dtype=np.complex128))
+            self._cy_element.update_voltage(self._voltage / SQRT3)
 
     #
     # Json Mixin interface


### PR DESCRIPTION
Use faster methods to update the parameters of loads, lines and voltage sources. This makes the updating about 10%~15% faster. 