### PR TITLE
Make quantity lazy

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,7 +21,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- {gh-pr}`463` Support compact JSON output with `indent=False` and improve performance by using `orjson` if installed.
+- {gh-pr}`465` Improve performance of quantities by making the `Q_` class lazy.
+- {gh-pr}`464` Support compact JSON output with `indent=False` and improve performance by using `orjson` if installed.
 - {gh-pr}`462` Add `name` attribute to `ElectricalNetwork` to store the name of the network.
 - {gh-pr}`460` Modify the load flow convergence check to use residuals and tolerance comparison. This fixes the case of
   convergence at exactly the number of iterations specified by the `max_iterations` parameter.

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,7 +21,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- {gh-pr}`465` Improve performance of quantities by making the `Q_` class lazy.
+- {gh-pr}`465` Make results access on elements between 2x and 3x faster by making the `Q_` class lazy.
 - {gh-pr}`464` Support compact JSON output with `indent=False` and improve performance by using `orjson` if installed.
 - {gh-pr}`462` Add `name` attribute to `ElectricalNetwork` to store the name of the network.
 - {gh-pr}`460` Modify the load flow convergence check to use residuals and tolerance comparison. This fixes the case of

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -14,7 +14,7 @@ from roseau.load_flow.models.core import Element
 from roseau.load_flow.models.line_parameters import LineParameters
 from roseau.load_flow.models.transformer_parameters import TransformerParameters
 from roseau.load_flow.typing import ComplexArray, Id, JsonDict, Side
-from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import one_or_more_repr, warn_external
 from roseau.load_flow_engine.cy_engine import CyBranch
 
@@ -234,40 +234,36 @@ class AbstractBranch(Element[_CyB_co], Generic[_Side_co, _CyB_co]):
             )
 
     @property
-    @ureg_wraps(("A", "A"), (None,))
     def res_currents(self) -> tuple[Q_[ComplexArray], Q_[ComplexArray]]:
         """The load flow result of the branch currents (A)."""
         return (
-            self._side1._res_currents_getter(warning=True),
-            self._side2._res_currents_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_currents_getter(warning=True), "A"),
+            Q_(self._side2._res_currents_getter(warning=False), "A"),  # warn only once
+        )
 
     @property
-    @ureg_wraps(("VA", "VA"), (None,))
     def res_powers(self) -> tuple[Q_[ComplexArray], Q_[ComplexArray]]:
         """The load flow result of the branch powers (VA)."""
         return (
-            self._side1._res_powers_getter(warning=True),
-            self._side2._res_powers_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_powers_getter(warning=True), "VA"),
+            Q_(self._side2._res_powers_getter(warning=False), "VA"),  # warn only once
+        )
 
     @property
-    @ureg_wraps(("V", "V"), (None,))
     def res_potentials(self) -> tuple[Q_[ComplexArray], Q_[ComplexArray]]:
         """The load flow result of the branch potentials (V)."""
         return (
-            self._side1._res_potentials_getter(warning=True),
-            self._side2._res_potentials_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_potentials_getter(warning=True), "V"),
+            Q_(self._side2._res_potentials_getter(warning=False), "V"),  # warn only once
+        )
 
     @property
-    @ureg_wraps(("V", "V"), (None,))
     def res_voltages(self) -> tuple[Q_[ComplexArray], Q_[ComplexArray]]:
         """The load flow result of the branch voltages (V)."""
         return (
-            self._side1._res_voltages_getter(warning=True),
-            self._side2._res_voltages_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_voltages_getter(warning=True), "V"),
+            Q_(self._side2._res_voltages_getter(warning=False), "V"),  # warn only once
+        )
 
     #
     # Json Mixin interface

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -102,10 +102,9 @@ class Bus(AbstractTerminal[CyBus]):
         return f"{type(self).__name__}(id={self.id!r}, phases={self.phases!r})"
 
     @property
-    @ureg_wraps("V", (None,))
     def initial_potentials(self) -> Q_[ComplexArray]:
         """An array of initial potentials of the bus (V)."""
-        return self._initial_potentials
+        return Q_(self._initial_potentials, "V")
 
     @initial_potentials.setter
     @ureg_wraps(None, (None, "V"))

--- a/roseau/load_flow/models/connectables.py
+++ b/roseau/load_flow/models/connectables.py
@@ -12,7 +12,7 @@ from roseau.load_flow.models.core import _CyE_co
 from roseau.load_flow.models.terminals import AbstractTerminal
 from roseau.load_flow.sym import phasor_to_sym
 from roseau.load_flow.typing import ComplexArray, Id, JsonDict, Side
-from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import SIDE_DESC, abstractattrs, ensure_startsupper, one_or_more_repr, warn_external
 from roseau.load_flow_engine.cy_engine import CyBranch
 
@@ -153,18 +153,15 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
         return potentials * currents.conjugate()
 
     @property
-    @ureg_wraps("A", (None,))
     def res_currents(self) -> Q_[ComplexArray]:
         """The load flow result of the element currents (A)."""
-        return self._res_currents_getter(warning=True)
+        return Q_(self._res_currents_getter(warning=True), "A")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_powers(self) -> Q_[ComplexArray]:
         """The load flow result of the "line powers" flowing into the element (VA)."""
-        return self._res_powers_getter(warning=True)
+        return Q_(self._res_powers_getter(warning=True), "VA")
 
