### PR TITLE
Fix conversion of transformer parameters from OpenDSS when loadloss is non-zero

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 # Changelog
 
+## Unreleased
+
+- {gh-pr}`454` Fix conversion of transformer parameters from OpenDSS when `loadloss` is non-zero.
+
 ## Version 0.14.1
 
 - {gh-pr}`451` Plot switches that are represented as lines in the interactive map plots.

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -574,7 +574,10 @@ def test_from_open_dss():
         kvs=(33, 0.405),
         kvas=1800,
         leadlag="euro",
-        xhl=6,
+        # The model above given by Roger Dugan seems to be simplified. Lines 2152-2157 of
+        # https://sourceforge.net/p/electricdss/code/HEAD/tree/trunk/Version8/Source/PDElements/Transformer.pas
+        # show that in the actual model XHL² = %Z² - %Loadloss², not XHL = %Z
+        xhl=np.sqrt(6**2 - 0.902**2),
         loadloss=0.902,
         noloadloss=0.136,
         imag=0.3,

--- a/roseau/load_flow/models/transformer_parameters.py
+++ b/roseau/load_flow/models/transformer_parameters.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import re
 from functools import lru_cache
 from importlib import resources
@@ -632,7 +633,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         kvs: tuple[float, float] | FloatArrayLike1D,
         kvas: float | Q_[float] | tuple[float, float] | FloatArrayLike1D,
         leadlag: str,
-        xhl: float,
+        xhl: float | Q_[float],
         loadloss: float | Q_[float] | None = None,
         noloadloss: float | Q_[float] = 0,
         imag: float | Q_[float] = 0,
@@ -805,7 +806,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         p0 = (noloadloss / 100) * sn
         i0 = imag / 100
         psc = (loadloss / 100) * sn
-        vsc = xhl / 100
+        vsc = math.sqrt(xhl**2 + loadloss**2) / 100
         z2, ym = cls._compute_zy(vg=vg, uhv=uhv, ulv=ulv, sn=sn, p0=p0, i0=i0, psc=psc, vsc=vsc)
 
         instance = cls(


### PR DESCRIPTION
- `XHL` corresponds to the percent reactance high-to-low voltage windings
- `%loadloss` corresponds to the percent losses (active)
- `%Z` (or `vsc` in RLF terms) corresponds to the percentage **impedance** which should take into account both

The old conversion worked in the tutorials repository because `%loadloss` was zero there but in the BDGD we have non-zero load loss