### PR TITLE
Support single-phase transformer params from DSS

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`456` Support single-phase transformer parameters conversion from OpenDSS.
 - {gh-pr}`454` Fix conversion of transformer parameters from OpenDSS when `loadloss` is non-zero.
 
 ## Version 0.14.1

--- a/roseau/load_flow/exceptions.py
+++ b/roseau/load_flow/exceptions.py
@@ -139,6 +139,8 @@ class RoseauLoadFlowExceptionCode(StrEnum):
 
     # OpenDSS import
     DSS_BAD_LOSS = auto()
+    DSS_BAD_PHASES = auto()
+    DSS_BAD_WINDINGS = auto()
 
     def __eq__(self, other) -> bool:
         if isinstance(other, str):

--- a/roseau/load_flow/models/tests/test_transformer_parameters.py
+++ b/roseau/load_flow/models/tests/test_transformer_parameters.py
@@ -145,7 +145,7 @@ def test_transformer_parameters():
     with pytest.raises(RoseauLoadFlowException) as e:
         TransformerParameters.from_dict(data)
     assert e.value.msg == (
-        "Transformer parameters 'test' has the low voltage higher than the high voltage: uhv=350 V and ulv=400.0045 V."
+        "Transformer parameters 'test' has the low voltage higher than the high voltage: uhv=350.0 V and ulv=400.0045 V."
     )
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_VOLTAGES
 
@@ -220,6 +220,7 @@ def test_transformers_parameters_units():
     assert np.isclose(tp._ulv, 400)
     assert np.isclose(tp._uhv, 20000)
     assert np.isclose(tp._sn, 50e3)
+    assert tp._fn is not None
     assert np.isclose(tp._fn, 50)
 
     # Bad unit for each of them