-    @ureg_wraps("percent", (None,))
     def res_current_unbalance(self) -> Q_[float]:
         """Calculate the current unbalance (CU) on this element.
 
@@ -187,7 +184,7 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
             raise RoseauLoadFlowException(msg, code=RoseauLoadFlowExceptionCode.BAD_PHASE)
         currents = self._res_currents_getter(warning=True)
         _, i1, i2 = phasor_to_sym(currents[:3])  # (0, +, -)
-        return abs(i2) / abs(i1) * 100  # type: ignore
+        return Q_(abs(i2) / abs(i1) * 100, "percent")
 
     #
     # Json Mixin interface

--- a/roseau/load_flow/models/flexible_parameters.py
+++ b/roseau/load_flow/models/flexible_parameters.py
@@ -193,28 +193,24 @@ class Control(JsonMixin):
         return self._type
 
     @property
-    @ureg_wraps("V", (None,))
     def u_min(self) -> Q_[float]:
         """The minimum voltage i.e. the one the control reached the maximum action."""
-        return self._u_min  # type: ignore
+        return Q_(self._u_min, "V")
 
     @property
-    @ureg_wraps("V", (None,))
     def u_down(self) -> Q_[float]:
         """The voltage which starts to trigger the control (lower value)."""
-        return self._u_down  # type: ignore
+        return Q_(self._u_down, "V")
 
     @property
-    @ureg_wraps("V", (None,))
     def u_up(self) -> Q_[float]:
         """TThe voltage  which starts to trigger the control (upper value)."""
-        return self._u_up  # type: ignore
+        return Q_(self._u_up, "V")
 
     @property
-    @ureg_wraps("V", (None,))
     def u_max(self) -> Q_[float]:
         """The maximum voltage i.e. the one the control reached its maximum action."""
-        return self._u_max  # type: ignore
+        return Q_(self._u_max, "V")
 
     @property
     def alpha(self) -> float:
@@ -594,10 +590,9 @@ class FlexibleParameter(JsonMixin):
         )
 
     @property
-    @ureg_wraps("VA", (None,))
     def s_max(self) -> Q_[float]:
         """The apparent power of the flexible load (VA). It is the radius of the feasible circle."""
-        return self._s_max  # type: ignore
+        return Q_(self._s_max, "VA")
 
     @s_max.setter
     @ureg_wraps(None, (None, "VA"))
@@ -622,10 +617,9 @@ class FlexibleParameter(JsonMixin):
         return self._q_min_value if self._q_min_value is not None else -self._s_max
 
     @property
-    @ureg_wraps("VAr", (None,))
     def q_min(self) -> Q_[float]:
         """The minimum reactive power of the flexible load (VAr)."""
-        return self._q_min  # type: ignore
+        return Q_(self._q_min, "VAr")
 
     @q_min.setter
     @ureg_wraps(None, (None, "VAr"))
@@ -656,10 +650,9 @@ class FlexibleParameter(JsonMixin):
         return self._q_max_value if self._q_max_value is not None else self._s_max
 
     @property
-    @ureg_wraps("VAr", (None,))
     def q_max(self) -> Q_[float]:
         """The maximum reactive power of the flexible load (VAr)."""
-        return self._q_max  # type: ignore
+        return Q_(self._q_max, "VAr")
 
     @q_max.setter
     @ureg_wraps(None, (None, "VAr"))

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -92,10 +92,9 @@ class Ground(Element[CyGround]):
         return self._res_getter(self._res_potential, warning)
 
     @property
-    @ureg_wraps("V", (None,))
     def res_potential(self) -> Q_[complex]:
         """The load flow result of the ground potential (V)."""
-        return self._res_potential_getter(warning=True)  # type: ignore
+        return Q_(self._res_potential_getter(warning=True), "V")
 
     #
     # Json Mixin interface
@@ -252,10 +251,9 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
         return self._element._side_value
 
     @property
-    @ureg_wraps("ohm", (None,))
     def impedance(self) -> Q_[complex]:
         """The impedance of the connection to the ground (ohm)."""
-        return self._impedance  # type: ignore
+        return Q_(self._impedance, "ohm")
 
     @impedance.setter
     @ureg_wraps(None, (None, "ohm"))
@@ -323,10 +321,9 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
         return self._res_getter(value=self._res_current, warning=warning)
 
     @property
-    @ureg_wraps("A", (None,))
     def res_current(self) -> Q_[complex]:
         """The load flow result of the current flowing through this connection to the ground (A)."""
-        return self._res_current_getter(warning=True)  # type: ignore
+        return Q_(self._res_current_getter(warning=True), "A")
 
     #
     # Json Mixin interface

--- a/roseau/load_flow/models/line_parameters.py
+++ b/roseau/load_flow/models/line_parameters.py
@@ -153,14 +153,12 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         return s
 
     @property
-    @ureg_wraps("ohm/km", (None,))
     def z_line(self) -> Q_[ComplexMatrix]:
-        return self._z_line
+        return Q_(self._z_line, "ohm/km")
 
     @property
-    @ureg_wraps("S/km", (None,))
     def y_shunt(self) -> Q_[ComplexMatrix]:
-        return self._y_shunt
+        return Q_(self._y_shunt, "S/km")
 
     @property
     def with_shunt(self) -> bool:

--- a/roseau/load_flow/models/lines.py
+++ b/roseau/load_flow/models/lines.py
@@ -154,10 +154,9 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
                 self._cy_element.update_line_parameters(z_line=self._z_line.ravel())
 
     @property
-    @ureg_wraps("km", (None,))
     def length(self) -> Q_[float]:
         """The length of the line (in km)."""
-        return self._length
+        return Q_(self._length, "km")
 
     @length.setter
     @ureg_wraps(None, (None, "km"))
@@ -211,22 +210,19 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
             self._update_internal_parameters()
 
     @property
-    @ureg_wraps("ohm", (None,))
     def z_line(self) -> Q_[ComplexMatrix]:
         """Impedance of the line (in Ohm)."""
-        return self._parameters._z_line * self._length
+        return Q_(self._parameters._z_line * self._length, "ohm")
 
     @property
-    @ureg_wraps("S", (None,))
     def y_shunt(self) -> Q_[ComplexMatrix]:
         """Shunt admittance of the line (in Siemens)."""
-        return self._parameters._y_shunt * self._length
+        return Q_(self._parameters._y_shunt * self._length, "S")
 
     @property
-    @ureg_wraps("", (None,))
     def max_loading(self) -> Q_[float]:
         """The maximum loading of the line (unitless)"""
-        return self._max_loading
+        return Q_(self._max_loading, "")
 
     @max_loading.setter
     @ureg_wraps(None, (None, ""))
@@ -318,46 +314,41 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
             return "normal"
 
     @property
-    @ureg_wraps("V", (None,))
     def res_ground_potential(self) -> Q_[complex]:
         """Get the potential of the ground port of the shunt line (in V)."""
-        return self._res_ground_potential_getter(warning=True)
+        return Q_(self._res_ground_potential_getter(warning=True), "V")
 
     @property
-    @ureg_wraps("A", (None,))
     def res_series_currents(self) -> Q_[ComplexArray]:
         """Get the current in the series elements of the line (in A)."""
-        return self._res_series_currents_getter(warning=True)
+        return Q_(self._res_series_currents_getter(warning=True), "A")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_series_power_losses(self) -> Q_[ComplexArray]:
         """Get the power losses in the series elements of the line (in VA)."""
-        return self._res_series_power_losses_getter(warning=True)
+        return Q_(self._res_series_power_losses_getter(warning=True), "VA")
 
     @property
-    @ureg_wraps(("A", "A"), (None,))
     def res_shunt_currents(self) -> tuple[Q_[ComplexArray], Q_[ComplexArray]]:
         """Get the currents in the shunt elements of the line (in A)."""
         return (
-            self._side1._res_shunt_currents_getter(warning=True),
-            self._side2._res_shunt_currents_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_shunt_currents_getter(warning=True), "A"),
+            Q_(self._side2._res_shunt_currents_getter(warning=False), "A"),  # warn only once
+        )
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_shunt_power_losses(self) -> Q_[ComplexArray]:
         """Get the power losses in the shunt elements of the line (in VA)."""
-        return (
+        return Q_(
             self._side1._res_shunt_losses_getter(warning=True)
-            + self._side2._res_shunt_losses_getter(warning=False)  # warn only once
-        )  # type: ignore
+            + self._side2._res_shunt_losses_getter(warning=False),  # warn only once
+            "VA",
+        )
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_power_losses(self) -> Q_[ComplexArray]:
         """Get the power losses in the line (in VA)."""
-        return self._res_power_losses_getter(warning=True)
+        return Q_(self._res_power_losses_getter(warning=True), "VA")
 
     @property
     def res_loading(self) -> Q_[FloatArray] | None:
@@ -453,13 +444,11 @@ class LineSide(AbstractBranchSide):
         return potentials * currents.conjugate()
 
     @property
-    @ureg_wraps("A", (None,))
     def res_shunt_currents(self) -> Q_[ComplexArray]:
         """Get the currents in the shunt elements of the line side (in A)."""
-        return self._res_shunt_currents_getter(warning=True)  # type: ignore
+        return Q_(self._res_shunt_currents_getter(warning=True), "A")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_shunt_losses(self) -> Q_[ComplexArray]:
         """Get the losses in the shunt elements of the line side (in VA)."""
-        return self._res_shunt_losses_getter(warning=True)  # type: ignore
+        return Q_(self._res_shunt_losses_getter(warning=True), "VA")

--- a/roseau/load_flow/models/loads.py
+++ b/roseau/load_flow/models/loads.py
@@ -89,20 +89,18 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
         return voltages * currents.conjugate()
 
     @property
-    @ureg_wraps("A", (None,))
     def res_inner_currents(self) -> Q_[ComplexArray]:
         """The load flow result of the currents that flow in the inner components of the load (A)."""
-        return self._res_inner_currents_getter(warning=True)
+        return Q_(self._res_inner_currents_getter(warning=True), "A")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_inner_powers(self) -> Q_[ComplexArray]:
         """The load flow result of the powers that flow in the inner components of the load (VA).
 
         Unlike `res_powers`, the inner powers do not depend on the reference of potentials. They
         are the physical powers consumed by each of the load dipoles.
         """
-        return self._res_inner_powers_getter(warning=True)
+        return Q_(self._res_inner_powers_getter(warning=True), "VA")
 
     def _validate_value(self, value: ComplexScalarOrArrayLike1D) -> ComplexArray:
         values = [value for _ in range(self._size)] if np.isscalar(value) else value
@@ -314,13 +312,12 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyDeltaPowerLoad | CyFlexibleLoad | C
         return self._flexible_params is not None
 
     @property
-    @ureg_wraps("VA", (None,))
     def powers(self) -> Q_[ComplexArray]:
         """The powers of the load (VA).
 
         Setting the powers will update the load's power values and invalidate the network results.
         """
-        return self._powers
+        return Q_(self._powers, "VA")
 
     @powers.setter
     @ureg_wraps(None, (None, "VA"))
@@ -366,7 +363,6 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyDeltaPowerLoad | CyFlexibleLoad | C
         return self._res_getter(value=self._res_flexible_powers, warning=warning)
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_flexible_powers(self) -> Q_[ComplexArray]:
         """The load flow result of the load flexible powers (VA).
 
