### PR TITLE
Improve voltage propagation involving delta sources

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`421` Improve initial voltage guesses in the Newton algorithm for networks involving delta connected sources.
+
 - {gh-pr}`419` {gh-pr}`420` Require Python 3.12 or newer and bump the minimum supported versions of some dependencies
   per [SPEC-0](https://scientific-python.org/specs/spec-0000/).
 

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -1165,7 +1165,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         starting_source = None
         potentials = {"n": 0j}
         # if there are multiple voltage sources, start from the higher one (the last one in the sorted below)
-        for source in sorted(self.sources.values(), key=lambda x: abs(x._voltages).mean()):
+        for source in sorted(
+            self.sources.values(), key=lambda x: abs(x._voltages).mean() / (1 if "n" in x.phases else SQRT3)
+        ):
             source_voltages = source._voltages.tolist()
             starting_source = source
             if "n" in source.phases:
@@ -1192,7 +1194,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         assert starting_source is not None, "No voltage source found in the network."
         if len(potentials) < len(all_phases):
             # We failed to determine all the potentials (the sources are strange), fallback to something simple
-            v = abs(starting_source._voltages).mean()
+            v = abs(starting_source._voltages).mean().item()
+            if "n" not in starting_source.phases:
+                v /= SQRT3
             potentials["a"] = v
             potentials["b"] = v * ALPHA2
             potentials["c"] = v * ALPHA


### PR DESCRIPTION
This fixes two bugs in our source voltage propagation logic:
- If the network has both delta and wye sources, we compare their pn voltages to determine the source with higher voltages. Previously we compared pp voltages to pn voltages.
- If a delta source is used to fill up potentials of missing phases, the resulting potentials we off by a factor of $\sqrt 3$.