@@ -549,6 +550,7 @@ def test_from_open_dss():
         ~ Wdg=2 bus=LVBusname.1.2.3.4 kV=0.405 kVA=1800 conn=wye
         ~ %Loadloss=0.902 %imag=0.3 %noload=.136  LeadLag=Euro
     """
+    # Three phase
     sn = Q_(1800, "kVA")
     tp_rlf = TransformerParameters.from_open_and_short_circuit_tests(
         id="tp-test",
@@ -566,7 +568,6 @@ def test_from_open_dss():
         range="Tech+",
         efficiency="Wonderful",
     )
-
     tp_dss = TransformerParameters.from_open_dss(
         id="tp-test",
         # Electrical parameters
@@ -586,8 +587,6 @@ def test_from_open_dss():
         range="Tech+",
         efficiency="Wonderful",
     )
-
-    # Electrical parameters
     assert tp_rlf.vg == tp_dss.vg
     assert tp_rlf.uhv == tp_dss.uhv
     assert tp_rlf.ulv == tp_dss.ulv
@@ -596,11 +595,81 @@ def test_from_open_dss():
     assert tp_rlf.orientation == tp_dss.orientation
     np.testing.assert_allclose(tp_rlf.z2.m, tp_dss.z2.m)
     np.testing.assert_allclose(tp_rlf.ym.m, tp_dss.ym.m)
-
-    # Optional parameters
+    np.testing.assert_allclose(tp_rlf.vsc.m, tp_dss.vsc.m)
+    np.testing.assert_allclose(tp_rlf.psc.m, tp_dss.psc.m)
+    np.testing.assert_allclose(tp_rlf.i0.m, tp_dss.i0.m)
+    np.testing.assert_allclose(tp_rlf.p0.m, tp_dss.p0.m)
     assert tp_rlf.manufacturer == tp_dss.manufacturer
     assert tp_rlf.range == tp_dss.range
     assert tp_rlf.efficiency == tp_dss.efficiency
+
+    # Single phase
+    kvs = (12.47, 0.12)
+    kvas = (25, 25)
+    tp_dss = TransformerParameters.from_open_dss(
+        id="1ph", phases=1, conns=("delta", "wye"), kvs=kvs, kvas=kvas, xhl=2.0, noloadloss=0.2, rs=(1.2, 1.2), imag=0.6
+    )
+    assert tp_dss.type == "single-phase"
+    assert tp_dss.vg == "Ii0"
+    assert tp_dss.sn.m_as("kVA") == kvas[0]
+    np.testing.assert_allclose(tp_dss.psc.m_as("kW"), 2.4 / 100 * kvas[0])  # 2.4% = sum(rs)
+    np.testing.assert_allclose(tp_dss.uhv.m_as("kV"), kvs[0])  # already line-to-line
+    np.testing.assert_allclose(tp_dss.ulv.m_as("kV"), kvs[1] * np.sqrt(3))  # line-to-line from line-to-neutral
+    # Other options: LL and LN connections, both loadloass and rs, etc.
+    tp_dss = TransformerParameters.from_open_dss(
+        id="1ph", phases=1, conns=("ll", "ln"), kvs=kvs, kvas=kvas, xhl=2.04, noloadloss=0.2, rs=(1, 1), loadloss=2
+    )
+    np.testing.assert_allclose(tp_dss.psc.m_as("kW"), 2 / 100 * kvas[0])  # 2% = sum(rs) = loadloss
+    np.testing.assert_allclose(tp_dss.uhv.m_as("kV"), kvs[0])  # already line-to-line
+    np.testing.assert_allclose(tp_dss.ulv.m_as("kV"), kvs[1] * np.sqrt(3))  # line-to-line from line-to-neutral
+
+    # Warnings
+    with pytest.warns(match=r"Only one base kVA rating is expected, got 2"):
+        tp_dss_w = TransformerParameters.from_open_dss(
+            id="1ph", phases=1, conns=("delta", "wye"), kvs=(20, 0.4), kvas=(1, 0.8), xhl=2, loadloss=0
+        )
+    np.testing.assert_allclose(tp_dss_w.sn.m_as("kVA"), 1)  # The first one is taken
+    with pytest.warns(match=r"The sum of rs=\(1.2, 1.2\) is not equal to the value of loadloss=2"):
+        tp_dss_w = TransformerParameters.from_open_dss(
+            id="1ph", phases=1, conns=("delta", "wye"), kvs=(20, 0.4), kvas=1, xhl=2, loadloss=2, rs=(1.2, 1.2)
+        )
+    np.testing.assert_allclose(tp_dss_w.psc.m_as("kW"), 2 / 100 * 1)  # 2% = loadloss is taken
+    with pytest.warns(match=r"rs=1.2 is not consistent with loadloss=2 for 2 windings"):
+        tp_dss_w = TransformerParameters.from_open_dss(
+            id="1ph", phases=1, conns=("delta", "wye"), kvs=(20, 0.4), kvas=1, xhl=2, loadloss=2, rs=1.2
+        )
+    np.testing.assert_allclose(tp_dss_w.psc.m_as("kW"), 2 / 100 * 1)  # 2% = loadloss is taken
+
+    # Errors
+    with pytest.raises(TypeError, match=r"missing 1 required keyword argument: 'loadloss' or 'rs'"):
+        TransformerParameters.from_open_dss(id="err", conns=("delta", "wye"), kvs=(15, 0.4), kvas=1e3, xhl=1)
+    with pytest.raises(
+        RoseauLoadFlowException, match=r"Only single-phase or three-phase transformers are currently supported"
+    ) as e:
+        TransformerParameters.from_open_dss(
+            id="err", conns=("delta", "wye"), kvs=(15, 0.4), kvas=1e3, xhl=1, loadloss=0, phases=2
+        )
+    assert e.value.code == RoseauLoadFlowExceptionCode.DSS_BAD_PHASES
+    with pytest.raises(RoseauLoadFlowException, match=r"Only 2-winding transformers are currently supported") as e:
+        TransformerParameters.from_open_dss(
+            id="err", conns=("delta", "wye"), kvs=(15, 0.4), kvas=1e3, xhl=1, loadloss=0, windings=3
+        )
+    assert e.value.code == RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS
+    with pytest.raises(RoseauLoadFlowException, match=r"Expected 2 connections, got 3") as e:
+        TransformerParameters.from_open_dss(
+            id="err", conns=("delta", "wye", "wye"), kvs=(15, 0.4), kvas=1e3, xhl=1, loadloss=0
+        )
+    assert e.value.code == RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS
+    with pytest.raises(RoseauLoadFlowException, match=r"Expected 2 kV ratings, got 3") as e:
+        TransformerParameters.from_open_dss(
+            id="err", conns=("delta", "wye"), kvs=(15, 0.4, 0.4), kvas=1e3, xhl=1, loadloss=0
+        )
+    assert e.value.code == RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS
+    with pytest.raises(RoseauLoadFlowException, match=r"Expected 2 kVA ratings, got 3") as e:
+        TransformerParameters.from_open_dss(
+            id="err", conns=("delta", "wye"), kvs=(15, 0.4), kvas=(1e3, 1e3, 1e3), xhl=1, loadloss=0
+        )
+    assert e.value.code == RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS
 
 
 def test_from_power_factory():
@@ -748,7 +817,7 @@ def test_to_dict():
     assert d.pop("vg") == tp2.vg
     assert d.pop("z2") == [tp2.z2.m.real, tp2.z2.m.imag]
     assert d.pop("ym") == [tp2.ym.m.real, tp2.ym.m.imag]
-    assert d.pop("fn") == tp2.fn.m
+    assert d.pop("fn") == tp2.fn.m if tp2.fn is not None else None
     assert d.pop("manufacturer") == tp2.manufacturer
     assert d.pop("range") == tp2.range
     assert d.pop("efficiency") == tp2.efficiency

--- a/roseau/load_flow/models/transformer_parameters.py
+++ b/roseau/load_flow/models/transformer_parameters.py
@@ -9,11 +9,12 @@ from typing import Final, Literal, NoReturn, Self
 import numpy as np
 import pandas as pd
 
+from roseau.load_flow.constants import SQRT3
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.types import TransformerCooling, TransformerInsulation
-from roseau.load_flow.typing import FloatArrayLike1D, Id, JsonDict
+from roseau.load_flow.typing import Complex, Float, Id, JsonDict, QtyOrMag
 from roseau.load_flow.units import Q_, ureg_wraps
-from roseau.load_flow.utils import CatalogueMixin, Identifiable, JsonMixin
+from roseau.load_flow.utils import CatalogueMixin, Identifiable, JsonMixin, warn_external
 from roseau.load_flow_engine.cy_engine import (
     CyCenterTransformer,
     CySingleTransformer,
@@ -58,12 +59,12 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         id: Id,
         *,
         vg: str,
-        uhv: float | Q_[float],
-        ulv: float | Q_[float],
-        sn: float | Q_[float],
-        z2: complex | Q_[complex],
-        ym: complex | Q_[complex],
-        fn: float | Q_[float] | None = None,
+        uhv: QtyOrMag[Float],
+        ulv: QtyOrMag[Float],
+        sn: QtyOrMag[Float],
+        z2: QtyOrMag[Complex],
+        ym: QtyOrMag[Complex],
+        fn: QtyOrMag[Float] | None = None,
         manufacturer: str | None = None,
         range: str | None = None,
         efficiency: str | None = None,
@@ -135,12 +136,19 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
                 Informative only, it has no impact on the load flow.
         """
         super().__init__(id)