@@ -381,7 +377,7 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyDeltaPowerLoad | CyFlexibleLoad | C
             msg = f"The load {self.id!r} is not flexible and does not have flexible powers"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LOAD_TYPE)
-        return self._res_flexible_powers_getter(warning=True)
+        return Q_(self._res_flexible_powers_getter(warning=True), "VA")
 
 
 @final
@@ -442,13 +438,12 @@ class CurrentLoad(AbstractLoad[CyCurrentLoad | CyDeltaCurrentLoad]):
         self._cy_connect()
 
     @property
-    @ureg_wraps("A", (None,))
     def currents(self) -> Q_[ComplexArray]:
         """The currents of the load (Amps).
 
         Setting the currents will update the load's currents and invalidate the network results.
         """
-        return self._currents
+        return Q_(self._currents, "A")
 
     @currents.setter
     @ureg_wraps(None, (None, "A"))
@@ -515,10 +510,9 @@ class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad | CyDeltaAdmittanceLoad]):
         self._cy_connect()
 
     @property
-    @ureg_wraps("ohm", (None,))
     def impedances(self) -> Q_[ComplexArray]:
         """The impedances of the load (Ohms)."""
-        return self._impedances
+        return Q_(self._impedances, "ohm")
 
     @impedances.setter
     @ureg_wraps(None, (None, "ohm"))

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -6,7 +6,7 @@ from roseau.load_flow.models.buses import Bus
 from roseau.load_flow.models.core import Element
 from roseau.load_flow.models.grounds import Ground
 from roseau.load_flow.typing import Id, JsonDict
-from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import one_or_more_repr
 from roseau.load_flow_engine.cy_engine import CyDeltaPotentialRef, CyPotentialRef
 
@@ -119,13 +119,12 @@ class PotentialRef(Element[CyPotentialRef | CyDeltaPotentialRef]):
         return self._res_getter(self._res_current, warning)
 
     @property
-    @ureg_wraps("A", (None,))
     def res_current(self) -> Q_[complex]:
         """The sum of the currents (A) of the connection associated to the potential reference.
 
         This sum should be equal to 0 after the load flow.
         """
-        return self._res_current_getter(warning=True)
+        return Q_(self._res_current_getter(warning=True), "A")
 
     #
     # Json Mixin interface

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -84,7 +84,6 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource | CyDeltaVoltageSourc
         self._cy_connect()
 
     @property
-    @ureg_wraps("V", (None,))
     def voltages(self) -> Q_[ComplexArray]:
         """The complex voltages of the source (V).
 
@@ -98,7 +97,7 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource | CyDeltaVoltageSourc
             of the second and third phases are -120° and 120°, respectively (120° phase shift
             clockwise).
         """
-        return self._voltages
+        return Q_(self._voltages, "V")
 
     @voltages.setter
     @ureg_wraps(None, (None, "V"))

--- a/roseau/load_flow/models/terminals.py
+++ b/roseau/load_flow/models/terminals.py
@@ -10,7 +10,7 @@ from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowE
 from roseau.load_flow.models.core import Element, _CyE_co
 from roseau.load_flow.sym import phasor_to_sym
 from roseau.load_flow.typing import ComplexArray, Id, JsonDict, Side
-from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import SIDE_DESC, SIDE_INDEX, SIDE_SUFFIX
 
 logger = logging.getLogger(__name__)
@@ -109,13 +109,11 @@ class AbstractTerminal(Element[_CyE_co], ABC):
         return _calculate_voltages(potentials, self.phases)
 
     @property
-    @ureg_wraps("V", (None,))
     def res_potentials(self) -> Q_[ComplexArray]:
         """The load flow result of the element potentials (V)."""
-        return self._res_potentials_getter(warning=True)
+        return Q_(self._res_potentials_getter(warning=True), "V")
 
     @property
-    @ureg_wraps("V", (None,))
     def res_voltages(self) -> Q_[ComplexArray]:
         """The load flow result of the element voltages (V).
 
@@ -126,27 +124,24 @@ class AbstractTerminal(Element[_CyE_co], ABC):
         To always get phase-to-phase voltages, use the property :attr:`.res_voltages_pp`.
         To always get phase-to-neutral voltages, use the property :attr:`.res_voltages_pn`.
         """
-        return self._res_voltages_getter(warning=True)
+        return Q_(self._res_voltages_getter(warning=True), "V")
 
     @property
-    @ureg_wraps("V", (None,))
     def res_voltages_pp(self) -> Q_[ComplexArray]:
         """The load flow result of the element's phase-to-phase voltages (V).
 
         Raises an error if the element has only one phase.
         """
-        return self._res_voltages_pp_getter(warning=True)
+        return Q_(self._res_voltages_pp_getter(warning=True), "V")
 
     @property
