### PR TITLE
Factorize results plotting in preparation for voltage profiles

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,6 @@
 {
   "recommendations": [
     "charliermarsh.ruff",
-    "esbenp.prettier-vscode",
     "ms-python.python",
-    "ms-python.vscode-pylance",
   ],
 }

--- a/roseau/load_flow/typing.py
+++ b/roseau/load_flow/typing.py
@@ -141,6 +141,7 @@ type ControlType = Literal["constant", "p_max_u_production", "p_max_u_consumptio
 type ProjectionType = Literal["euclidean", "keep_p", "keep_q"]
 type Solver = Literal["newton", "newton_goldstein", "backward_forward"]
 type Side = Literal[1, 2, "HV", "LV"]
+type ResultState = Literal["very-low", "low", "ok", "high", "very-high", "unknown"]
 
 # Input Types (Wide)
 type Int = int | np.integer

--- a/roseau/load_flow_single/models/tests/test_buses.py
+++ b/roseau/load_flow_single/models/tests/test_buses.py
@@ -222,6 +222,51 @@ def test_res_violated():
     assert bus.res_violated
 
 
+def test_res_state():
+    bus = Bus(id="bus")
+    bus._res_voltage = 400 + 0j
+
+    # No nominal voltage
+    assert bus._res_state_getter() == "unknown"
+
+    # No limits
+    bus.nominal_voltage = 400
+    assert bus._res_state_getter() == "unknown"
+
+    # Only max voltage
+    bus.max_voltage_level = 1.05
+    bus._res_voltage = (400 + 0j) * 1.06
+    assert bus._res_state_getter() == "very-high"
+    bus._res_voltage = (400 + 0j) * 1.04
+    assert bus._res_state_getter() == "high"
+    bus._res_voltage = (400 + 0j) * 1.02
+    assert bus._res_state_getter() == "ok"
+
+    # Only min voltage
+    bus.max_voltage_level = None
+    bus.min_voltage_level = 0.95
+    bus._res_voltage = (400 + 0j) * 0.94
+    assert bus._res_state_getter() == "very-low"
+    bus._res_voltage = (400 + 0j) * 0.96
+    assert bus._res_state_getter() == "low"
+    bus._res_voltage = (400 + 0j) * 0.98
+    assert bus._res_state_getter() == "ok"
+
+    # Both min and max voltage
+    bus.min_voltage_level = 0.95
+    bus.max_voltage_level = 1.05
+    bus._res_voltage = (400 + 0j) * 1.06
+    assert bus._res_state_getter() == "very-high"
+    bus._res_voltage = (400 + 0j) * 1.04
+    assert bus._res_state_getter() == "high"
+    bus._res_voltage = (400 + 0j) * 1.0
+    assert bus._res_state_getter() == "ok"
+    bus._res_voltage = (400 + 0j) * 0.96
+    assert bus._res_state_getter() == "low"
+    bus._res_voltage = (400 + 0j) * 0.94
+    assert bus._res_state_getter() == "very-low"
+
+
 def test_propagate_limits():  # noqa: C901
     b1_mv = Bus(id="b1_mv")
     b2_mv = Bus(id="b2_mv")

--- a/roseau/load_flow_single/models/tests/test_lines.py
+++ b/roseau/load_flow_single/models/tests/test_lines.py
@@ -193,6 +193,33 @@ def test_res_violated():
     assert np.allclose(line.res_loading, 12 / 11)
 
 
+def test_res_state():
+    bus1 = Bus(id="bus1")
+    bus2 = Bus(id="bus2")
+    lp = LineParameters(id="lp", z_line=1 + 0j)
+    line = Line(id="line", bus1=bus1, bus2=bus2, parameters=lp, length=Q_(50, "m"))
+
+    line.side1._res_voltage = 230
+    line.side2._res_voltage = 225
+    line.side1._res_current = 50
+    line.side2._res_current = -50
+
+    # No ampacity
+    assert line._res_state_getter() == "unknown"
+
+    # With ampacity
+    lp._ampacity = 100
+    assert line._res_state_getter() == "ok"
+    line.side1._res_current = 80
+    assert line._res_state_getter() == "high"
+    line.side1._res_current = 120
+    assert line._res_state_getter() == "very-high"
+
+    # Change max loading
+    line._max_loading = 1.2
+    assert line._res_state_getter() == "high"
+
+
 def test_lines_results():
     z_line = (0.1 + 0.1j) / 2
     y_shunt = None

--- a/roseau/load_flow_single/models/tests/test_transformers.py
+++ b/roseau/load_flow_single/models/tests/test_transformers.py
@@ -80,6 +80,33 @@ def test_res_violated():
     assert np.allclose(transformer.res_loading, 87 * 400 * np.sqrt(3) / 50_000)
 
 
+def test_res_state():
+    bus1 = Bus(id="bus1")
+    bus2 = Bus(id="bus2")
+    tp = TransformerParameters.from_open_and_short_circuit_tests(
+        id="tp", vg="Yzn11", sn=50e3, uhv=20e3, ulv=400, p0=145, i0=0.018, psc=1350, vsc=0.04
+    )
+    tr = Transformer(id="transformer", bus_hv=bus1, bus_lv=bus2, parameters=tp)
+
+    def current(s, u):
+        return s / (np.sqrt(3) * u)
+
+    tr.side_hv._res_voltage = 20e3
+    tr.side_lv._res_voltage = 400
+    tr.side_hv._res_current = current(30e3, 20e3)
+    tr.side_lv._res_current = current(-30e3, 400)
+
+    assert tr._res_state_getter() == "ok"
+    tr.side_hv._res_current = current(45e3, 20e3)
+    assert tr._res_state_getter() == "high"
+    tr.side_hv._res_current = current(60e3, 20e3)
+    assert tr._res_state_getter() == "very-high"
+
+    # Change max loading
+    tr._max_loading = 1.2
+    assert tr._res_state_getter() == "high"
+
+
 def test_transformer_results():
     bus_hv = Bus(id="bus_hv")
     bus_lv = Bus(id="bus_lv")


### PR DESCRIPTION
This PR factorizes results plotting in preparation for the addition of voltage profiles plots.
- Add internal methods `bus/line/transformer._result_state_getter()` to get a "state" of the results of the element (voltage or loading very-high, high, ok, etc.)
- Define a color for each state
- Remove the folium colormaps in favor of the added methods and colors

Also a drive by change that increases line width for better visibility in interactive maps

To do next:
- Add voltage profile plotting
- Add results plotting on a map for multi-phase networks
- Allow color customization of results (currently, colors are hardcoded) 