+        sn = float(sn)
+        uhv = float(uhv)
+        ulv = float(ulv)
+        if fn is not None:
+            fn = float(fn)
+        z2 = complex(z2)
+        ym = complex(ym)
 
         # Check
         if uhv < ulv:
             msg = (
                 f"Transformer parameters {id!r} has the low voltage higher than the high voltage: "
-                f"uhv={uhv!s} V and ulv={ulv!s} V."
+                f"uhv={uhv} V and ulv={ulv} V."
             )
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_VOLTAGES)
@@ -170,11 +178,11 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
 
         # Change the voltages if the reference voltages is phase-to-neutral
         if whv[0] == "Y":
-            uhv /= np.sqrt(3.0)
+            uhv /= SQRT3
         elif whv[0] == "Z":
             uhv /= 3.0
         if wlv[0] == "y":
-            ulv /= np.sqrt(3.0)
+            ulv /= SQRT3
         elif wlv[0] == "z":
             ulv /= 3.0
 
@@ -200,20 +208,22 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
 
     def __repr__(self) -> str:
         s = f"<{type(self).__name__}: id={self.id!r}, vg={self._vg!r}, sn={self._sn}, uhv={self._uhv}, ulv={self._ulv}"
-        for attr, val, tp in (
-            ("fn", self._fn, float),
-            ("p0", self._p0, float),
-            ("i0", self._i0, float),
-            ("psc", self._psc, float),
-            ("vsc", self._vsc, float),
-            ("manufacturer", self._manufacturer, str),
-            ("range", self._range, str),
-            ("efficiency", self._efficiency, str),
-            ("cooling", self._cooling, str),
-            ("insulation", self._insulation, str),
+        for attr, val in (
+            ("fn", self._fn),
+            ("p0", self._p0),
+            ("i0", self._i0),
+            ("psc", self._psc),
+            ("vsc", self._vsc),
+            ("manufacturer", self._manufacturer),
+            ("range", self._range),
+            ("efficiency", self._efficiency),
+            ("cooling", self._cooling),
+            ("insulation", self._insulation),
         ):
             if val is not None:
-                s += f", {attr}={tp(val)!r}"
+                if isinstance(val, str):
+                    val = str(val)  # normalize enumerations
+                s += f", {attr}={val!r}"
         s += ">"
         return s
 
@@ -299,7 +309,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         return self._sn
 
     @property
-    def fn(self) -> Q_[float]:
+    def fn(self) -> Q_[float] | None:
         """The nominal frequency of the transformer (Hz)."""
         return Q_(self._fn, "Hz") if self._fn is not None else None
 
@@ -398,8 +408,8 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
 
     @classmethod
     def _compute_zy(
-        cls, vg: str, uhv: float, ulv: float, sn: float, p0: float, i0: float, psc: float, vsc: float
-    ) -> tuple[complex, complex]:
+        cls, vg: str, uhv: Float, ulv: Float, sn: Float, p0: Float, i0: Float, psc: Float, vsc: Float
+    ) -> tuple[Complex, Complex]:
         whv, wlv, _ = cls.extract_windings(vg=vg)
 
         # Open-circuit (no-load) test