-    @ureg_wraps("V", (None,))
     def res_voltages_pn(self) -> Q_[ComplexArray]:
         """The load flow result of the element's phase-to-neutral voltages (V).
 
         Raises an error if the element does not have a neutral.
         """
-        return self._res_voltages_pn_getter(warning=True)
+        return Q_(self._res_voltages_pn_getter(warning=True), "V")
 
-    @ureg_wraps("percent", (None, None))
     def res_voltage_unbalance(self, definition: Literal["VUF", "LVUR", "PVUR"] = "VUF") -> Q_[float]:
         """Calculate the voltage unbalance (VU) on this element.
 
@@ -200,17 +195,18 @@ class AbstractTerminal(Element[_CyE_co], ABC):
             # Indeed |V2_pp| / |V1_pp| = |V2 (1-α²)| / |V1(1-α)| = |V2| / |V1|
             potentials = self._res_potentials_getter(warning=True)
             _, v1, v2 = phasor_to_sym(potentials[:3])  # (0, +, -)
-            return abs(v2) / abs(v1) * 100  # type: ignore
+            result = abs(v2) / abs(v1) * 100
         elif definition == "LVUR":
             voltages = abs(self._res_voltages_pp_getter(warning=True))
             avg = sum(voltages) / 3
-            return max(abs(voltages - avg)) / avg * 100  # type: ignore
+            result = max(abs(voltages - avg)) / avg * 100
         elif definition == "PVUR":
             voltages = abs(self._res_voltages_pn_getter(warning=True))
             avg = sum(voltages) / 3
-            return max(abs(voltages - avg)) / avg * 100  # type: ignore
+            result = max(abs(voltages - avg)) / avg * 100
         else:
             raise ValueError(f"Invalid voltage unbalance definition: {definition!r}.")
+        return Q_(result, "percent")
 
     #
     # Json Mixin interface

--- a/roseau/load_flow/models/transformer_parameters.py
+++ b/roseau/load_flow/models/transformer_parameters.py
@@ -296,22 +296,19 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
     phase_displacement = clock
 
     @property
-    @ureg_wraps("V", (None,))
     def uhv(self) -> Q_[float]:
         """Rated phase-to-phase voltage of the HV side (V)."""
-        return self._uhv
+        return Q_(self._uhv, "V")
 
     @property
-    @ureg_wraps("V", (None,))
     def ulv(self) -> Q_[float]:
         """Rated no-load phase-to-phase voltage of the LV side (V)."""
-        return self._ulv
+        return Q_(self._ulv, "V")
 
     @property
-    @ureg_wraps("VA", (None,))
     def sn(self) -> Q_[float]:
         """The nominal power of the transformer (VA)."""
-        return self._sn
+        return Q_(self._sn, "VA")
 
     @property
     def fn(self) -> Q_[float] | None:
@@ -319,22 +316,19 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
         return Q_(self._fn, "Hz") if self._fn is not None else None
 
     @property
-    @ureg_wraps("ohm", (None,))
     def z2(self) -> Q_[complex]:
         """The series impedance of the transformer (Ohm)."""
-        return self._z2
+        return Q_(self._z2, "ohm")
 
     @property
-    @ureg_wraps("S", (None,))
     def ym(self) -> Q_[complex]:
         """The magnetizing admittance of the transformer (S)."""
-        return self._ym
+        return Q_(self._ym, "S")
 
     @property
-    @ureg_wraps("", (None,))
     def k(self) -> Q_[float]:
         """The transformation ratio of the transformer."""
-        return self._k
+        return Q_(self._k, "")
 
     @property
     def orientation(self) -> float:

--- a/roseau/load_flow/models/transformers.py
+++ b/roseau/load_flow/models/transformers.py
@@ -224,10 +224,9 @@ class Transformer(AbstractBranch["TransformerSide", CyTransformer]):
             self._cy_update_parameters(tap=self.tap, parameters=value)
 
     @property
-    @ureg_wraps("", (None,))
     def max_loading(self) -> Q_[float]:
         """The maximum loading of the transformer (unitless)"""
-        return self._max_loading
+        return Q_(self._max_loading, "")
 
     @max_loading.setter
     @ureg_wraps(None, (None, ""))
@@ -246,10 +245,9 @@ class Transformer(AbstractBranch["TransformerSide", CyTransformer]):
         return self._parameters.sn
 
     @property
-    @ureg_wraps("VA", (None,))
     def max_power(self) -> Q_[float]:
         """The maximum power loading of the transformer (in VA)."""
-        return self.parameters._sn * self._max_loading  # type: ignore
+        return Q_(self.parameters._sn * self._max_loading, "VA")
 
     def _cy_update_parameters(self, tap: float, parameters: TransformerParameters) -> None:
         z2, ym, k = parameters._z2, parameters._ym, parameters._k
@@ -404,18 +402,16 @@ class Transformer(AbstractBranch["TransformerSide", CyTransformer]):
             return "normal"
 
     @property
-    @ureg_wraps("", (None,))
     def res_loading(self) -> Q_[float]:
         """Get the loading of the transformer (unitless)."""
-        return self._res_loading_getter(warning=True)
+        return Q_(self._res_loading_getter(warning=True), "")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_power_losses(self) -> Q_[complex]:
         """Get the total power losses in the transformer (in VA)."""
         powers_hv = self._side1._res_powers_getter(warning=True)
         powers_lv = self._side2._res_powers_getter(warning=False)  # warn only once
-        return sum(powers_hv) + sum(powers_lv)
+        return Q_(sum(powers_hv) + sum(powers_lv), "VA")
 
     @property
     def res_violated(self) -> bool:

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -58,8 +58,12 @@ else:
     Quantity = ureg.Quantity
     Quantity.__class_getitem__ = classmethod(GenericAlias)
 
+_Q_SEQ = (list, tuple)
+
 
 class Q_(Quantity[M_co], Generic[M_co]):  # noqa: N801, UP046  # ty:ignore[invalid-generic-class]
+    __slots__ = ("_cv", "_cu", "_cq", "_cm")
+
     @overload  # Known magnitude type
     def __new__[M: Magnitude](cls, value: M, units: UnitLike | None = None) -> "Q_[M]": ...
     @overload  # Unknown magnitude type
@@ -86,35 +90,37 @@ class Q_(Quantity[M_co], Generic[M_co]):  # noqa: N801, UP046  # ty:ignore[inval
     def __new__(cls, value: "Q_[Any]", units: UnitLike | None = None) -> "Q_[Any]": ...
     def __new__(cls, value, units=None):
         self = object.__new__(cls)
-        self.__cached_value = value
-        self.__cached_units = units
-        self.__cached_q = None
-        self.__cached_m = None
+        self._cv = value  # cached value
+        self._cu = units  # cached units
+        self._cq = None  # cached quantity
+        self._cm = None  # cached magnitude
         return self
 
     @property
     def m(self) -> M_co:
         """Quantity's magnitude."""
