### PR TITLE
Minor cleanups and micro-optimizations

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`466` Avoid unnecessary copies of already array inputs.
 - {gh-pr}`465` Make results access on elements between 2x and 3x faster by making the `Q_` class lazy.
 - {gh-pr}`464` Support compact JSON output with `indent=False` and improve performance by using `orjson` if installed.
 - {gh-pr}`462` Add `name` attribute to `ElectricalNetwork` to store the name of the network.

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Final, Self, final
 
@@ -317,7 +318,7 @@ class Bus(AbstractTerminal[CyBus]):
                     force
                     or self._nominal_voltage is None
                     or element._nominal_voltage is None
-                    or np.isclose(element._nominal_voltage, self._nominal_voltage)
+                    or math.isclose(element._nominal_voltage, self._nominal_voltage)
                 ):
                     msg = (
                         f"Cannot propagate the nominal voltage ({self._nominal_voltage} V) of bus {self.id!r} "
@@ -329,7 +330,7 @@ class Bus(AbstractTerminal[CyBus]):
                     force
                     or self._min_voltage_level is None
                     or element._min_voltage_level is None
-                    or np.isclose(element._min_voltage_level, self._min_voltage_level)
+                    or math.isclose(element._min_voltage_level, self._min_voltage_level)
                 ):
                     msg = (
                         f"Cannot propagate the minimum voltage level ({self._min_voltage_level}) of bus {self.id!r} "
@@ -341,7 +342,7 @@ class Bus(AbstractTerminal[CyBus]):
                     force
                     or self._max_voltage_level is None
                     or element._max_voltage_level is None
-                    or np.isclose(element._max_voltage_level, self._max_voltage_level)
+                    or math.isclose(element._max_voltage_level, self._max_voltage_level)
                 ):
                     msg = (
                         f"Cannot propagate the maximum voltage level ({self._max_voltage_level}) of bus {self.id!r} "
@@ -499,12 +500,12 @@ class Bus(AbstractTerminal[CyBus]):
             data["initial_potentials"] = [[v.real, v.imag] for v in self._initial_potentials.tolist()]
         if self.geometry is not None:
             data["geometry"] = self.geometry.__geo_interface__
-        if self.nominal_voltage is not None:
-            data["nominal_voltage"] = self.nominal_voltage.magnitude
-        if self.min_voltage_level is not None:
-            data["min_voltage_level"] = self.min_voltage_level.magnitude
-        if self.max_voltage_level is not None:
-            data["max_voltage_level"] = self.max_voltage_level.magnitude
+        if self._nominal_voltage is not None:
+            data["nominal_voltage"] = self._nominal_voltage
+        if self._min_voltage_level is not None:
+            data["min_voltage_level"] = self._min_voltage_level
+        if self._max_voltage_level is not None:
+            data["max_voltage_level"] = self._max_voltage_level
         if include_results:
             data["results"] = data.pop("results")  # move results to the end
         return data

--- a/roseau/load_flow/models/flexible_parameters.py
+++ b/roseau/load_flow/models/flexible_parameters.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, NoReturn, Self
 
@@ -126,7 +127,7 @@ class Control(JsonMixin):
         # Warn the user if a value different from 0 was given to the control for a useless value
         msg_list = []
         for name, value in useless_values.items():
-            if not np.isclose(value, 0):
+            if not math.isclose(value, 0, abs_tol=1e-8):
                 msg_list.append(f"{name!r} ({value:.1f} V)")
 
         if msg_list:

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -1,3 +1,4 @@
+import cmath
 import logging
 from typing import TYPE_CHECKING, Final, Literal, Self, final
 
@@ -260,7 +261,7 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
     def impedance(self, value: Complex | Q_[Complex]) -> None:
         self._impedance = complex(value)
         self._invalidate_network_results()
-        if np.isclose(self._impedance, 0):
+        if cmath.isclose(self._impedance, 0, abs_tol=1e-8):
             if not (self._cy_initialized and isinstance(self._cy_element, CySwitch)):
                 if self._cy_initialized:
                     self._cy_element.disconnect()

--- a/roseau/load_flow/models/line_parameters.py
+++ b/roseau/load_flow/models/line_parameters.py
@@ -1,4 +1,6 @@
+import cmath
 import logging
+import math
 import re
 import warnings
 from collections.abc import Sequence
@@ -116,13 +118,13 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         super().__init__(id)
         self._z_line: ComplexMatrix
         self._y_shunt: ComplexMatrix
-        self._z_line = np.array(z_line, dtype=np.complex128)
+        self._z_line = np.asarray(z_line, dtype=np.complex128)
         if y_shunt is None:
             self._with_shunt = False
             self._y_shunt = np.zeros_like(self._z_line, dtype=np.complex128)
         else:
             self._with_shunt = not np.allclose(y_shunt, 0)
-            self._y_shunt = np.array(y_shunt, dtype=np.complex128)
+            self._y_shunt = np.asarray(y_shunt, dtype=np.complex128)
         self._size = self._z_line.shape[0]
         self._ampacities = None
         self.ampacities = ampacities
@@ -363,7 +365,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
                 yn = bn * 1j  # Neutral shunt admittance (Siemens/km)
                 ypn = bpn * 1j  # Phase-to-neutral shunt admittance (Siemens/km)
 
-                if np.isclose(zpn, 0) and np.isclose(zn, 0):
+                if cmath.isclose(zpn, 0, abs_tol=1e-8) and cmath.isclose(zn, 0, abs_tol=1e-8):
                     warn_external(
                         f"The line model {id!r} does not have neutral elements. It will be modelled as a 3 wires line "
                         f"instead.",
@@ -377,7 +379,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
 
             # Check the validity of the resulting matrices
             det_z = nplin.det(z_line)
-            if np.isclose(abs(det_z), 0):
+            if math.isclose(abs(det_z), 0, abs_tol=1e-8):
                 if choice == 0:
                     # Warn the user that the PwF data are bad...
                     logger.warning(
@@ -1762,7 +1764,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode[f"BAD_{name.upper()}_VALUE"])
             else:
-                return np.array([value for _ in range(size)], dtype=np.float64)
+                return np.array([value] * size, dtype=np.float64)
         else:
             if np.all(value_isna):
                 return None
@@ -1775,7 +1777,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode[f"BAD_{name.upper()}_VALUE"])
 
             # Build the numpy array fails with pd.NA inside
-            values = np.array(value, dtype=np.float64)
+            values = np.asarray(value, dtype=np.float64)
             if len(value) != size:
                 msg = f"Incorrect number of {name}: {len(value)} instead of {size}."
                 logger.error(msg)

--- a/roseau/load_flow/models/loads.py
+++ b/roseau/load_flow/models/loads.py
@@ -103,8 +103,8 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
         return Q_(self._res_inner_powers_getter(warning=True), "VA")
 
     def _validate_value(self, value: ComplexScalarOrArrayLike1D) -> ComplexArray:
-        values = [value for _ in range(self._size)] if np.isscalar(value) else value
-        values = np.array(values, dtype=np.complex128)
+        values = ([value] * self._size) if np.isscalar(value) else value
+        values = np.asarray(values, dtype=np.complex128)
         if len(values) != self._size:
             msg = f"Incorrect number of {self.type}s: {len(values)} instead of {self._size}"
             logger.error(msg)

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -113,7 +113,7 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource | CyDeltaVoltageSourc
                 voltages = value * PositiveSequence
         else:
             voltages = value
-        voltages = np.array(voltages, dtype=np.complex128)
+        voltages = np.asarray(voltages, dtype=np.complex128)
         if len(voltages) != self._size:
             msg = f"Incorrect number of voltages: {len(voltages)} instead of {self._size}"
             logger.error(msg)

--- a/roseau/load_flow/models/transformer_parameters.py
+++ b/roseau/load_flow/models/transformer_parameters.py
@@ -1,3 +1,4 @@
+import cmath
 import logging
 import math
 import re
@@ -157,7 +158,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             )
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_TRANSFORMER_VOLTAGES)
-        if np.isclose(z2, 0.0):
+        if cmath.isclose(z2, 0, abs_tol=1e-8):
             msg = (
                 f"Transformer parameters {id!r} has a null series impedance z2. Ideal transformers "
                 f"are not supported yet."
@@ -834,7 +835,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
             rs = float(rs)
             if loadloss is None:
                 loadloss = rs * windings
-            elif not np.isclose(rs * windings, loadloss):
+            elif not math.isclose(rs * windings, loadloss, abs_tol=1e-8):
                 warn_external(
                     f"rs={rs} is not consistent with loadloss={loadloss} for {windings} windings. "
                     f"Only the value of loadloss will be used and rs will be ignored."
@@ -846,7 +847,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.DSS_BAD_WINDINGS)
             if loadloss is None:
                 loadloss = float(sum(rs))
-            elif not np.isclose(sum(rs), loadloss):
+            elif not math.isclose(sum(rs), loadloss, abs_tol=1e-8):
                 warn_external(
                     f"The sum of rs={rs!r} is not equal to the value of loadloss={loadloss!r}. "
                     f"Only the value of loadloss will be used and rs will be ignored."

--- a/roseau/load_flow_single/models/buses.py
+++ b/roseau/load_flow_single/models/buses.py
@@ -410,12 +410,12 @@ class Bus(AbstractTerminal[CyBus]):
             data["initial_voltage"] = [self._initial_voltage.real, self._initial_voltage.imag]
         if self.geometry is not None:
             data["geometry"] = self.geometry.__geo_interface__
-        if self.nominal_voltage is not None:
-            data["nominal_voltage"] = self.nominal_voltage.magnitude
-        if self.min_voltage_level is not None:
-            data["min_voltage_level"] = self.min_voltage_level.magnitude
-        if self.max_voltage_level is not None:
-            data["max_voltage_level"] = self.max_voltage_level.magnitude
+        if self._nominal_voltage is not None:
+            data["nominal_voltage"] = self._nominal_voltage
+        if self._min_voltage_level is not None:
+            data["min_voltage_level"] = self._min_voltage_level
+        if self._max_voltage_level is not None:
+            data["max_voltage_level"] = self._max_voltage_level
         if include_results:
             data["results"] = data.pop("results")  # move results to the end
         return data

--- a/roseau/load_flow_single/models/line_parameters.py
+++ b/roseau/load_flow_single/models/line_parameters.py
@@ -87,7 +87,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             self._with_shunt = False
         else:
             self._y_shunt = self._check_value(id=id, value=y_shunt, name="y_shunt")
-            self._with_shunt = not cmath.isclose(self._y_shunt, 0)
+            self._with_shunt = not cmath.isclose(self._y_shunt, 0, abs_tol=1e-8)
 
         # Parameters that are not used in the load flow
         self.line_type = line_type
@@ -493,7 +493,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             id=id,
             z_line=r1 + 1j * x1,
             y_shunt=1j * 2 * math.pi * basefreq * c1 * 1e-9,
-            ampacity=np.array(params["ampacities"]).item(0),  # make it scalar if needed
+            ampacity=np.asarray(params["ampacities"]).item(0),  # make it scalar if needed
             line_type=params["line_type"],
         )
 
@@ -815,7 +815,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode[f"BAD_{name.upper()}_VALUE"])
 
         # Ensure that z_line is not 0
-        if name == "z_line" and cmath.isclose(value, 0):
+        if name == "z_line" and cmath.isclose(value, 0, abs_tol=1e-8):
             msg = f"The z_line value of line type {id!r} can't be zero: {value}"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_Z_LINE_VALUE)

--- a/roseau/load_flow_single/models/loads.py
+++ b/roseau/load_flow_single/models/loads.py
@@ -272,7 +272,7 @@ class ImpedanceLoad(AbstractLoad[CyAdmittanceLoad]):
 
     def _validate_value(self, value: Complex) -> complex:
         # A load cannot have a zero impedance
-        if cmath.isclose(value, 0):
+        if cmath.isclose(value, 0, abs_tol=1e-8):
             msg = f"The impedance of the load {self.id!r} is null"
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_Z_VALUE)


### PR DESCRIPTION
I had claude audit the code to make some improvements

----------------------
- Replace scalar np.isclose with math.isclose/cmath.isclose (with abs_tol=1e-8 for zero checks to preserve np.isclose default behavior)
- Use np.asarray instead of np.array to avoid copying already-array inputs
- Access private float attributes directly in _to_dict instead of constructing Q_ objects just to read back .magnitude