@@ -466,16 +476,16 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         id: Id,
         *,
         tech: Literal[2, "single-phase", 3, "three-phase"],
-        sn: float | Q_[float],
-        uhv: float | Q_[float],
-        ulv: float | Q_[float],
+        sn: QtyOrMag[Float],
+        uhv: QtyOrMag[Float],
+        ulv: QtyOrMag[Float],
         vg_hv: str,
         vg_lv: str,
         phase_shift: int,
-        uk: float | Q_[float],
-        pc: float | Q_[float],
-        curmg: float | Q_[float],
-        pfe: float | Q_[float],
+        uk: QtyOrMag[Float],
+        pc: QtyOrMag[Float],
+        curmg: QtyOrMag[Float],
+        pfe: QtyOrMag[Float],
         # Roseau parameters
         manufacturer: str | None = None,
         range: str | None = None,
@@ -572,36 +582,22 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_TYPE)
 
-        uhv *= 1e3
-        ulv *= 1e3
-        sn *= 1e6
-        p0 = pfe * 1e3
-        psc = pc * 1e3
-        i0 = curmg / 100
-        vsc = uk / 100
-
-        z2, ym = cls._compute_zy(vg=vg, uhv=uhv, ulv=ulv, sn=sn, p0=p0, i0=i0, psc=psc, vsc=vsc)
-
-        instance = cls(
+        return cls.from_open_and_short_circuit_tests(
             id=id,
             vg=vg,
-            uhv=uhv,
-            ulv=ulv,
-            sn=sn,
-            z2=z2,
-            ym=ym,
+            uhv=uhv * 1e3,
+            ulv=ulv * 1e3,
+            sn=sn * 1e6,
+            p0=pfe * 1e3,
+            i0=curmg / 100,
+            psc=pc * 1e3,
+            vsc=uk / 100,
             manufacturer=manufacturer,
             range=range,
             efficiency=efficiency,
             cooling=cooling,
             insulation=insulation,
         )
-        instance._p0 = p0
-        instance._i0 = i0
-        instance._psc = psc
-        instance._vsc = vsc
-        instance._has_test_results = True
-        return instance
 
     @classmethod
     @ureg_wraps(
@@ -623,21 +619,25 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             None,
             None,
             None,
+            None,
+            None,
         ),
     )