-        if self.__cached_m is None:
-            if isinstance(self.__cached_value, (list, tuple)):
-                self.__cached_m = np.array(self.__cached_value)
-            elif isinstance(self.__cached_value, ureg.Quantity):
-                if self.__cached_units is None:
-                    self.__cached_m = self.__cached_value.m
-                else:
-                    self.__cached_m = ureg.convert(
-                        self.__cached_value.m, self.__cached_value.units, self.__cached_units
-                    )
-            else:
-                self.__cached_m = self.__cached_value
-        return self.__cached_m
+        val = self._cv
+        # Fast path: scalar value
+        if not (is_seq := isinstance(val, _Q_SEQ)) and not isinstance(val, Quantity):
+            return val
+        # Slow path: list/tuple/Quantity — compute and cache
+        m = self._cm
+        if m is None:
+            if is_seq:
+                self._cm = m = np.array(val)
+            else:  # Quantity
+                cu = self._cu
+                self._cm = m = val.m if cu is None else ureg.convert(val.m, val.units, cu)
+        return m  # type: ignore
 
     magnitude = m
 
     def __getattr__(self, name: str) -> Any:
-        if self.__cached_q is None:
-            self.__cached_q = ureg.Quantity(self.__cached_value, self.__cached_units)
-        res = getattr(self.__cached_q, name)
+        qty = self._cq
+        if qty is None:
+            qty = ureg.Quantity(self._cv, self._cu)
+            self._cq = qty
+        res = getattr(qty, name)
         self.__dict__[name] = res  # cache the result
         return res
 

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
 
 import numpy as np
 from numpy.typing import NDArray
-from pint.registry import Quantity, Unit, UnitRegistry
+from pint.registry import Unit, UnitRegistry
 from pint.util import UnitsContainer, to_units_container
 
 __all__ = ["ureg", "Q_", "ureg_wraps"]
@@ -44,59 +44,80 @@ ureg: UnitRegistry = UnitRegistry(
 )
 ureg.define("volt_ampere_reactive = 1 * volt_ampere = VAr")
 
+# Copy types defined in pint but not exposed publicly
+type Scalar = int | float | Decimal | Fraction | complex | np.number[Any]
+type Array = np.ndarray[Any, Any]
+type UnitLike = str | dict[str, Scalar] | UnitsContainer | Unit
+type Magnitude = Scalar | Array
+M_co = TypeVar("M_co", covariant=True, bound=Magnitude)
+
+
 if TYPE_CHECKING:
-    # Copy types defined in pint but not exposed publicly
-    type Scalar = int | float | Decimal | Fraction | complex | np.number[Any]
-    type Array = np.ndarray[Any, Any]
-    type UnitLike = str | dict[str, Scalar] | UnitsContainer | Unit
-    type Magnitude = Scalar | Array
-    M_co = TypeVar("M_co", covariant=True, bound=Magnitude)
-
-    # Redefine Q_ with support for sequences and better type hints
-    class Q_(Quantity[M_co], Generic[M_co]):  # noqa: N801, UP046
-        @overload  # Known magnitude type
-        def __new__[M: Magnitude](cls, value: M, units: UnitLike | None = None) -> "Q_[M]": ...
-
-        @overload  # Unknown magnitude type
-        def __new__(cls, value: str, units: UnitLike | None = None) -> "Q_[Any]": ...
-
-        @overload  # int sequence becomes int64 array
-        def __new__(
-            cls, value: Sequence[int | Sequence[int]], units: UnitLike | None = None
-        ) -> "Q_[NDArray[np.int64]]": ...
-
-        @overload  # float sequence becomes float64 array
-        def __new__(
-            cls, value: Sequence[float | Sequence[float]], units: UnitLike | None = None
-        ) -> "Q_[NDArray[np.float64]]": ...
-
-        @overload  # complex sequence becomes complex128 array
-        def __new__(
-            cls, value: Sequence[complex | Sequence[complex]], units: UnitLike | None = None
-        ) -> "Q_[NDArray[np.complex128]]": ...
-
-        @overload  # numpy number sequence becomes array with same dtype
-        def __new__[N: np.number](
-            cls, value: Sequence[N | Sequence[N]], units: UnitLike | None = None
-        ) -> "Q_[NDArray[N]]": ...
-
-        @overload  # quantity gets passed through (copied) when units are None
-        def __new__[M: Magnitude](cls, value: "Q_[M]", units: None = None) -> "Q_[M]": ...
-
-        @overload  # quantity may get altered when units are not None (conversion)
-        def __new__(cls, value: "Q_[Any]", units: UnitLike | None = None) -> "Q_[Any]": ...
-
-        def __new__(cls, value: M_co, units: UnitLike | None = None) -> "Q_[M_co]":  # type: ignore
-            return super().__new__(cls, value, units)  # type: ignore
-
-        def __init__(self, value: M_co | Sequence, units: UnitLike | None = None) -> None:
-            super().__init__(value, units)  # type: ignore  # for PyCharm only, it does not recognize __new__ alone
-
-        def __getattr__(self, name: str) -> Any: ...  # attributes of the magnitude are accessible on the quantity
-
+    from pint.registry import Quantity
 else:
-    ureg.Quantity.__class_getitem__ = classmethod(GenericAlias)
-    globals()["Q_"] = ureg.Quantity  # Use globals() to trick PyCharm
+    Quantity = ureg.Quantity
+    Quantity.__class_getitem__ = classmethod(GenericAlias)
+
+
+class Q_(Quantity[M_co], Generic[M_co]):  # noqa: N801, UP046  # ty:ignore[invalid-generic-class]
+    @overload  # Known magnitude type
+    def __new__[M: Magnitude](cls, value: M, units: UnitLike | None = None) -> "Q_[M]": ...
+    @overload  # Unknown magnitude type
+    def __new__(cls, value: str, units: UnitLike | None = None) -> "Q_[Any]": ...
+    @overload  # int sequence becomes int64 array
+    def __new__(
+        cls, value: Sequence[int | Sequence[int]], units: UnitLike | None = None
+    ) -> "Q_[NDArray[np.int64]]": ...
+    @overload  # float sequence becomes float64 array
+    def __new__(
+        cls, value: Sequence[float | Sequence[float]], units: UnitLike | None = None
+    ) -> "Q_[NDArray[np.float64]]": ...
+    @overload  # complex sequence becomes complex128 array
+    def __new__(
+        cls, value: Sequence[complex | Sequence[complex]], units: UnitLike | None = None
+    ) -> "Q_[NDArray[np.complex128]]": ...
+    @overload  # numpy number sequence becomes array with same dtype
+    def __new__[N: np.number](
+        cls, value: Sequence[N | Sequence[N]], units: UnitLike | None = None
+    ) -> "Q_[NDArray[N]]": ...
+    @overload  # quantity gets passed through (copied) when units are None
+    def __new__[M1: Magnitude](cls, value: "Q_[M1]", units: None = None) -> "Q_[M1]": ...
+    @overload  # quantity may get altered when units are not None (conversion)
+    def __new__(cls, value: "Q_[Any]", units: UnitLike | None = None) -> "Q_[Any]": ...
+    def __new__(cls, value, units=None):
+        self = object.__new__(cls)
+        self.__cached_value = value
+        self.__cached_units = units
+        self.__cached_q = None
+        self.__cached_m = None
+        return self
+
+    @property
+    def m(self) -> M_co:
+        """Quantity's magnitude."""
+        if self.__cached_m is None:
+            if isinstance(self.__cached_value, (list, tuple)):
+                self.__cached_m = np.array(self.__cached_value)
+            elif isinstance(self.__cached_value, ureg.Quantity):
+                if self.__cached_units is None:
+                    self.__cached_m = self.__cached_value.m
+                else:
+                    self.__cached_m = ureg.convert(
+                        self.__cached_value.m, self.__cached_value.units, self.__cached_units
+                    )
+            else:
+                self.__cached_m = self.__cached_value
+        return self.__cached_m
+
+    magnitude = m
+
+    def __getattr__(self, name: str) -> Any:
+        if self.__cached_q is None:
+            self.__cached_q = ureg.Quantity(self.__cached_value, self.__cached_units)
+        res = getattr(self.__cached_q, name)
+        self.__dict__[name] = res  # cache the result
+        return res
+
 
 type OptionalUnits = str | Unit | None | tuple[str | Unit | None, ...] | list[str | Unit | None]
 
