### PR TITLE
Mark final classes as final for better ty support

### DIFF
--- a/roseau/load_flow/io/common.py
+++ b/roseau/load_flow/io/common.py
@@ -1,11 +1,11 @@
 from typing import TypedDict, final
 
 from roseau.load_flow.models import (
-    AbstractLoad,
     Bus,
     Ground,
     GroundConnection,
     Line,
+    Load,
     PotentialRef,
     Switch,
     Transformer,
@@ -19,7 +19,7 @@ class NetworkElements(TypedDict):
     """A dictionary of network elements."""
 
     buses: dict[Id, Bus]
-    loads: dict[Id, AbstractLoad]
+    loads: dict[Id, Load]
     sources: dict[Id, VoltageSource]
     lines: dict[Id, Line]
     transformers: dict[Id, Transformer]

--- a/roseau/load_flow/io/dgs/__init__.py
+++ b/roseau/load_flow/io/dgs/__init__.py
@@ -19,13 +19,13 @@ from roseau.load_flow.io.dgs.switches import elm_coup_to_switches
 from roseau.load_flow.io.dgs.transformers import elm_tr2_to_transformers, typ_tr2_to_tp
 from roseau.load_flow.io.dgs.utils import dgs_dict_to_df, has_typ_lne, has_typ_tr2, parse_dgs_version
 from roseau.load_flow.models import (
-    AbstractLoad,
     Bus,
     Element,
     Ground,
     GroundConnection,
     Line,
     LineParameters,
+    Load,
     PotentialRef,
     Switch,
     Transformer,
@@ -84,7 +84,7 @@ def network_from_dgs(data: Mapping[str, Any], /, use_name_as_id: bool = False) -
     # ElectricalNetwork elements
     buses: dict[str, Bus] = {}  # key is the FID
     sources: dict[Id, VoltageSource] = {}
-    loads: dict[Id, AbstractLoad] = {}
+    loads: dict[Id, Load] = {}
     lines: dict[Id, Line] = {}
     transformers: dict[Id, Transformer] = {}
     switches: dict[Id, Switch] = {}

--- a/roseau/load_flow/io/dgs/loads.py
+++ b/roseau/load_flow/io/dgs/loads.py
@@ -15,7 +15,7 @@ from roseau.load_flow.io.dgs.constants import (
     PV_SYS_PHASES,
     PwFLoadType,
 )
-from roseau.load_flow.models import AbstractLoad, Bus, PowerLoad
+from roseau.load_flow.models import Bus, Load, PowerLoad
 from roseau.load_flow.typing import Id
 
 logger = logging.getLogger(__name__)
@@ -253,7 +253,7 @@ def compute_3phase_load_powers(
 #
 def elm_lod_all_to_loads(
     elm_lod: pd.DataFrame,
-    loads: dict[Id, AbstractLoad],
+    loads: dict[Id, Load],
     buses: dict[str, Bus],
     sta_cubic: pd.DataFrame,
     factor: float,

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -25,6 +25,7 @@ from roseau.load_flow.models import (
     GroundConnection,
     Line,
     LineParameters,
+    Load,
     PotentialRef,
     Switch,
     Transformer,
@@ -119,7 +120,7 @@ def network_from_dict(  # noqa: C901
         bus = Bus.from_dict(data=bus_data, include_results=include_results)
         buses[bus.id] = bus
         has_results = has_results and not bus._no_results
-    loads: dict[Id, AbstractLoad] = {}
+    loads: dict[Id, Load] = {}
     for load_data in data["loads"]:
         load_data["bus"] = buses[load_data["bus"]]
         load = AbstractLoad.from_dict(data=load_data, include_results=include_results)

--- a/roseau/load_flow/models/__init__.py
+++ b/roseau/load_flow/models/__init__.py
@@ -13,7 +13,7 @@ from roseau.load_flow.models.flexible_parameters import Control, FlexibleParamet
 from roseau.load_flow.models.grounds import Ground, GroundConnection
 from roseau.load_flow.models.line_parameters import LineParameters
 from roseau.load_flow.models.lines import Line
-from roseau.load_flow.models.loads import AbstractLoad, CurrentLoad, ImpedanceLoad, PowerLoad
+from roseau.load_flow.models.loads import AbstractLoad, CurrentLoad, ImpedanceLoad, Load, PowerLoad
 from roseau.load_flow.models.potential_refs import PotentialRef
 from roseau.load_flow.models.sources import VoltageSource
 from roseau.load_flow.models.switches import Switch
@@ -47,6 +47,7 @@ __all__ = [
     "FlexibleParameter",
     "Control",
     "Projection",
+    "Load",  # type alias
     # Transformers
     "Transformer",
     "TransformerParameters",

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Final, Self
+from typing import TYPE_CHECKING, Any, Final, Self, final
 
 import numpy as np
 import pandas as pd
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from roseau.load_flow.models.grounds import Ground
 
 
+@final
 class Bus(AbstractTerminal[CyBus]):
     """A multi-phase electrical bus."""
 

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Final, Literal, Self
+from typing import TYPE_CHECKING, Final, Literal, Self, final
 
 import numpy as np
 from typing_extensions import deprecated
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@final
 class Ground(Element[CyGround]):
     """A ground element represents the earth in the network.
 
@@ -121,6 +122,7 @@ class Ground(Element[CyGround]):
         return {"id": self.id, "potential": [v.real, v.imag]}
 
 
+@final
 class GroundConnection(Element[CySimplifiedLine | CySwitch]):
     """An ideal or impedant connection to the ground."""
 

--- a/roseau/load_flow/models/lines.py
+++ b/roseau/load_flow/models/lines.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Self
+from typing import Final, Self, final
 
 import numpy as np
 from shapely.geometry.base import BaseGeometry
@@ -17,6 +17,7 @@ from roseau.load_flow_engine.cy_engine import CyShuntLine, CySimplifiedLine
 logger = logging.getLogger(__name__)
 
 
+@final
 class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
     """An electrical line PI model with series impedance and optional shunt admittance."""
 
@@ -426,6 +427,7 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
         return results
 
 
+@final
 class LineSide(AbstractBranchSide):
     element_type = "line"
     allowed_phases = Line.allowed_phases  # type: ignore

--- a/roseau/load_flow/models/loads.py
+++ b/roseau/load_flow/models/loads.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import Final
+from typing import Final, final
 
 import numpy as np
 from typing_extensions import TypeVar
@@ -135,7 +135,7 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
                 )
 
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "AbstractLoad":
+    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "Load":
         load_type = data["type"]
         if load_type == "power":
             if (fp_data_list := data.get("flexible_params")) is not None:
@@ -206,6 +206,7 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
         return results
 
 
+@final
 class PowerLoad(AbstractLoad[CyPowerLoad | CyDeltaPowerLoad | CyFlexibleLoad | CyDeltaFlexibleLoad]):
     """A constant power load."""
 
@@ -383,6 +384,7 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyDeltaPowerLoad | CyFlexibleLoad | C
         return self._res_flexible_powers_getter(warning=True)
 
 
+@final
 class CurrentLoad(AbstractLoad[CyCurrentLoad | CyDeltaCurrentLoad]):
     """A constant current load."""
 
@@ -457,6 +459,7 @@ class CurrentLoad(AbstractLoad[CyCurrentLoad | CyDeltaCurrentLoad]):
             self._cy_element.update_currents(self._currents)
 
 
+@final
 class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad | CyDeltaAdmittanceLoad]):
     """A constant impedance load."""
 
@@ -524,3 +527,7 @@ class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad | CyDeltaAdmittanceLoad]):
         self._invalidate_network_results()
         if self._cy_initialized:
             self._cy_element.update_admittances(1.0 / self._impedances)
+
+
+type Load = PowerLoad | CurrentLoad | ImpedanceLoad
+"""Alias to the union of all load types."""

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Self
+from typing import Final, Self, final
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.models.buses import Bus
@@ -13,6 +13,7 @@ from roseau.load_flow_engine.cy_engine import CyDeltaPotentialRef, CyPotentialRe
 logger = logging.getLogger(__name__)
 
 
+@final
 class PotentialRef(Element[CyPotentialRef | CyDeltaPotentialRef]):
     """A potential reference.
 

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Self
+from typing import Final, Self, final
 
 import numpy as np
 
@@ -14,6 +14,7 @@ from roseau.load_flow_engine.cy_engine import CyDeltaVoltageSource, CyVoltageSou
 logger = logging.getLogger(__name__)
 
 
+@final
 class VoltageSource(AbstractDisconnectable[CyVoltageSource | CyDeltaVoltageSource]):
     """A voltage source fixes the voltages on the phases of the bus it is connected to.
 

--- a/roseau/load_flow/models/switches.py
+++ b/roseau/load_flow/models/switches.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Literal
+from typing import Final, Literal, final
 
 from shapely.geometry.base import BaseGeometry
 
@@ -15,6 +15,7 @@ from roseau.load_flow_engine.cy_engine import CyOpenSwitch, CySwitch
 logger = logging.getLogger(__name__)
 
 
+@final
 class Switch(AbstractBranch["SwitchSide", CySwitch | CyOpenSwitch]):
     """A general purpose switch branch."""
 
@@ -188,6 +189,7 @@ class Switch(AbstractBranch["SwitchSide", CySwitch | CyOpenSwitch]):
         return data
 
 
+@final
 class SwitchSide(AbstractBranchSide):
     element_type = "switch"
     allowed_phases = Switch.allowed_phases  # type: ignore

--- a/roseau/load_flow/models/transformers.py
+++ b/roseau/load_flow/models/transformers.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cached_property
-from typing import Final
+from typing import Final, final
 
 from shapely.geometry.base import BaseGeometry
 
@@ -16,6 +16,7 @@ from roseau.load_flow_engine.cy_engine import CyTransformer
 logger = logging.getLogger(__name__)
 
 
+@final
 class Transformer(AbstractBranch["TransformerSide", CyTransformer]):
     """A generic transformer model.
 
@@ -447,6 +448,7 @@ class Transformer(AbstractBranch["TransformerSide", CyTransformer]):
         return results
 
 
+@final
 class TransformerSide(AbstractBranchSide):
     element_type = "transformer"
     allowed_phases = Transformer.allowed_phases  # type: ignore

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -19,17 +19,14 @@ from roseau.load_flow.converters import _calculate_voltages, calculate_voltage_p
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.io import network_from_dgs, network_from_dict, network_to_dict
 from roseau.load_flow.models import (
-    AbstractLoad,
     AbstractTerminal,
     Bus,
-    CurrentLoad,
     Element,
     Ground,
     GroundConnection,
-    ImpedanceLoad,
     Line,
+    Load,
     PotentialRef,
-    PowerLoad,
     Switch,
     Transformer,
     VoltageSource,
@@ -151,7 +148,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         lines: MapOrSeq[Line],
         transformers: MapOrSeq[Transformer],
         switches: MapOrSeq[Switch],
-        loads: MapOrSeq[AbstractLoad],
+        loads: MapOrSeq[Load],
         sources: MapOrSeq[VoltageSource],
         grounds: MapOrSeq[Ground],
         potential_refs: MapOrSeq[PotentialRef],
@@ -165,9 +162,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         )
         self.switches: dict[Id, Switch] = self._elements_as_dict(switches, RoseauLoadFlowExceptionCode.BAD_SWITCH_ID)
         # Use a union of all loads types to help autocompletion when typing `load.powers` for example
-        self.loads: dict[Id, AbstractLoad | PowerLoad | CurrentLoad | ImpedanceLoad] = self._elements_as_dict(
-            loads, RoseauLoadFlowExceptionCode.BAD_LOAD_ID
-        )
+        self.loads: dict[Id, Load] = self._elements_as_dict(loads, RoseauLoadFlowExceptionCode.BAD_LOAD_ID)
         self.sources: dict[Id, VoltageSource] = self._elements_as_dict(
             sources, RoseauLoadFlowExceptionCode.BAD_SOURCE_ID
         )
@@ -741,7 +736,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         loads_dict = {"load_id": [], "phase": [], "flexible_power": []}
         dtypes = {c: DTYPES[c] for c in loads_dict} | {"phase": VoltagePhaseDtype}
         for load_id, load in self.loads.items():
-            if not (isinstance(load, PowerLoad) and load.is_flexible):
+            if not (load.type == "power" and load.is_flexible):
                 continue
             for flexible_power, phase in zip(
                 load._res_flexible_powers_getter(warning=False).tolist(), load.voltage_phases, strict=True

--- a/roseau/load_flow_single/io/common.py
+++ b/roseau/load_flow_single/io/common.py
@@ -1,7 +1,7 @@
 from typing import TypedDict, final
 
 from roseau.load_flow.typing import CRSLike, Id
-from roseau.load_flow_single.models import AbstractLoad, Bus, Line, Switch, Transformer, VoltageSource
+from roseau.load_flow_single.models import Bus, Line, Load, Switch, Transformer, VoltageSource
 
 
 @final
@@ -9,7 +9,7 @@ class NetworkElements(TypedDict):
     """A dictionary of the network elements."""
 
     buses: dict[Id, Bus]
-    loads: dict[Id, AbstractLoad]
+    loads: dict[Id, Load]
     sources: dict[Id, VoltageSource]
     lines: dict[Id, Line]
     transformers: dict[Id, Transformer]

--- a/roseau/load_flow_single/io/dgs/__init__.py
+++ b/roseau/load_flow_single/io/dgs/__init__.py
@@ -39,10 +39,10 @@ from roseau.load_flow_single.io.dgs.transformers import (
     typ_tr2_to_tp,
 )
 from roseau.load_flow_single.models import (
-    AbstractLoad,
     Bus,
     Line,
     LineParameters,
+    Load,
     Switch,
     Transformer,
     TransformerParameters,
@@ -101,7 +101,7 @@ def network_from_dgs(data: Mapping[str, Any], /, use_name_as_id: bool = False) -
     # ElectricalNetwork elements
     buses: dict[str, Bus] = {}  # key is the FID
     sources: dict[Id, VoltageSource] = {}
-    loads: dict[Id, AbstractLoad] = {}
+    loads: dict[Id, Load] = {}
     lines: dict[Id, Line] = {}
     transformers: dict[Id, Transformer] = {}
     switches: dict[Id, Switch] = {}

--- a/roseau/load_flow_single/io/dgs/loads.py
+++ b/roseau/load_flow_single/io/dgs/loads.py
@@ -18,7 +18,7 @@ from roseau.load_flow.io.dgs.utils import DGSData, clean_id
 from roseau.load_flow.typing import Id
 from roseau.load_flow.utils import warn_external
 from roseau.load_flow_single.io.dgs.pwf import STA_CUBIC_FID_INDEX, STA_CUBIC_OBJ_ID_INDEX
-from roseau.load_flow_single.models import AbstractLoad, Bus, PowerLoad
+from roseau.load_flow_single.models import Bus, Load, PowerLoad
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 #
 def elm_lod_all_to_loads(
     elm_lod: pd.DataFrame,
-    loads: dict[Id, AbstractLoad],
+    loads: dict[Id, Load],
     buses: dict[str, Bus],
     sta_cubic: pd.DataFrame,
     factor: float,
@@ -104,7 +104,7 @@ def elm_lod_all_to_loads(
 #
 # RLF -> DGS
 #
-def loads_to_elm_lod(loads: Iterable[AbstractLoad], fid_counter: Iterator[str], sta_cubic: dict[Id, list]) -> DGSData:
+def loads_to_elm_lod(loads: Iterable[Load], fid_counter: Iterator[str], sta_cubic: dict[Id, list]) -> DGSData:
     attributes: list[str] = [
         "FID",  # Unique identifier for DGS file
         "OP",  # Operation (C=create, U=update, D=delete, M=merge, I=ignore)

--- a/roseau/load_flow_single/io/dict.py
+++ b/roseau/load_flow_single/io/dict.py
@@ -22,6 +22,7 @@ from roseau.load_flow_single.models import (
     Bus,
     Line,
     LineParameters,
+    Load,
     Switch,
     Transformer,
     TransformerParameters,
@@ -103,7 +104,7 @@ def network_from_dict(
         bus = Bus.from_dict(data=bus_data, include_results=include_results)
         buses[bus.id] = bus
         has_results = has_results and not bus._no_results
-    loads: dict[Id, AbstractLoad] = {}
+    loads: dict[Id, Load] = {}
     for load_data in data["loads"]:
         load_data["bus"] = buses[load_data["bus"]]
         load = AbstractLoad.from_dict(data=load_data, include_results=include_results)

--- a/roseau/load_flow_single/io/rlf.py
+++ b/roseau/load_flow_single/io/rlf.py
@@ -9,13 +9,13 @@ from roseau.load_flow.typing import ComplexArray, Id, JsonDict
 from roseau.load_flow.utils import warn_external
 from roseau.load_flow_single.io.common import NetworkElements
 from roseau.load_flow_single.models import (
-    AbstractLoad,
     Bus,
     CurrentLoad,
     FlexibleParameter,
     ImpedanceLoad,
     Line,
     LineParameters,
+    Load,
     PowerLoad,
     Switch,
     Transformer,
@@ -272,7 +272,7 @@ def network_from_rlf(  # noqa: C901
         sources[src_s.id] = src_s
 
     # Convert loads
-    loads: dict[Id, AbstractLoad] = {}
+    loads: dict[Id, Load] = {}
     for ld_m in en_m.loads.values():
         ph = ld_m.phases
         if "abc" not in ph:

--- a/roseau/load_flow_single/models/__init__.py
+++ b/roseau/load_flow_single/models/__init__.py
@@ -6,7 +6,7 @@ from roseau.load_flow_single.models.core import Element
 from roseau.load_flow_single.models.flexible_parameters import Control, FlexibleParameter
 from roseau.load_flow_single.models.line_parameters import LineParameters
 from roseau.load_flow_single.models.lines import Line
-from roseau.load_flow_single.models.loads import AbstractLoad, CurrentLoad, ImpedanceLoad, PowerLoad
+from roseau.load_flow_single.models.loads import AbstractLoad, CurrentLoad, ImpedanceLoad, Load, PowerLoad
 from roseau.load_flow_single.models.sources import VoltageSource
 from roseau.load_flow_single.models.switches import Switch
 from roseau.load_flow_single.models.terminals import AbstractTerminal
@@ -35,6 +35,7 @@ __all__ = [
     "FlexibleParameter",
     "Control",
     "Projection",
+    "Load",  # type alias
     # Transformers
     "Transformer",
     "TransformerParameters",

--- a/roseau/load_flow_single/models/buses.py
+++ b/roseau/load_flow_single/models/buses.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from collections.abc import Iterator
-from typing import Final, Self
+from typing import Final, Self, final
 
 import numpy as np
 import pandas as pd
@@ -18,6 +18,7 @@ from roseau.load_flow_single.models.terminals import AbstractTerminal
 logger = logging.getLogger(__name__)
 
 
+@final
 class Bus(AbstractTerminal[CyBus]):
     """An electrical bus."""
 

--- a/roseau/load_flow_single/models/lines.py
+++ b/roseau/load_flow_single/models/lines.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final
+from typing import Final, final
 
 import numpy as np
 from shapely.geometry.base import BaseGeometry
@@ -15,6 +15,7 @@ from roseau.load_flow_single.models.line_parameters import LineParameters
 logger = logging.getLogger(__name__)
 
 
+@final
 class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
     """An electrical line PI model with series impedance and optional shunt admittance."""
 
@@ -319,6 +320,7 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
         return results
 
 
+@final
 class LineSide(AbstractBranchSide):
     element_type = "line"
     _branch: Line

--- a/roseau/load_flow_single/models/loads.py
+++ b/roseau/load_flow_single/models/loads.py
@@ -1,7 +1,7 @@
 import cmath
 import logging
 from abc import ABC, abstractmethod
-from typing import Final
+from typing import Final, final
 
 import numpy as np
 from typing_extensions import TypeVar
@@ -49,7 +49,7 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "AbstractLoad":
+    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "Load":
         load_type = data["type"]
         if load_type == "power":
             power = complex(data["power"][0], data["power"][1])
@@ -83,6 +83,7 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
         return load_dict
 
 
+@final
 class PowerLoad(AbstractLoad[CyPowerLoad | CyFlexibleLoad]):
     """A constant power load."""
 
@@ -192,6 +193,7 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyFlexibleLoad]):
         return data
 
 
+@final
 class CurrentLoad(AbstractLoad[CyCurrentLoad]):
     """A constant current load."""
 
@@ -243,6 +245,7 @@ class CurrentLoad(AbstractLoad[CyCurrentLoad]):
             self._cy_element.update_current(self._current)
 
 
+@final
 class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad]):
     """A constant impedance load."""
 
@@ -293,3 +296,7 @@ class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad]):
         self._invalidate_network_results()
         if self._cy_initialized:
             self._cy_element.update_admittance(1.0 / self._impedance)
+
+
+type Load = PowerLoad | CurrentLoad | ImpedanceLoad
+"""Alias to the union of all load types."""

--- a/roseau/load_flow_single/models/sources.py
+++ b/roseau/load_flow_single/models/sources.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Self
+from typing import Final, Self, final
 
 import numpy as np
 
@@ -13,6 +13,7 @@ from roseau.load_flow_single.models.connectables import AbstractDisconnectable
 logger = logging.getLogger(__name__)
 
 
+@final
 class VoltageSource(AbstractDisconnectable[CyVoltageSource]):
     """A voltage source fixes the voltage of the bus it is connected to.
 

--- a/roseau/load_flow_single/models/switches.py
+++ b/roseau/load_flow_single/models/switches.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Literal
+from typing import Final, Literal, final
 
 from shapely.geometry.base import BaseGeometry
 
@@ -15,6 +15,7 @@ from roseau.load_flow_single.models.sources import VoltageSource
 logger = logging.getLogger(__name__)
 
 
+@final
 class Switch(AbstractBranch["SwitchSide", CySwitch | CyOpenSwitch]):
     """A general purpose switch branch."""
 

--- a/roseau/load_flow_single/models/transformers.py
+++ b/roseau/load_flow_single/models/transformers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final
+from typing import Final, final
 
 from shapely.geometry.base import BaseGeometry
 
@@ -15,6 +15,7 @@ from roseau.load_flow_single.models.transformer_parameters import TransformerPar
 logger = logging.getLogger(__name__)
 
 
+@final
 class Transformer(AbstractBranch["TransformerSide", CySingleTransformer]):
     """A generic transformer model.
 
@@ -229,6 +230,7 @@ class Transformer(AbstractBranch["TransformerSide", CySingleTransformer]):
         return results
 
 
+@final
 class TransformerSide(AbstractBranchSide):
     element_type = "transformer"
     _branch: Transformer

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -20,18 +20,7 @@ from roseau.load_flow.utils import DTYPES, AbstractNetwork, LoadTypeDtype, count
 from roseau.load_flow_engine.cy_engine import CyGround, CyPotentialRef
 from roseau.load_flow_single.io import network_from_dgs, network_from_dict, network_to_dgs, network_to_dict
 from roseau.load_flow_single.io.rlf import OnIncompatibleType, network_from_rlf
-from roseau.load_flow_single.models import (
-    AbstractLoad,
-    Bus,
-    CurrentLoad,
-    Element,
-    ImpedanceLoad,
-    Line,
-    PowerLoad,
-    Switch,
-    Transformer,
-    VoltageSource,
-)
+from roseau.load_flow_single.models import Bus, Element, Line, Load, Switch, Transformer, VoltageSource
 
 if TYPE_CHECKING:
     from networkx import MultiGraph
@@ -117,7 +106,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
         lines: MapOrSeq[Line],
         transformers: MapOrSeq[Transformer],
         switches: MapOrSeq[Switch],
-        loads: MapOrSeq[AbstractLoad],
+        loads: MapOrSeq[Load],
         sources: MapOrSeq[VoltageSource],
         crs: CRSLike | None = None,
     ) -> None:
@@ -127,9 +116,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             transformers, RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_ID
         )
         self.switches: dict[Id, Switch] = self._elements_as_dict(switches, RoseauLoadFlowExceptionCode.BAD_SWITCH_ID)
-        self.loads: dict[Id, AbstractLoad | PowerLoad | CurrentLoad | ImpedanceLoad] = self._elements_as_dict(
-            loads, RoseauLoadFlowExceptionCode.BAD_LOAD_ID
-        )
+        self.loads: dict[Id, Load] = self._elements_as_dict(loads, RoseauLoadFlowExceptionCode.BAD_LOAD_ID)
         self.sources: dict[Id, VoltageSource] = self._elements_as_dict(
             sources, RoseauLoadFlowExceptionCode.BAD_SOURCE_ID
         )


### PR DESCRIPTION
ty uses set-theoretic types, so it doesn't narrow intersections between types correctly because it doesn't know that a subclass cannot exist for load and source for example.

Example:
```py
if isinstance(element, rlf.AbstractLoad):
    element  # ty: AbstractLoad
elif isinstance(element, rlf.VoltageSource):
    element  # ty before: VoltageSource & ~AbstractLoad
             # ty after: VoltageSource
```


It also didn't recognize attributes on loads that don't exist on `AbstractLoad`