-    def from_open_dss(
+    def from_open_dss(  # noqa: C901
         cls,
         id: Id,
         *,
-        conns: tuple[str, str],
-        kvs: tuple[float, float] | FloatArrayLike1D,
-        kvas: float | Q_[float] | tuple[float, float] | FloatArrayLike1D,
-        leadlag: str,
-        xhl: float | Q_[float],
-        loadloss: float | Q_[float] | None = None,
-        noloadloss: float | Q_[float] = 0,
-        imag: float | Q_[float] = 0,
-        rs: float | Q_[float] | tuple[float, float] | FloatArrayLike1D | None = None,
+        conns: tuple[str, ...],
+        kvs: QtyOrMag[tuple[Float, ...]],
+        kvas: QtyOrMag[Float | tuple[Float, ...]],
+        xhl: QtyOrMag[Float],
+        leadlag: str = "ansi",
+        loadloss: QtyOrMag[Float] | None = None,
+        noloadloss: QtyOrMag[Float] = 0,
+        imag: QtyOrMag[Float] = 0,
+        rs: QtyOrMag[Float | tuple[Float, ...]] | None = None,
+        phases: int = 3,
+        windings: int = 2,
         # Roseau parameters
         manufacturer: str | None = None,
         range: str | None = None,
@@ -658,8 +658,9 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
                 connected banks or {delta | ll} for delta (line-line) connected banks.
 
             kvs:
-                OpenDSS parameter: `KVs`. Rated phase-to-phase voltage of the windings, kV. This is
-                a sequence of two values equivalent to (Up, Us).
+                OpenDSS parameter: `KVs`. Rated voltage of the windings kV. For 3-phase transformers,
+                enter phase-to-phase kV. For single-phase transformers, enter actual winding kV
+                rating.
 
             kvas:
                 OpenDSS parameter: `KVAs`. Base kVA rating (OA rating) of the windings. Note that
@@ -693,6 +694,13 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
                 with `loadloss`, they have to have equivalent values. For a two-winding transformer,
                 `%rs=[0.1, 0.1]` is equivalent to `%loadloss=0.2`.
 
+            phases:
+                OpenDSS parameter: `Phases`. Number of phases. Default is 3.
+
+            windings:
+                OpenDSS parameter: `Windings`. Number of windings. Default is 2. Only two-winding
+                transformers are currently supported.
+
             manufacturer:
                 The name of the manufacturer for the transformer. Informative only, it has no impact
                 on the load flow.
@@ -719,7 +727,9 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
 
         Example usage::
 
-            # DSS command: `New transformer.LVTR Buses=[sourcebus, A.1.2.3] Conns=[delta wye] KVs=[11, 0.4] KVAs=[250 250] %Rs=0.00 xhl=2.5 %loadloss=0`
+            # DSS command:
+            # New transformer.LVTR Buses=[sourcebus, A.1.2.3] Conns=[delta wye] KVs=[11, 0.4]
+            # ~ KVAs=[250 250] %Rs=0.00 xhl=2.5 %loadloss=0
             tp = rlf.TransformerParameters.from_open_dss(
                 id="dss-tp",
                 conns=("delta", "wye"),
@@ -733,7 +743,23 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
                 rs=0,  # redundant with `loadloss=0`
             )
         """
+        # Phases
+        if phases not in (1, 3):
+            msg = f"Only single-phase or three-phase transformers are currently supported, got {phases} phases."
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_PHASES)
+
         # Windings
+        if windings != 2:
+            # TODO convert 3-winding single-phase transformers to center tapped
+            # See https://opendss.epri.com/ModelingSingle-PhaseTransformers.html
+            msg = f"Only 2-winding transformers are currently supported, got windings={windings}."
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
+        if len(conns) != windings:
+            msg = f"Expected {windings} connections, got {len(conns)}: {conns!r}"
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
         whv, wlv = (c.lower() for c in conns)
         wye_names = ("wye", "ln")
         delta_names = ("delta", "ll")
@@ -744,7 +770,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         else:
             msg = f"Got unknown winding (1) connection {conns[0]!r}, expected one of ('wye', 'ln', 'delta', 'll')."
             logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_WINDINGS)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
         if wlv in wye_names:
             wlv = "yn"
         elif wlv in delta_names:
@@ -752,7 +778,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         else:
             msg = f"Got unknown winding (2) connection {conns[1]!r}, expected one of ('wye', 'ln', 'delta', 'll')."
             logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_WINDINGS)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
 
         # Lead lag
         leadlag_l = leadlag.lower()
@@ -764,7 +790,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             else:
                 msg = f"Got unknown leadlag value {leadlag!r}, expected one of ('lead', 'lag', 'ansi', 'euro')"
                 logger.error(msg)
-                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_WINDINGS)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
         else:
             clock = 0  # TODO is leadlag used with Dd or Yy transformers?
 
@@ -772,63 +798,77 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         vg = f"{whv}{wlv}{clock}"
 
         # High and low rated voltages
-        uhv, ulv = (u * 1000 for u in kvs)  # in Volts
+        if len(kvs) != windings:
+            msg = f"Expected {windings} kV ratings, got {len(kvs)}: {kvs!r}"
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
+        uhv, ulv = kvs
+        if phases == 1:
+            vg = "Ii0"
+            # According to the OpenDSS documentation, for 2- or 3-phase transformers, the kV ratings
+            # are line-to-line, but for 1-phase transformers, the kV ratings are actual winding ratings.
+            if whv[0] == "Y":
+                uhv *= SQRT3
+            if wlv[0] == "y":
+                ulv *= SQRT3
 
         # Nominal power
-        sn: float  # in Watts
-        if np.isscalar(kvas):
-            sn = kvas * 1000
-        else:
-            kvs_uniq = np.unique(kvas)
-            if len(kvs_uniq) > 1:
-                logger.warning(
-                    f"Only one base kVA rating is expected, got {kvs_uniq!r}. Only the first one will be used"
-                )
-            sn = kvs_uniq[0] * 1000
+        if not np.isscalar(kvas):
+            if len(kvas) != windings:
+                msg = f"Expected {windings} kVA ratings, got {len(kvas)}: {kvas!r}"
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
+            if (n_kvas := len(np.unique(kvas))) > 1:
+                warn_external(f"Only one base kVA rating is expected, got {n_kvas}. Only the first one will be used")
+            kvas = kvas[0]
+        sn = kvas * 1e3
 
-        # Z2 and Ym
-        rs_array = [rs, rs] if np.isscalar(rs) else rs
-        if loadloss is None:
-            if rs is None:
-                raise TypeError("from_open_dss() missing 1 required keyword argument: 'loadloss' or 'rs'")
-            else:
-                r1, r2 = rs_array
-                loadloss = r1 + r2
-        elif not np.isscalar(loadloss):
+        # Load losses
+        if loadloss is not None and not np.isscalar(loadloss):
             msg = f"%Loadloss must be a scalar, got {loadloss!r}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_LOSS)
-        elif rs is not None and not np.isclose(sum(rs_array), loadloss):
-            msg = f"The values of rs={rs!r} are not equivalent to the value of loadloss={loadloss!r}"
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_LOSS)
+        if rs is None:
+            if loadloss is None:
+                raise TypeError("from_open_dss() missing 1 required keyword argument: 'loadloss' or 'rs'")
+        elif np.isscalar(rs):
+            rs = float(rs)
+            if loadloss is None:
+                loadloss = rs * windings
+            elif not np.isclose(rs * windings, loadloss):
+                warn_external(
+                    f"rs={rs} is not consistent with loadloss={loadloss} for {windings} windings. "
+                    f"Only the value of loadloss will be used and rs will be ignored."
+                )
+        else:
+            if len(rs) != windings:
+                msg = f"Expected {windings} %Rs values, got {len(rs)}: {rs!r}"
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
+            if loadloss is None:
+                loadloss = float(sum(rs))
+            elif not np.isclose(sum(rs), loadloss):
+                warn_external(
+                    f"The sum of rs={rs!r} is not equal to the value of loadloss={loadloss!r}. "
+                    f"Only the value of loadloss will be used and rs will be ignored."
+                )
 
-        p0 = (noloadloss / 100) * sn
-        i0 = imag / 100
-        psc = (loadloss / 100) * sn
-        vsc = math.sqrt(xhl**2 + loadloss**2) / 100
-        z2, ym = cls._compute_zy(vg=vg, uhv=uhv, ulv=ulv, sn=sn, p0=p0, i0=i0, psc=psc, vsc=vsc)
-
-        instance = cls(
+        return cls.from_open_and_short_circuit_tests(
             id=id,
             vg=vg,
-            uhv=uhv,
-            ulv=ulv,
+            uhv=uhv * 1e3,
+            ulv=ulv * 1e3,
             sn=sn,
-            z2=z2,
-            ym=ym,
+            p0=(noloadloss / 100) * sn,
+            i0=imag / 100,
+            psc=(loadloss / 100) * sn,
+            vsc=math.sqrt(xhl**2 + loadloss**2) / 100,
             manufacturer=manufacturer,
             range=range,
             efficiency=efficiency,
             cooling=cooling,
             insulation=insulation,
         )
-        instance._p0 = p0
-        instance._i0 = i0
-        instance._psc = psc
-        instance._vsc = vsc
-        instance._has_test_results = True
-        return instance
 
     #
     # Open and short circuit tests
@@ -840,14 +880,14 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         id: Id,
         *,
         vg: str,
-        uhv: float | Q_[float],
-        ulv: float | Q_[float],
-        sn: float | Q_[float],
-        p0: float | Q_[float],
-        i0: float | Q_[float],
-        psc: float | Q_[float],
-        vsc: float | Q_[float],
-        fn: float | Q_[float] | None = None,
+        uhv: QtyOrMag[Float],
+        ulv: QtyOrMag[Float],
+        sn: QtyOrMag[Float],
+        p0: QtyOrMag[Float],
+        i0: QtyOrMag[Float],
+        psc: QtyOrMag[Float],
+        vsc: QtyOrMag[Float],
+        fn: QtyOrMag[Float] | None = None,
         manufacturer: str | None = None,
         range: str | None = None,
         efficiency: str | None = None,
@@ -969,10 +1009,10 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             cooling=cooling,
             insulation=insulation,
         )
-        instance._p0 = p0
-        instance._i0 = i0
-        instance._psc = psc
-        instance._vsc = vsc
+        instance._p0 = float(p0)
+        instance._i0 = float(i0)
+        instance._psc = float(psc)
+        instance._vsc = float(vsc)
         instance._has_test_results = True
         return instance
 
@@ -1060,9 +1100,9 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
 
     def _to_dict(self, include_results: bool) -> JsonDict:
         # Make sure z2 and ym are not numpy types (for JSON serialization)
-        z2 = complex(self._z2)
-        ym = complex(self._ym)
-        data = {
+        z2 = self._z2
+        ym = self._ym
+        data: JsonDict = {
             "id": self.id,
             "vg": self._vg,
             "sn": self._sn,
@@ -1186,10 +1226,10 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         cooling: str | None,
         insulation: str | None,
         vg: str | re.Pattern[str] | None,
-        sn: float | None,
-        uhv: float | None,
-        ulv: float | None,
-        fn: float | None,
+        sn: Float | None,
+        uhv: Float | None,
+        ulv: Float | None,
+        fn: Float | None,
         raise_if_not_found: bool,
     ) -> tuple[pd.DataFrame, str]:
         # Get the catalogue data
@@ -1287,10 +1327,10 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         cooling: str | TransformerCooling | None = None,
         insulation: str | TransformerInsulation | None = None,
         vg: str | re.Pattern[str] | None = None,
-        sn: float | Q_[float] | None = None,
-        uhv: float | Q_[float] | None = None,
-        ulv: float | Q_[float] | None = None,
-        fn: float | Q_[float] | None = None,
+        sn: QtyOrMag[Float] | None = None,
+        uhv: QtyOrMag[Float] | None = None,
+        ulv: QtyOrMag[Float] | None = None,
+        fn: QtyOrMag[Float] | None = None,
         id: Id | None = None,
     ) -> Self:
         """Build a transformer parameters from one in the catalogue.
@@ -1374,14 +1414,14 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         return cls.from_open_and_short_circuit_tests(
             id=id,
             vg=catalogue_data.at[idx, "vg"],
-            uhv=catalogue_data.at[idx, "uhv"].item(),
-            ulv=catalogue_data.at[idx, "ulv"].item(),
-            sn=catalogue_data.at[idx, "sn"].item(),
-            p0=catalogue_data.at[idx, "p0"].item(),
-            i0=catalogue_data.at[idx, "i0"].item(),
-            psc=catalogue_data.at[idx, "psc"].item(),
-            vsc=catalogue_data.at[idx, "vsc"].item(),
-            fn=catalogue_data.at[idx, "fn"].item(),
+            uhv=catalogue_data.at[idx, "uhv"],
+            ulv=catalogue_data.at[idx, "ulv"],
+            sn=catalogue_data.at[idx, "sn"],
+            p0=catalogue_data.at[idx, "p0"],
+            i0=catalogue_data.at[idx, "i0"],
+            psc=catalogue_data.at[idx, "psc"],
+            vsc=catalogue_data.at[idx, "vsc"],
+            fn=catalogue_data.at[idx, "fn"],
             manufacturer=catalogue_data.at[idx, "manufacturer"],
             range=catalogue_data.at[idx, "range"],
             efficiency=catalogue_data.at[idx, "efficiency"],
@@ -1401,10 +1441,10 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         cooling: str | TransformerCooling | None = None,
         insulation: str | TransformerInsulation | None = None,
         vg: str | re.Pattern[str] | None = None,
-        sn: float | Q_[float] | None = None,
-        uhv: float | Q_[float] | None = None,
-        ulv: float | Q_[float] | None = None,
-        fn: float | Q_[float] | None = None,
+        sn: QtyOrMag[Float] | None = None,
+        uhv: QtyOrMag[Float] | None = None,
+        ulv: QtyOrMag[Float] | None = None,
+        fn: QtyOrMag[Float] | None = None,
     ) -> pd.DataFrame:
         """Get the catalogue of available transformers.
 


### PR DESCRIPTION
- Support conversion of single-phase transformers from OpenDSS.
- Use `from_open_and_short_circuit_tests` in `from_power_factory` and `from_open_dss` for better checks and less code
- Add more checks with errors or warnings in `from_open_dss`
- Normalize all scalars to float/complex in one place in the constructor instead of multiple places (repr, from_catalogue, to_dict, etc.)
- Fix some type hints that were missing Quantity

This enables the creation of BDGD's Open-Delta transformers that are modelled using two single-phase transformers.