@@ -157,7 +178,7 @@ def _parse_wrap_args(args: Iterable[str | Unit | None]) -> Callable:
     return _converter
 
 
-def _apply_defaults(sig: Signature, args: tuple[Any], kwargs: dict[str, Any]) -> tuple[list[Any], dict[str, Any]]:
+def _apply_defaults(sig: Signature, args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[list[Any], dict[str, Any]]:
     """Apply default keyword arguments.
 
     Named keywords may have been left blank. This function applies the default
@@ -165,7 +186,7 @@ def _apply_defaults(sig: Signature, args: tuple[Any], kwargs: dict[str, Any]) ->
     """
     n = len(args)
     for i, param in enumerate(sig.parameters.values()):
-        if i >= n and param.default != Parameter.empty and param.name not in kwargs:
+        if i >= n and param.default is not Parameter.empty and param.name not in kwargs:
             kwargs[param.name] = param.default
     return list(args), kwargs
 
@@ -239,14 +260,12 @@ def wraps(ureg: UnitRegistry, ret: OptionalUnits, args: OptionalUnits) -> _Ident
             result = func(*new_values, **new_kw)
 
             if is_ret_container:
-                return ret.__class__(
-                    res if unit is None else ureg.Quantity(res, unit) for unit, res in zip_longest(ret, result)
-                )
+                return ret.__class__(res if unit is None else Q_(res, unit) for unit, res in zip_longest(ret, result))
 
             if ret is None:
                 return result
 
-            return ureg.Quantity(result, ret)
+            return Q_(result, ret)
 
         return wrapper
 

--- a/roseau/load_flow_single/models/branches.py
+++ b/roseau/load_flow_single/models/branches.py
@@ -8,7 +8,7 @@ from typing_extensions import TypeVar
 
 from roseau.load_flow import SQRT3
 from roseau.load_flow.typing import Id, JsonDict, Side
-from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import warn_external
 from roseau.load_flow_engine.cy_engine import CyBranch
 from roseau.load_flow_single.models.buses import Bus
@@ -163,31 +163,28 @@ class AbstractBranch(Element[_CyB_co], Generic[_Side_co, _CyB_co]):
             self._side2._res_voltage = self._cy_element.get_port_potential(self._n) * SQRT3
 
     @property
-    @ureg_wraps(("A", "A"), (None,))
     def res_currents(self) -> tuple[Q_[complex], Q_[complex]]:
         """The load flow result of the branch currents (A)."""
         return (
-            self._side1._res_current_getter(warning=True),
-            self._side2._res_current_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_current_getter(warning=True), "A"),
+            Q_(self._side2._res_current_getter(warning=False), "A"),  # warn only once
+        )
 
     @property
-    @ureg_wraps(("V", "V"), (None,))
     def res_voltages(self) -> tuple[Q_[complex], Q_[complex]]:
         """The load flow result of the branch voltages (V)."""
         return (
-            self._side1._res_voltage_getter(warning=True),
-            self._side2._res_voltage_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_voltage_getter(warning=True), "V"),
+            Q_(self._side2._res_voltage_getter(warning=False), "V"),  # warn only once
+        )
 
     @property
-    @ureg_wraps(("VA", "VA"), (None,))
     def res_powers(self) -> tuple[Q_[complex], Q_[complex]]:
         """The load flow result of the branch powers (VA)."""
         return (
-            self._side1._res_power_getter(warning=True),
-            self._side2._res_power_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_power_getter(warning=True), "VA"),
+            Q_(self._side2._res_power_getter(warning=False), "VA"),  # warn only once
+        )
 
     #
     # Json Mixin interface

--- a/roseau/load_flow_single/models/buses.py
+++ b/roseau/load_flow_single/models/buses.py
@@ -93,10 +93,9 @@ class Bus(AbstractTerminal[CyBus]):
         return f"{type(self).__name__}(id={self.id!r})"
 
     @property
-    @ureg_wraps("V", (None,))
     def initial_voltage(self) -> Q_[complex]:
         """Initial voltage of the bus (V)."""
-        return self._initial_voltage
+        return Q_(self._initial_voltage, "V")
 
     @initial_voltage.setter
     @ureg_wraps(None, (None, "V"))

--- a/roseau/load_flow_single/models/connectables.py
+++ b/roseau/load_flow_single/models/connectables.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from roseau.load_flow import SQRT3
 from roseau.load_flow.typing import Id, JsonDict, Side
-from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import abstractattrs
 from roseau.load_flow_engine.cy_engine import CyBranch
 from roseau.load_flow_single.models.buses import Bus
@@ -77,16 +77,14 @@ class AbstractConnectable(AbstractTerminal[_CyE_co], ABC):
         return voltage * current.conjugate() * SQRT3
 
     @property
-    @ureg_wraps("A", (None,))
     def res_current(self) -> Q_[complex]:
         """The load flow result of the element's current (A)."""
-        return self._res_current_getter(warning=True)  # type: ignore
+        return Q_(self._res_current_getter(warning=True), "A")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_power(self) -> Q_[complex]:
         """The load flow result of the element's power (VA)."""
-        return self._res_power_getter(warning=True)  # type: ignore
+        return Q_(self._res_power_getter(warning=True), "VA")
 
     #
     # Json Mixin interface

--- a/roseau/load_flow_single/models/flexible_parameters.py
+++ b/roseau/load_flow_single/models/flexible_parameters.py
@@ -174,10 +174,9 @@ class FlexibleParameter(MultiFlexibleParameter):
         )
 
     @property
-    @ureg_wraps("VA", (None,))
     def s_max(self) -> Q_[float]:
         """The apparent power of the flexible load (VA). It is the radius of the feasible circle."""
-        return self._s_max  # type: ignore
+        return Q_(self._s_max, "VA")
 
     @s_max.setter
     @ureg_wraps(None, (None, "VA"))
@@ -202,10 +201,9 @@ class FlexibleParameter(MultiFlexibleParameter):
         return self._q_min_value if self._q_min_value is not None else -self._s_max
 
     @property
-    @ureg_wraps("VAr", (None,))
     def q_min(self) -> Q_[float]:
         """The minimum reactive power of the flexible load (VAr)."""
