### PR TITLE
Fix repr of GroundConnection

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 # Changelog
 
+## Unreleased
+
+- {gh-pr}`439` Fix repr string of `rlf.GroundConnection`
+
 ## Version 0.14.0
 
 - {gh-pr}`435` {gh-issue}`436` Add `rlf.converters.kron_reduction` function to perform Kron reduction on any nxn matrix

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -229,7 +229,7 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
         parts = [
             f"id={self.id!r}",
             f"ground={self._ground.id!r}",
-            f"element={self._element_info!r} {self._element._side_desc}".rstrip(),
+            f"element=<{self._element.element_type} {self._element.id!r} {self._element._side_desc}".rstrip() + ">",
             f"impedance={self._impedance!r}",
             f"phase={self._phase!r}",
             f"on_connected={self.on_connected!r}",

--- a/roseau/load_flow/models/tests/test_grounds.py
+++ b/roseau/load_flow/models/tests/test_grounds.py
@@ -193,3 +193,20 @@ def test_ground_deprecations():
     assert ground.connections[0].element is bus
     assert ground.connections[0].phase == "a"
     assert ground.connections[0].side is None
+
+
+def test_ground_connection_repr():
+    ground = Ground("Ground")
+    bus = Bus("Bus", phases="an")
+    gc = GroundConnection(ground=ground, element=bus)
+    assert repr(gc) == (
+        "<GroundConnection: id=\"bus 'Bus' phase 'n' to ground 'Ground'\", ground='Ground', "
+        "element=<bus 'Bus'>, impedance=0j, phase='n', on_connected='raise'>"
+    )
+    bus2 = Bus("Bus2", phases="an")
+    sw = Switch("Sw", bus1=bus, bus2=bus2)
+    gc2 = GroundConnection(id="GC2", ground=ground, element=sw.side1)
+    assert repr(gc2) == (
+        "<GroundConnection: id='GC2', ground='Ground', element=<switch 'Sw' side (1)>, "
+        "impedance=0j, phase='n', on_connected='raise'>"
+    )


### PR DESCRIPTION
It used to contain the ID of the ground connection where it was supposed to contain the ID of the element connected.