### PR TITLE
Add name attribute to ElectricalNetwork

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`462` Add `name` attribute to `ElectricalNetwork` to store the name of the network.
 - {gh-pr}`460` Modify the load flow convergence check to use residuals and tolerance comparison. This fixes the case of
   convergence at exactly the number of iterations specified by the `max_iterations` parameter.
 - {gh-pr}`459` Add support for three-phase transformers with "untrue" vector groups

--- a/roseau/load_flow/io/common.py
+++ b/roseau/load_flow/io/common.py
@@ -18,6 +18,7 @@ from roseau.load_flow.typing import CRSLike, Id
 class NetworkElements(TypedDict):
     """A dictionary of network elements."""
 
+    name: str
     buses: dict[Id, Bus]
     loads: dict[Id, Load]
     sources: dict[Id, VoltageSource]

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -91,6 +91,9 @@ def network_from_dict(  # noqa: C901
     is_multiphase = data.get("is_multiphase", True)
     assert is_multiphase, f"Unsupported phase selection {is_multiphase=}."
 
+    # Name
+    name = data.get("name", "Network")
+
     # CRS
     crs_dict = data.get("crs", {"data": None, "normalize": False})
     crs = CRS(crs_dict["data"]) if crs_dict["normalize"] else crs_dict["data"]
@@ -217,6 +220,7 @@ def network_from_dict(  # noqa: C901
 
     return (
         {
+            "name": name,
             "buses": buses,
             "lines": lines,
             "transformers": transformers,
@@ -311,6 +315,7 @@ def network_to_dict(en: "ElectricalNetwork", *, include_results: bool) -> JsonDi
 
     res = {
         "version": NETWORK_JSON_VERSION,
+        "name": en.name,
         "is_multiphase": True,
         "crs": crs,
         "grounds": grounds,

--- a/roseau/load_flow/io/tests/test_dict.py
+++ b/roseau/load_flow/io/tests/test_dict.py
@@ -121,6 +121,7 @@ def test_to_dict():
     # Dict content
     lp1.ampacities = 1000
     res = en.to_dict(include_results=False)
+    assert res["name"] == "Network"  # default name
     res_bus0, res_bus1 = res["buses"]
     res_line0, res_line1 = res["lines"]
     assert "geometry" in res_bus0
@@ -141,6 +142,14 @@ def test_to_dict():
     assert "results" not in res_bus1
     assert "results" not in res_line0
     assert "results" not in res_line1
+
+    # Custom name is serialized and round-trips correctly
+    en.name = "My Network"
+    res = en.to_dict(include_results=False)
+    assert res["name"] == "My Network"
+    en2 = ElectricalNetwork.from_dict(res)
+    assert en2.name == "My Network"
+    assert repr(en2).startswith("<ElectricalNetwork 'My Network':")
 
     # Same id, different transformer parameters -> fail
     ground = Ground("ground")
@@ -191,6 +200,7 @@ def test_all_converters():
         expected_dict = v2_to_v3_converter(expected_dict)
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
+    expected_dict["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict)
 
 
@@ -208,6 +218,7 @@ def test_from_dict_v0():
         expected_dict = v2_to_v3_converter(expected_dict)
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
+    expected_dict["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict)
 
 
@@ -224,6 +235,7 @@ def test_from_dict_v1():
         expected_dict = v2_to_v3_converter(expected_dict)
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
+    expected_dict["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict)
 
     # Test with `include_results=False`
@@ -236,6 +248,7 @@ def test_from_dict_v1():
         expected_dict_no_results = v2_to_v3_converter(expected_dict_no_results)
         expected_dict_no_results = v3_to_v4_converter(expected_dict_no_results)
         expected_dict_no_results = v4_to_v5_converter(expected_dict_no_results)
+    expected_dict_no_results["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict_no_results)
 
 
@@ -260,7 +273,7 @@ def test_from_dict_v2():
         expected_dict = v2_to_v3_converter(expected_dict)
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
-
+    expected_dict["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict)
 
     # Test max loading of transformers
@@ -279,7 +292,7 @@ def test_from_dict_v3():
     with warnings.catch_warnings(action="ignore"):
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
-
+    expected_dict["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict)
 
     # Test vector group of transformers

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -58,6 +58,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     :meth:`solve_load_flow` method.
 
     Args:
+        name:
+            The name of the network. Defaults to ``"Network"``.
+
         buses:
             The buses of the network. Either a list of buses or a dictionary of buses with
             their IDs as keys. Buses are the nodes of the network. They connect other elements
@@ -103,6 +106,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             accepted by geopandas and pyproj, such as an authority string or WKT string.
 
     Attributes:
+        name (str):
+            The name of the network.
+
         buses (dict[Id, roseau.load_flow.Bus]):
             Dictionary of buses of the network indexed by their IDs. Also available as a
             :attr:`GeoDataFrame<buses_frame>`.
@@ -144,6 +150,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     def __init__(
         self,
         *,
+        name: str = "Network",
         buses: MapOrSeq[Bus],
         lines: MapOrSeq[Line],
         transformers: MapOrSeq[Transformer],
@@ -185,11 +192,11 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             "potential ref": self.potential_refs,
             "ground connection": self.ground_connections,
         }
-        super().__init__(crs=crs)
+        super().__init__(name=name, crs=crs)
 
     def __repr__(self) -> str:
         return (
-            f"<{type(self).__name__}:"
+            f"<{type(self).__name__} {self.name!r}:"
             f" {count_repr(self.buses, 'bus', 'buses')},"
             f" {count_repr(self.lines, 'line', 'lines')},"
             f" {count_repr(self.transformers, 'transformer', 'transformers')},"
@@ -377,7 +384,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             A networkx multi-graph representing the electrical network.
         """
         nx = optional_deps.networkx
-        graph = nx.MultiGraph()
+        graph = nx.MultiGraph(name=self.name)
         for bus in self.buses.values():
             graph.add_node(
                 bus.id,
@@ -1363,7 +1370,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.CATALOGUE_MISSING) from None
 
-        return cls.from_dict(json_dict)
+        network = cls.from_dict(json_dict)
+        network.name = f"{name} ({load_point_name})"
+        return network
 
     # TODO: delete the alias when we know how to teach sphinx to include the docstring of the parent class
     tool_data = AbstractNetwork.tool_data

--- a/roseau/load_flow/plotting.py
+++ b/roseau/load_flow/plotting.py
@@ -480,7 +480,7 @@ def _plot_interactive_map_internal(  # noqa: C901
         map_kws["zoom_control"] = "topright"
 
     m = folium.Map(**map_kws)
-    network_layer = folium.FeatureGroup(name="Electrical Network").add_to(m)
+    network_layer = folium.FeatureGroup(name=network.name).add_to(m)
     names = {"bus": "Buses", "line": "Lines", "transformer": "Transformers", "switch": "Switches"}
     for e_type, frame in dataframes.items():
         if frame.empty:
@@ -1199,6 +1199,7 @@ class _VoltageProfile[NetT: ElectricalNetwork | rlfs.ElectricalNetwork, ModeT: L
         title = f"Voltage Profile Starting at Bus {self.starting_bus_id!r}"
         if self.mode:
             title = f"{self.mode.capitalize()} {title}"
+        title = f"{self.network.name} - {title}"
         return title
 
     @property

--- a/roseau/load_flow/utils/mixins.py
+++ b/roseau/load_flow/utils/mixins.py
@@ -596,7 +596,7 @@ class AbstractNetwork(RLFObject, JsonMixin, CatalogueMixin[JsonDict], Generic[_E
     _DEFAULT_SOLVER: Solver = "newton_goldstein"
 
     @abstractmethod
-    def __init__(self, *, crs: CRSLike | None = None) -> None:
+    def __init__(self, *, name: str = "Network", crs: CRSLike | None = None) -> None:
         for elements in self._elements_by_type.values():
             for element in elements.values():
                 element._check_compatible_phase_tech(self)
@@ -613,6 +613,7 @@ class AbstractNetwork(RLFObject, JsonMixin, CatalogueMixin[JsonDict], Generic[_E
         self._create_network()
         self._valid = True
         self._solver = AbstractSolver.from_dict(data={"name": self._DEFAULT_SOLVER, "params": {}}, network=self)
+        self.name: str = name
         self.crs: CRSLike | None = crs
         self._tool_data = ToolData()
 
@@ -624,13 +625,16 @@ class AbstractNetwork(RLFObject, JsonMixin, CatalogueMixin[JsonDict], Generic[_E
             self._add_parameters("transformer", transformer.parameters)  # type: ignore
 
     @classmethod
-    def from_element(cls, initial_bus: AbstractElement, crs: CRSLike | None = None) -> Self:
+    def from_element(cls, initial_bus: AbstractElement, name: str = "Network", crs: CRSLike | None = None) -> Self:
         """Construct the network from only one element (bus) and add the others automatically.
 
         Args:
             initial_bus:
                 Any bus of the network. The network is constructed from this bus and all the
                 elements connected to it. This is usually the main source bus of the network.
+
+            name:
+                The name of the network. Defaults to ``"Network"``.
 
             crs:
                 An optional Coordinate Reference System to use with geo data frames. Can be anything
@@ -661,7 +665,7 @@ class AbstractNetwork(RLFObject, JsonMixin, CatalogueMixin[JsonDict], Generic[_E
             elements_kwargs["potential_refs"] = elements_by_type["potential ref"]
             elements_kwargs["grounds"] = elements_by_type["ground"]
             elements_kwargs["ground_connections"] = elements_by_type["ground connection"]
-        return cls(**elements_kwargs, crs=crs)
+        return cls(**elements_kwargs, name=name, crs=crs)
 
     def solve_load_flow(
         self,

--- a/roseau/load_flow_single/io/common.py
+++ b/roseau/load_flow_single/io/common.py
@@ -8,6 +8,7 @@ from roseau.load_flow_single.models import Bus, Line, Load, Switch, Transformer,
 class NetworkElements(TypedDict):
     """A dictionary of the network elements."""
 
+    name: str
     buses: dict[Id, Bus]
     loads: dict[Id, Load]
     sources: dict[Id, VoltageSource]

--- a/roseau/load_flow_single/io/dict.py
+++ b/roseau/load_flow_single/io/dict.py
@@ -62,6 +62,9 @@ def network_from_dict(
             "`rlf.ElectricalNetwork` instead of `rlfs.ElectricalNetwork`?"
         )
 
+    # Name
+    name = data.get("name", "Network")
+
     # Check the version, 3 was the first version to support RLFS
     version = data["version"]
     assert version >= 3, f"Unsupported network file version {version}, expected >=3."
@@ -157,6 +160,7 @@ def network_from_dict(
 
     return (
         {
+            "name": name,
             "buses": buses,
             "lines": lines,
             "transformers": transformers,
@@ -241,6 +245,7 @@ def network_to_dict(en: "ElectricalNetwork", *, include_results: bool) -> JsonDi
 
     res = {
         "version": NETWORK_JSON_VERSION,
+        "name": en.name,
         "is_multiphase": False,
         "crs": crs,
         "buses": buses,

--- a/roseau/load_flow_single/io/rlf.py
+++ b/roseau/load_flow_single/io/rlf.py
@@ -314,6 +314,7 @@ def network_from_rlf(  # noqa: C901
 
     return (
         {
+            "name": en_m.name,
             "buses": buses,
             "lines": lines,
             "transformers": transformers,

--- a/roseau/load_flow_single/io/tests/test_dict.py
+++ b/roseau/load_flow_single/io/tests/test_dict.py
@@ -67,6 +67,7 @@ def test_to_dict():
     # Dict content
     lp1.ampacity = 1000
     res = en.to_dict(include_results=False)
+    assert res["name"] == "Network"  # default name
     res_bus0, res_bus1 = res["buses"]
     res_line0, res_line1 = res["lines"]
     assert "geometry" in res_bus0
@@ -87,6 +88,14 @@ def test_to_dict():
     assert "results" not in res_bus1
     assert "results" not in res_line0
     assert "results" not in res_line1
+
+    # Custom name is serialized and round-trips correctly
+    en.name = "My Network"
+    res = en.to_dict(include_results=False)
+    assert res["name"] == "My Network"
+    en2 = rlfs.ElectricalNetwork.from_dict(res)
+    assert en2.name == "My Network"
+    assert repr(en2).startswith("<ElectricalNetwork 'My Network':")
 
     # Same id, different transformer parameters -> fail
     vn = 400
@@ -148,6 +157,7 @@ def test_all_converters():
     with warnings.catch_warnings(action="ignore"):
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
+    expected_dict["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict)
 
 
@@ -161,6 +171,7 @@ def test_from_dict_v3():
     with warnings.catch_warnings(action="ignore"):
         expected_dict = v3_to_v4_converter(expected_dict)
         expected_dict = v4_to_v5_converter(expected_dict)
+    expected_dict["name"] = "Network"  # default name added in current format
     assert_json_close(net_dict, expected_dict)
 
 

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -37,6 +37,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     :meth:`solve_load_flow` method.
 
     Args:
+        name:
+            The name of the network. Defaults to ``"Network"``.
+
         buses:
             The buses of the network. Either a list of buses or a dictionary of buses with
             their IDs as keys. Buses are the nodes of the network. They connect other elements
@@ -69,6 +72,9 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             accepted by geopandas and pyproj, such as an authority string or WKT string.
 
     Attributes:
+        name (str):
+            The name of the network.
+
         buses (dict[Id, roseau.load_flow_single.Bus]):
             Dictionary of buses of the network indexed by their IDs. Also available as a
             :attr:`GeoDataFrame<buses_frame>`.
@@ -102,6 +108,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     def __init__(
         self,
         *,
+        name: str = "Network",
         buses: MapOrSeq[Bus],
         lines: MapOrSeq[Line],
         transformers: MapOrSeq[Transformer],
@@ -139,11 +146,11 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             "load": self.loads,
             "source": self.sources,
         }
-        super().__init__(crs=crs)
+        super().__init__(name=name, crs=crs)
 
     def __repr__(self) -> str:
         return (
-            f"<{type(self).__name__}:"
+            f"<{type(self).__name__} {self.name!r}:"
             f" {count_repr(self.buses, 'bus', 'buses')},"
             f" {count_repr(self.lines, 'line', 'lines')},"
             f" {count_repr(self.transformers, 'transformer', 'transformers')},"
@@ -256,7 +263,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
             A networkx multi-graph representing the electrical network.
         """
         nx = optional_deps.networkx
-        graph = nx.MultiGraph()
+        graph = nx.MultiGraph(name=self.name)
         for bus in self.buses.values():
             graph.add_node(
                 bus.id,


### PR DESCRIPTION
Working with many networks simultaneously, I often find myself needing to store the name of the network somewhere and keeping the name and the network tied together. This PR provide a practical solution to this problem.

Note that I haven't bumped the version number of the JSON file as this is a very small change that is not worth the effort.

--------------------------------

**Disclaimer**

I used a coding agent to make this change and reviewed the changes thoroughly.
Below is the summary of the agent:
- Add optional `name: str = "Network"` parameter to the constructors of both multi-phase and single-phase `ElectricalNetwork` classes and to `AbstractNetwork.from_element`.
- Serialize/deserialize the name in `network_to_dict`/`network_from_dict` (both packages) and propagate it through `network_from_rlf`.
- Set a meaningful name from the catalogue in `from_catalogue` (e.g. "LVFeeder01 (Load_point_1)").
- Include the name in `__repr__`, pass it to the networkx `MultiGraph`, prepend it to the voltage-profile plot title, and use it as the folium `FeatureGroup` label in interactive maps.
- Update tests to assert the default name is serialized and that a custom name round-trips correctly through `to_dict`/`from_dict`.