-        return self._q_min  # type: ignore
+        return Q_(self._q_min, "VAr")
 
     @q_min.setter
     @ureg_wraps(None, (None, "VAr"))
@@ -236,10 +234,9 @@ class FlexibleParameter(MultiFlexibleParameter):
         return self._q_max_value if self._q_max_value is not None else self._s_max
 
     @property
-    @ureg_wraps("VAr", (None,))
     def q_max(self) -> Q_[float]:
         """The maximum reactive power of the flexible load (VAr)."""
-        return self._q_max  # type: ignore
+        return Q_(self._q_max, "VAr")
 
     @q_max.setter
     @ureg_wraps(None, (None, "VAr"))

--- a/roseau/load_flow_single/models/line_parameters.py
+++ b/roseau/load_flow_single/models/line_parameters.py
@@ -114,16 +114,14 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         return s
 
     @property
-    @ureg_wraps("ohm/km", (None,))
     def z_line(self) -> Q_[complex]:
         """The positive-sequence impedance of the line (Ohm/km)."""
-        return self._z_line
+        return Q_(self._z_line, "ohm/km")
 
     @property
-    @ureg_wraps("S/km", (None,))
     def y_shunt(self) -> Q_[complex]:
         """The positive-sequence shunt admittance of the line (S/km)."""
-        return self._y_shunt
+        return Q_(self._y_shunt, "S/km")
 
     @property
     def with_shunt(self) -> bool:

--- a/roseau/load_flow_single/models/lines.py
+++ b/roseau/load_flow_single/models/lines.py
@@ -101,10 +101,9 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
                 self._cy_element.update_single_line_parameters(z_line=self._z_line)
 
     @property
-    @ureg_wraps("km", (None,))
     def length(self) -> Q_[float]:
         """The length of the line (in km)."""
-        return self._length  # type: ignore
+        return Q_(self._length, "km")
 
     @length.setter
     @ureg_wraps(None, (None, "km"))
@@ -144,22 +143,19 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
             self._update_internal_parameters()
 
     @property
-    @ureg_wraps("ohm", (None,))
     def z_line(self) -> Q_[complex]:
         """Impedance of the line (in Ohm)."""
-        return self._z_line  # type: ignore
+        return Q_(self._z_line, "ohm")
 
     @property
-    @ureg_wraps("S", (None,))
     def y_shunt(self) -> Q_[complex]:
         """Shunt admittance of the line (in Siemens)."""
-        return self._y_shunt  # type: ignore
+        return Q_(self._y_shunt, "S")
 
     @property
-    @ureg_wraps("", (None,))
     def max_loading(self) -> Q_[float]:
         """The maximum loading of the line (unitless)"""
-        return self._max_loading  # type: ignore
+        return Q_(self._max_loading, "")
 
     @max_loading.setter
     @ureg_wraps(None, (None, ""))
@@ -231,40 +227,36 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
             return "normal"
 
     @property
-    @ureg_wraps("A", (None,))
     def res_series_current(self) -> Q_[complex]:
         """Get the current in the series elements of the line (in A)."""
-        return self._res_series_current_getter(warning=True)  # type: ignore
+        return Q_(self._res_series_current_getter(warning=True), "A")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_series_power_losses(self) -> Q_[complex]:
         """Get the power losses in the series elements of the line (in VA)."""
-        return self._res_series_power_losses_getter(warning=True)  # type: ignore
+        return Q_(self._res_series_power_losses_getter(warning=True), "VA")
 
     @property
-    @ureg_wraps(("A", "A"), (None,))
     def res_shunt_currents(self) -> tuple[Q_[complex], Q_[complex]]:
         """Get the currents in the shunt elements of the line (in A)."""
         return (
-            self._side1._res_shunt_current_getter(warning=True),
-            self._side2._res_shunt_current_getter(warning=False),  # warn only once
-        )  # type: ignore
+            Q_(self._side1._res_shunt_current_getter(warning=True), "A"),
+            Q_(self._side2._res_shunt_current_getter(warning=False), "A"),  # warn only once
+        )
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_shunt_power_losses(self) -> Q_[complex]:
         """Get the power losses in the shunt elements of the line (in VA)."""
-        return (
+        return Q_(
             self._side1._res_shunt_losses_getter(warning=True)
-            + self._side2._res_shunt_losses_getter(warning=False)  # warn only once
-        )  # type: ignore
+            + self._side2._res_shunt_losses_getter(warning=False),  # warn only once
+            "VA",
+        )
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_power_losses(self) -> Q_[complex]:
         """Get the power losses in the line (in VA)."""
-        return self._res_power_losses_getter(warning=True)  # type: ignore
+        return Q_(self._res_power_losses_getter(warning=True), "VA")
 
     @property
     def res_loading(self) -> Q_[float] | None:
@@ -343,13 +335,11 @@ class LineSide(AbstractBranchSide):
         return voltage * current.conjugate() * SQRT3
 
     @property
-    @ureg_wraps("A", (None,))
     def res_shunt_current(self) -> Q_[complex]:
         """Get the current in the shunt elements of the line side (in A)."""
-        return self._res_shunt_current_getter(warning=True)  # type: ignore
+        return Q_(self._res_shunt_current_getter(warning=True), "A")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_shunt_losses(self) -> Q_[complex]:
         """Get the losses in the shunt elements of the line side (in VA)."""
-        return self._res_shunt_losses_getter(warning=True)  # type: ignore
+        return Q_(self._res_shunt_losses_getter(warning=True), "VA")

--- a/roseau/load_flow_single/models/loads.py
+++ b/roseau/load_flow_single/models/loads.py
@@ -141,13 +141,12 @@ class PowerLoad(AbstractLoad[CyPowerLoad | CyFlexibleLoad]):
         return self._flexible_param is not None
 
     @property
-    @ureg_wraps("VA", (None,))
     def power(self) -> Q_[complex]:
         """The power of the load (VA).
 
         Setting the power will update the load's power values and invalidate the network results.
         """
-        return self._power
+        return Q_(self._power, "VA")
 
     @power.setter
     @ureg_wraps(None, (None, "VA"))
@@ -228,13 +227,12 @@ class CurrentLoad(AbstractLoad[CyCurrentLoad]):
         self._cy_connect()
 
     @property
-    @ureg_wraps("A", (None,))
     def current(self) -> Q_[complex]:
         """The current of the load (Amps).
 
         Setting the current will update the load's current and invalidate the network results.
         """
-        return self._current
+        return Q_(self._current, "A")
 
     @current.setter
     @ureg_wraps(None, (None, "A"))
@@ -281,13 +279,12 @@ class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad]):
         return super()._validate_value(value)
 
     @property
-    @ureg_wraps("ohm", (None,))
     def impedance(self) -> Q_[complex]:
         """The impedance of the load (Ohms).
 
         Setting the impedance will update the load's impedance and invalidate the network results.
         """
-        return self._impedance
+        return Q_(self._impedance, "ohm")
 
     @impedance.setter
     @ureg_wraps(None, (None, "ohm"))

