### PR TITLE
Add switches status to their dataframe and graph

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`440` Add switch `closed` status to the network's switches dataframe and graph representation.
 - {gh-pr}`439` Fix repr string of `rlf.GroundConnection`
 
 ## Version 0.14.0

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -287,12 +287,13 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     def switches_frame(self) -> gpd.GeoDataFrame:
         """The :attr:`switches` of the network as a geo dataframe."""
         index = []
-        data = {"phases": [], "bus1_id": [], "bus2_id": [], "geometry": []}
+        data = {"phases": [], "bus1_id": [], "bus2_id": [], "closed": [], "geometry": []}
         for switch in self.switches.values():
             index.append(switch.id)
             data["phases"].append(switch.phases)
             data["bus1_id"].append(switch.bus1.id)
             data["bus2_id"].append(switch.bus2.id)
+            data["closed"].append(switch.closed)
             data["geometry"].append(switch.geometry)
         index = pd.Index(index, name="id")
         return gpd.GeoDataFrame(data=data, index=index, geometry="geometry", crs=self.crs)
@@ -427,6 +428,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
                     id=switch.id,
                     type="switch",
                     phases=switch.phases,
+                    closed=switch.closed,
                     geom=geom_mapping(switch.geometry),
                 )
         return graph

--- a/roseau/load_flow/tests/test_electrical_network.py
+++ b/roseau/load_flow/tests/test_electrical_network.py
@@ -603,8 +603,8 @@ def test_frames(small_network: ElectricalNetwork):
     # Switches
     switches_gdf = small_network.switches_frame
     assert isinstance(switches_gdf, gpd.GeoDataFrame)
-    assert switches_gdf.shape == (0, 4)
-    assert switches_gdf.columns.tolist() == ["phases", "bus1_id", "bus2_id", "geometry"]
+    assert switches_gdf.shape == (0, 5)
+    assert switches_gdf.columns.tolist() == ["phases", "bus1_id", "bus2_id", "closed", "geometry"]
     assert switches_gdf.index.name == "id"
 
     # Loads
@@ -2115,6 +2115,7 @@ def test_to_graph(all_element_network: ElectricalNetwork):
             "type": "switch",
             "phases": switch.phases,
             "geom": switch.geometry.__geo_interface__ if switch.geometry is not None else None,
+            "closed": switch.closed,
         }
 
     # Test parallel branches

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -216,11 +216,12 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     def switches_frame(self) -> gpd.GeoDataFrame:
         """The :attr:`switches` of the network as a geo dataframe."""
         index = []
-        data = {"bus1_id": [], "bus2_id": [], "geometry": []}
+        data = {"bus1_id": [], "bus2_id": [], "closed": [], "geometry": []}
         for switch in self.switches.values():
             index.append(switch.id)
             data["bus1_id"].append(switch.bus1.id)
             data["bus2_id"].append(switch.bus2.id)
+            data["closed"].append(switch.closed)
             data["geometry"].append(switch.geometry)
         return gpd.GeoDataFrame(data=data, index=pd.Index(index, name="id"), geometry="geometry", crs=self.crs)
 
@@ -308,6 +309,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
                     switch.bus2.id,
                     id=switch.id,
                     type="switch",
+                    closed=switch.closed,
                     geom=geom_mapping(switch.geometry),
                 )
         return graph

--- a/roseau/load_flow_single/tests/test_electrical_network.py
+++ b/roseau/load_flow_single/tests/test_electrical_network.py
@@ -388,8 +388,8 @@ def test_network_frames(small_network: ElectricalNetwork):
     # Switches
     switches_gdf = small_network.switches_frame
     assert isinstance(switches_gdf, gpd.GeoDataFrame)
-    assert switches_gdf.shape == (1, 3)
-    assert switches_gdf.columns.tolist() == ["bus1_id", "bus2_id", "geometry"]
+    assert switches_gdf.shape == (1, 4)
+    assert switches_gdf.columns.tolist() == ["bus1_id", "bus2_id", "closed", "geometry"]
     assert switches_gdf.index.name == "id"
 
     # Loads
@@ -1131,6 +1131,7 @@ def test_to_graph(small_network: ElectricalNetwork):
             "id": switch.id,
             "type": "switch",
             "geom": switch.geometry.__geo_interface__ if switch.geometry is not None else None,
+            "closed": switch.closed,
         }
 
     # Test parallel branches


### PR DESCRIPTION
This was an oversight in the original PR that added support for open switches.