### PR TITLE
Restore bus and line in interactive map layer control

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,11 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 # Changelog
 
+## Unreleased
+
+- {gh-pr}`413` Restore bus and layers to the layer control in the interactive map plot. This was broken in version
+  0.13.0.
+
 ## Version 0.13.1
 
 - Fix a bug where license validation failed when the English (US) language was not installed on the system (observed on

--- a/roseau/load_flow/plotting.py
+++ b/roseau/load_flow/plotting.py
@@ -318,6 +318,7 @@ def _plot_interactive_map_internal(
     add_search: bool,
 ) -> "folium.Map":
     import folium
+    from folium.plugins import FeatureGroupSubGroup, Search
 
     def internal_style_function(feature):
         result = style_function(feature) if style_function is not None else None
@@ -410,7 +411,7 @@ def _plot_interactive_map_internal(
         highlight_function=internal_highlight_function,
         tooltip=line_tooltip,
         popup=line_popup,
-    ).add_to(network_layer)
+    ).add_to(FeatureGroupSubGroup(network_layer, "Lines").add_to(m))
     folium.GeoJson(
         data=buses_gdf,
         name="buses",
@@ -419,11 +420,9 @@ def _plot_interactive_map_internal(
         highlight_function=internal_highlight_function,
         tooltip=bus_tooltip,
         popup=bus_popup,
-    ).add_to(network_layer)
-    folium.LayerControl().add_to(m)
+    ).add_to(FeatureGroupSubGroup(network_layer, "Buses").add_to(m))
+    folium.LayerControl(collapsed=False).add_to(m)
     if add_search:
-        from folium.plugins import Search
-
         Search(network_layer, search_label="id", placeholder="Search network elements...").add_to(m)
     return m
 


### PR DESCRIPTION
Fixes a small bug introduced in the last release due to the use of `folium.FeatureGroup`.

Before:
<img width="480" height="270" alt="Before" src="https://github.com/user-attachments/assets/682f47a2-7585-4015-9731-1085c0d7b282" />

After:
<img width="480" height="270" alt="RLF_After" src="https://github.com/user-attachments/assets/096ff2fa-3b93-4297-9d40-11ca38ed21cf" />