--- a/roseau/load_flow_single/models/sources.py
+++ b/roseau/load_flow_single/models/sources.py
@@ -43,13 +43,12 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource]):
         self._cy_connect()
 
     @property
-    @ureg_wraps("V", (None,))
     def voltage(self) -> Q_[complex]:
         """The complex voltage of the source (V).
 
         Setting the voltage will update the source voltage and invalidate the network results.
         """
-        return self._voltage
+        return Q_(self._voltage, "V")
 
     @voltage.setter
     @ureg_wraps(None, (None, "V"))

--- a/roseau/load_flow_single/models/terminals.py
+++ b/roseau/load_flow_single/models/terminals.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 from roseau.load_flow import SQRT3
 from roseau.load_flow.typing import Id, JsonDict, Side
-from roseau.load_flow.units import Q_, ureg_wraps
+from roseau.load_flow.units import Q_
 from roseau.load_flow.utils import SIDE_DESC, SIDE_INDEX, SIDE_SUFFIX
 from roseau.load_flow_single.models.core import Element, _CyE_co
 
@@ -49,10 +49,9 @@ class AbstractTerminal(Element[_CyE_co], ABC):
         return self._res_getter(self._res_voltage, warning)
 
     @property
-    @ureg_wraps("V", (None,))
     def res_voltage(self) -> Q_[complex]:
         """The load flow result of the element's voltage (V)."""
-        return self._res_voltage_getter(warning=True)  # type: ignore
+        return Q_(self._res_voltage_getter(warning=True), "V")
 
     #
     # Json Mixin interface

--- a/roseau/load_flow_single/models/transformers.py
+++ b/roseau/load_flow_single/models/transformers.py
@@ -140,10 +140,9 @@ class Transformer(AbstractBranch["TransformerSide", CySingleTransformer]):
             self._cy_element.update_transformer_parameters(z2, ym, k * self.tap)
 
     @property
-    @ureg_wraps("", (None,))
     def max_loading(self) -> Q_[float]:
         """The maximum loading of the transformer (unitless)"""
-        return self._max_loading  # type: ignore
+        return Q_(self._max_loading, "")
 
     @max_loading.setter
     @ureg_wraps(None, (None, ""))
@@ -162,18 +161,16 @@ class Transformer(AbstractBranch["TransformerSide", CySingleTransformer]):
         return self._parameters.sn
 
     @property
-    @ureg_wraps("VA", (None,))
     def max_power(self) -> Q_[float]:
         """The maximum power loading of the transformer (in VA)."""
-        return self.parameters._sn * self._max_loading  # type: ignore
+        return Q_(self.parameters._sn * self._max_loading, "VA")
 
     @property
-    @ureg_wraps("VA", (None,))
     def res_power_losses(self) -> Q_[complex]:
         """Get the total power losses in the transformer (in VA)."""
         power_hv = self._side1._res_power_getter(warning=True)
         power_lv = self._side2._res_power_getter(warning=False)  # warn only once
-        return power_hv + power_lv  # type: ignore
+        return Q_(power_hv + power_lv, "VA")
 
     def _res_loading_getter(self, warning: bool) -> float:
         sn = self._parameters._sn
@@ -193,10 +190,9 @@ class Transformer(AbstractBranch["TransformerSide", CySingleTransformer]):
             return "normal"
 
     @property
-    @ureg_wraps("", (None,))
     def res_loading(self) -> Q_[float]:
         """Get the loading of the transformer (unitless)."""
-        return self._res_loading_getter(warning=True)  # type: ignore
+        return Q_(self._res_loading_getter(warning=True), "")
 
     @property
     def res_violated(self) -> bool:


### PR DESCRIPTION
This PR aims at reducing the performance difference between the results accessors on the network and the results accessors on the elements. The following changes have been made.

- The `Q_` class in now lazy
  - The most common use case for this class is using the `m` (or `magnitude`) property. This doesn't require parsing the unit and invoking the full pint registry lookups. This change means that we now only parse the unit when needed.
- Replace unit wrappers with direct `Q_` instantiation on simple property and results getters
  - This was already done for some getter that could return `None` (e.g `line.res_loading`), now it is done for all of them. This also improves the typing of those functions as the return type now is statically known to be `Q_` so we get rid of many `type: ignore` comments.

This was done in iterations with the help of an AI agent.

If you are interested, here are the performance changes after each commit:

<details><summary>Details</summary>
<p>

- Make `Q_` lazy

|     | Benchmark | `BASE` | `HEAD` | Efficiency |
| --- | --------- | ------ | ------ | ---------- |
| ⚡ | [`` test_rlfs_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlfs_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,756.6 µs | 987.3 µs | +77.92% |
| ⚡ | [`` test_rlf_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 5.6 ms | 3.5 ms | +59.03% |
| ⚡ | [`` test_rlf_to_dict ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_dict&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,458.8 µs | 969.6 µs | +50.45% |
| ⚡ | [`` test_rlf_to_json ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_json&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 2 ms | 1.5 ms | +33.01% |

- Add slots (claude)

|     | Benchmark | `BASE` | `HEAD` | Efficiency |
| --- | --------- | ------ | ------ | ---------- |
| ⚡ | [`` test_rlfs_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlfs_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,756.6 µs | 956.6 µs | +83.62% |
| ⚡ | [`` test_rlf_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 5.6 ms | 3.4 ms | +62.52% |
| ⚡ | [`` test_rlf_to_dict ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_dict&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,458.8 µs | 970.1 µs | +50.37% |
| ⚡ | [`` test_rlf_to_json ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_json&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 2 ms | 1.5 ms | +33.13% |

- Replace wrappers in `rlfs`

|     | Benchmark | `BASE` | `HEAD` | Efficiency |
| --- | --------- | ------ | ------ | ---------- |
| ⚡ | [`` test_rlfs_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlfs_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,756.6 µs | 491.2 µs | ×3.6 |
| ⚡ | [`` test_rlf_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 5.6 ms | 3.4 ms | +62.56% |
| ⚡ | [`` test_rlf_to_dict ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_dict&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,458.8 µs | 969.5 µs | +50.48% |
| ⚡ | [`` test_rlf_to_json ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_json&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 2 ms | 1.5 ms | +33.03% |

- Replace wrappers in `rlf` (claude)

|     | Benchmark | `BASE` | `HEAD` | Efficiency |
| --- | --------- | ------ | ------ | ---------- |
| ⚡ | [`` test_rlfs_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlfs_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,756.6 µs | 493.3 µs | ×3.6 |
| ⚡ | [`` test_rlf_elements_results_extraction ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_elements_results_extraction&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 5.6 ms | 2.4 ms | ×2.3 |
| ⚡ | [`` test_rlf_to_dict ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_dict&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 1,458.8 µs | 970.1 µs | +50.38% |
| ⚡ | [`` test_rlf_to_json ``](https://app.codspeed.io/RoseauTechnologies/Roseau_Load_Flow/branches/lazy-qty?uri=benchmarks%2Ftest_benchmarks.py%3A%3Atest_rlf_to_json&runnerMode=Simulation&utm_source=github&utm_medium=comment-v2&utm_content=benchmark) | 2 ms | 1.5 ms | +33.01% |
</p>
</details> 