### PR TITLE
Avoid unnecessary copies when deserializing networks

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`467` Avoid unnecessary copies when deserializing networks from JSON or dict and remove `from_dict` methods
+  from element classes, these methods did not work correctly because they depend on other elements.
 - {gh-pr}`466` Avoid unnecessary copies of already array inputs.
 - {gh-pr}`465` Make results access on elements between 2x and 3x faster by making the `Q_` class lazy.
 - {gh-pr}`464` Support compact JSON output with `indent=False` and improve performance by using `orjson` if installed.

--- a/roseau/load_flow/io/dict.py
+++ b/roseau/load_flow/io/dict.py
@@ -6,7 +6,6 @@ from and to dictionaries, or the methods `ElectricalNetwork.from_json` and `Elec
 to read and write networks from and to JSON files.
 """
 
-import copy
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Final
@@ -63,8 +62,6 @@ def network_from_dict(  # noqa: C901
         connections to construct the electrical network and a boolean indicating if the network has
         results.
     """
-    data = copy.deepcopy(data)  # Make a copy to avoid modifying the original
-
     version = data.get("version", 0)
     if version <= 4:
         warn_external(
@@ -103,36 +100,36 @@ def network_from_dict(  # noqa: C901
 
     # Lines and transformers parameters
     lines_params = {
-        lp["id"]: LineParameters.from_dict(data=lp, include_results=include_results) for lp in data["lines_params"]
+        lp["id"]: LineParameters._from_dict(data=lp, include_results=include_results) for lp in data["lines_params"]
     }
     transformers_params = {
-        tp["id"]: TransformerParameters.from_dict(data=tp, include_results=include_results)
+        tp["id"]: TransformerParameters._from_dict(data=tp, include_results=include_results)
         for tp in data["transformers_params"]
     }
 
     # Grounds
     grounds: dict[Id, Ground] = {}
     for ground_data in data["grounds"]:
-        ground = Ground.from_dict(data=ground_data, include_results=include_results)
+        ground = Ground._from_dict(data=ground_data, include_results=include_results)
         grounds[ground.id] = ground
         has_results = has_results and not ground._no_results
 
     # Buses, loads and sources
     buses: dict[Id, Bus] = {}
     for bus_data in data["buses"]:
-        bus = Bus.from_dict(data=bus_data, include_results=include_results)
+        bus = Bus._from_dict(data=bus_data, include_results=include_results)
         buses[bus.id] = bus
         has_results = has_results and not bus._no_results
     loads: dict[Id, Load] = {}
     for load_data in data["loads"]:
         load_data["bus"] = buses[load_data["bus"]]
-        load = AbstractLoad.from_dict(data=load_data, include_results=include_results)
+        load = AbstractLoad._from_dict(data=load_data, include_results=include_results)
         loads[load.id] = load
         has_results = has_results and not load._no_results
     sources: dict[Id, VoltageSource] = {}
     for source_data in data["sources"]:
         source_data["bus"] = buses[source_data["bus"]]
-        source = VoltageSource.from_dict(data=source_data, include_results=include_results)
+        source = VoltageSource._from_dict(data=source_data, include_results=include_results)
         sources[source.id] = source
         has_results = has_results and not source._no_results
 
@@ -147,7 +144,7 @@ def network_from_dict(  # noqa: C901
             msg = f"Potential reference data {pref_data['id']} missing bus or ground."
             logger.error(msg)
             raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.JSON_PREF_INVALID)
-        p_ref = PotentialRef.from_dict(data=pref_data, include_results=include_results)
+        p_ref = PotentialRef._from_dict(data=pref_data, include_results=include_results)
         potential_refs[p_ref.id] = p_ref
         has_results = has_results and not p_ref._no_results
 
@@ -159,7 +156,7 @@ def network_from_dict(  # noqa: C901
         line_data["parameters"] = lines_params[line_data.pop("params_id")]
         if (ground_id := line_data.pop("ground", None)) is not None:
             line_data["ground"] = grounds[ground_id]
-        line = Line.from_dict(data=line_data, include_results=include_results)
+        line = Line._from_dict(data=line_data, include_results=include_results)
         lines[line.id] = line
         has_results = has_results and not line._no_results
 
@@ -169,7 +166,7 @@ def network_from_dict(  # noqa: C901
         transformer_data["bus_hv"] = buses[transformer_data["bus_hv"]]
         transformer_data["bus_lv"] = buses[transformer_data["bus_lv"]]
         transformer_data["parameters"] = transformers_params[transformer_data.pop("params_id")]
-        transformer = Transformer.from_dict(data=transformer_data, include_results=include_results)
+        transformer = Transformer._from_dict(data=transformer_data, include_results=include_results)
         transformers[transformer.id] = transformer
         has_results = has_results and not transformer._no_results
 
@@ -178,7 +175,7 @@ def network_from_dict(  # noqa: C901
     for switch_data in data["switches"]:
         switch_data["bus1"] = buses[switch_data["bus1"]]
         switch_data["bus2"] = buses[switch_data["bus2"]]
-        switch = Switch.from_dict(data=switch_data, include_results=include_results)
+        switch = Switch._from_dict(data=switch_data, include_results=include_results)
         switches[switch.id] = switch
         has_results = has_results and not switch._no_results
 
@@ -203,7 +200,7 @@ def network_from_dict(  # noqa: C901
                 gc_data["element"] = getattr(switches[element["id"]], f"side{SIDE_SUFFIX[side]}")
             case what:
                 raise AssertionError(f"Unknown element type {what!r} for ground connection {gc_data['id']!r}.")
-        gc = GroundConnection.from_dict(data=gc_data, include_results=include_results)
+        gc = GroundConnection._from_dict(data=gc_data, include_results=include_results)
         ground_connections[gc.id] = gc
         has_results = has_results and not gc._no_results
 

--- a/roseau/load_flow/models/branches.py
+++ b/roseau/load_flow/models/branches.py
@@ -72,10 +72,6 @@ class AbstractBranchSide(AbstractConnectable[_CyB_co]):
     def __repr__(self) -> str:
         return f"<{type(self).__name__}: branch={self._branch.id!r}, side={self._side_value}, phases={self._phases!r}>"
 
-    @classmethod
-    def from_dict(cls, data, *, include_results=True) -> Self:
-        raise NotImplementedError("Cannot create a branch side from a dict.")
-
     def _connect(self, *elements) -> None:
         # Connections are done in the branch
         pass
@@ -269,7 +265,7 @@ class AbstractBranch(Element[_CyB_co], Generic[_Side_co, _CyB_co]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         data["geometry"] = cls._parse_geometry(data.pop("geometry", None))
         results = data.pop("results", None)
         self = cls(**data)

--- a/roseau/load_flow/models/buses.py
+++ b/roseau/load_flow/models/buses.py
@@ -479,7 +479,7 @@ class Bus(AbstractTerminal[CyBus]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         if (initial_potentials := data.get("initial_potentials")) is not None:
             initial_potentials = [complex(*v) for v in initial_potentials]
         self = cls(

--- a/roseau/load_flow/models/flexible_parameters.py
+++ b/roseau/load_flow/models/flexible_parameters.py
@@ -361,7 +361,7 @@ class Control(JsonMixin):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         alpha = data.get("alpha", cls._DEFAULT_ALPHA)
         epsilon = data.get("epsilon", cls._DEFAULT_EPSILON)
         if data["type"] == "constant":
@@ -499,7 +499,7 @@ class Projection(JsonMixin):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         alpha = data.get("alpha", cls._DEFAULT_ALPHA)
         epsilon = data.get("epsilon", cls._DEFAULT_EPSILON)
         return cls(type=data["type"], alpha=alpha, epsilon=epsilon)
@@ -1074,10 +1074,10 @@ class FlexibleParameter(JsonMixin):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
-        control_p = Control.from_dict(data=data["control_p"], include_results=include_results)
-        control_q = Control.from_dict(data=data["control_q"], include_results=include_results)
-        projection = Projection.from_dict(data=data["projection"], include_results=include_results)
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+        control_p = Control._from_dict(data=data["control_p"], include_results=include_results)
+        control_q = Control._from_dict(data=data["control_q"], include_results=include_results)
+        projection = Projection._from_dict(data=data["projection"], include_results=include_results)
         q_min = data.get("q_min", None)
         q_max = data.get("q_max", None)
         return cls(

--- a/roseau/load_flow/models/grounds.py
+++ b/roseau/load_flow/models/grounds.py
@@ -101,7 +101,7 @@ class Ground(Element[CyGround]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         results = data.pop("results", None)
         self = cls(**data)
         if include_results and results:
@@ -330,7 +330,7 @@ class GroundConnection(Element[CySimplifiedLine | CySwitch]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         results = data.pop("results", None)
         data["impedance"] = complex(*data.pop("impedance"))
         self = cls(**data)

--- a/roseau/load_flow/models/line_parameters.py
+++ b/roseau/load_flow/models/line_parameters.py
@@ -1618,7 +1618,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         """Line parameters constructor from dict.
 
         Args:

--- a/roseau/load_flow/models/lines.py
+++ b/roseau/load_flow/models/lines.py
@@ -369,9 +369,9 @@ class Line(AbstractBranch["LineSide", CyShuntLine | CySimplifiedLine]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         results = data.get("results", None)
-        self = super().from_dict(data, include_results=include_results)
+        self = super()._from_dict(data, include_results=include_results)
         if include_results and results and self.with_shunt:
             self._res_ground_potential = complex(*results["ground_potential"])
         return self

--- a/roseau/load_flow/models/loads.py
+++ b/roseau/load_flow/models/loads.py
@@ -133,12 +133,12 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
                 )
 
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "Load":
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "Load":
         load_type = data["type"]
         if load_type == "power":
             if (fp_data_list := data.get("flexible_params")) is not None:
                 fp = [
-                    FlexibleParameter.from_dict(data=fp_dict, include_results=include_results)
+                    FlexibleParameter._from_dict(data=fp_dict, include_results=include_results)
                     for fp_dict in fp_data_list
                 ]
             else:

--- a/roseau/load_flow/models/potential_refs.py
+++ b/roseau/load_flow/models/potential_refs.py
@@ -130,7 +130,7 @@ class PotentialRef(Element[CyPotentialRef | CyDeltaPotentialRef]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         self = cls(id=data["id"], element=data["element"], phases=data.get("phases"))
         if include_results and "results" in data:
             self._res_current = complex(*data["results"]["current"])

--- a/roseau/load_flow/models/sources.py
+++ b/roseau/load_flow/models/sources.py
@@ -127,7 +127,7 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource | CyDeltaVoltageSourc
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         self = cls(
             id=data["id"],
             bus=data["bus"],

--- a/roseau/load_flow/models/tests/test_buses.py
+++ b/roseau/load_flow/models/tests/test_buses.py
@@ -637,6 +637,6 @@ def test_to_from_dict_roundtrip():
         initial_potentials=[230 + 0j, 0j],
     )
     bus_dict = bus.to_dict(include_results=False)
-    bus2 = Bus.from_dict(bus_dict)
+    bus2 = Bus._from_dict(bus_dict)
     bus2_dict = bus2.to_dict(include_results=False)
     assert_json_close(bus_dict, bus2_dict)

--- a/roseau/load_flow/models/tests/test_loads.py
+++ b/roseau/load_flow/models/tests/test_loads.py
@@ -399,7 +399,7 @@ def test_loads_to_dict():
     flex_load = PowerLoad(id="load_f1", bus=bus, phases="abcn", powers=values, flexible_params=fp)
     assert flex_load.flexible_params is not None
     assert_json_close(flex_load.to_dict(include_results=False), expected_dict)
-    parsed_flex_load = PowerLoad.from_dict(expected_dict | {"bus": Bus(id="bus", phases="abcn")})
+    parsed_flex_load = PowerLoad._from_dict(expected_dict | {"bus": Bus(id="bus", phases="abcn")})
     assert isinstance(parsed_flex_load, PowerLoad)
     assert parsed_flex_load.id == flex_load.id
     assert parsed_flex_load.bus.id == flex_load.bus.id

--- a/roseau/load_flow/models/tests/test_switches.py
+++ b/roseau/load_flow/models/tests/test_switches.py
@@ -81,7 +81,7 @@ def test_switch_dict_roundtrip():
     sw_dict = sw.to_dict(include_results=True)
     sw_dict["bus1"] = bus1
     sw_dict["bus2"] = bus2
-    sw2 = Switch.from_dict(sw_dict, include_results=True)
+    sw2 = Switch._from_dict(sw_dict, include_results=True)
     assert sw2.id == sw.id
     assert sw2.bus1.id == sw.bus1.id
     assert sw2.bus2.id == sw.bus2.id

--- a/roseau/load_flow/models/transformer_parameters.py
+++ b/roseau/load_flow/models/transformer_parameters.py
@@ -1059,7 +1059,7 @@ class TransformerParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         if "p0" in data:
             # TODO should we validate z2 and ym if they exist?
             return cls.from_open_and_short_circuit_tests(

--- a/roseau/load_flow/network.py
+++ b/roseau/load_flow/network.py
@@ -1254,7 +1254,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     # Network saving/loading
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         """Construct an electrical network from a dict created with :meth:`to_dict`.
 
         Args:

--- a/roseau/load_flow/utils/mixins.py
+++ b/roseau/load_flow/utils/mixins.py
@@ -5,6 +5,7 @@ import textwrap
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
+from copy import deepcopy
 from heapq import heappop, heappush
 from importlib import resources
 from pathlib import Path
@@ -88,61 +89,11 @@ class Identifiable(RLFObject, metaclass=ABCMeta):
         return f"{type(self).__name__}(id={self.id!r})"
 
 
-class JsonMixin(metaclass=ABCMeta):
-    """Mixin for classes that can be serialized to and from JSON."""
+class ToJsonMixin(metaclass=ABCMeta):
+    """Mixin for classes that can be serialized to JSON."""
 
     _no_results = True
     _results_valid = False
-
-    @classmethod
-    @abstractmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
-        """Create an element from a dictionary created with :meth:`to_dict`.
-
-        Note:
-            This method does not work on all classes that define it as some of them require
-            additional information to be constructed. It can only be safely used on the
-            `ElectricNetwork`, `LineParameters` and `TransformerParameters` classes.
-
-        Args:
-            data:
-                The dictionary containing the element's data.
-
-            include_results:
-                If True (default) and the results of the load flow are included in the dictionary,
-                the results are also loaded into the element.
-
-        Returns:
-            The constructed element.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    def from_json(cls, path: StrPath, *, include_results: bool = True) -> Self:
-        """Construct an element from a JSON file created with :meth:`to_json`.
-
-        Note:
-            This method does not work on all classes that define it as some of them require
-            additional information to be constructed. It can only be safely used on the
-            `ElectricNetwork`, `LineParameters` and `TransformerParameters` classes.
-
-        Args:
-            path:
-                The path to the network data file.
-
-            include_results:
-                If True (default) and the results of the load flow are included in the file,
-                the results are also loaded into the element.
-
-        Returns:
-            The constructed element.
-        """
-        if orjson is not None:
-            data = orjson.loads(Path(path).read_bytes())
-        else:
-            with open(path, "rb") as fp:
-                data = json.load(fp)
-        return cls.from_dict(data=data, include_results=include_results)
 
     @abstractmethod
     def _to_dict(self, include_results: bool) -> JsonDict:
@@ -275,6 +226,61 @@ class JsonMixin(metaclass=ABCMeta):
         return _json_dump(dict_results, path=path, indent=indent)
 
 
+class JsonMixin(ToJsonMixin):
+    """Mixin for classes that can be serialized to and from JSON."""
+
+    @classmethod
+    @abstractmethod
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+        raise NotImplementedError
+
+    @classmethod
+    def from_dict(cls, data: JsonDict, *, include_results: bool = True, copy: bool = True) -> Self:
+        """Create an instance from a dictionary created with :meth:`to_dict`.
+
+        Args:
+            data:
+                The dictionary containing the data.
+
+            include_results:
+                If True (default) and the results of the load flow are included in the dictionary,
+                the results are also loaded.
+
+            copy:
+                If True (default), the input dictionary is deep-copied before processing so the
+                original is never modified. Pass ``False`` when the dictionary is a throwaway (e.g.
+                freshly parsed from JSON) to avoid the copy overhead.
+
+        Returns:
+            The constructed instance.
+        """
+        if copy:
+            data = deepcopy(data)
+        return cls._from_dict(data=data, include_results=include_results)
+
+    @classmethod
+    def from_json(cls, path: StrPath, *, include_results: bool = True) -> Self:
+        """Construct an instance from a JSON file created with :meth:`to_json`.
+
+        Args:
+            path:
+                The path to the data file.
+
+            include_results:
+                If True (default) and the results of the load flow are included in the file,
+                the results are also loaded.
+
+        Returns:
+            The constructed instance.
+        """
+        if orjson is not None:
+            data = orjson.loads(Path(path).read_bytes())
+        else:
+            with open(path, "rb") as fp:
+                data = json.load(fp)
+        return cls._from_dict(data=data, include_results=include_results)
+
+
 class CatalogueMixin[T](metaclass=ABCMeta):
     """A mixin class for objects which can be built from a catalogue. It adds the `from_catalogue` class method."""
 
@@ -401,7 +407,7 @@ class CatalogueMixin[T](metaclass=ABCMeta):
 
 
 @abstractattrs("element_type")
-class AbstractElement(Identifiable, JsonMixin, Generic[_N_co, _CyE_co]):
+class AbstractElement(Identifiable, ToJsonMixin, Generic[_N_co, _CyE_co]):
     """An abstract class of an element in an Electrical network."""
 
     element_type: ClassVar[str]

--- a/roseau/load_flow_single/io/dict.py
+++ b/roseau/load_flow_single/io/dict.py
@@ -6,7 +6,6 @@ from and to dictionaries, or the methods `ElectricalNetwork.from_json` and `Elec
 to read and write networks from and to JSON files.
 """
 
-import copy
 import logging
 from typing import TYPE_CHECKING
 
@@ -52,8 +51,6 @@ def network_from_dict(
         The buses, lines, transformers, switches, loads, and sources to construct the electrical
         network and a boolean indicating if the network has results.
     """
-    data = copy.deepcopy(data)  # Make a copy to avoid modifying the original
-
     # Check that the network is single phase with a clear error message
     is_multiphase = data.get("is_multiphase", True)
     if is_multiphase:
@@ -94,29 +91,29 @@ def network_from_dict(
 
     # Lines and transformers parameters
     lines_params = {
-        lp["id"]: LineParameters.from_dict(data=lp, include_results=include_results) for lp in data["lines_params"]
+        lp["id"]: LineParameters._from_dict(data=lp, include_results=include_results) for lp in data["lines_params"]
     }
     transformers_params = {
-        tp["id"]: TransformerParameters.from_dict(data=tp, include_results=include_results)
+        tp["id"]: TransformerParameters._from_dict(data=tp, include_results=include_results)
         for tp in data["transformers_params"]
     }
 
     # Buses, loads and sources
     buses: dict[Id, Bus] = {}
     for bus_data in data["buses"]:
-        bus = Bus.from_dict(data=bus_data, include_results=include_results)
+        bus = Bus._from_dict(data=bus_data, include_results=include_results)
         buses[bus.id] = bus
         has_results = has_results and not bus._no_results
     loads: dict[Id, Load] = {}
     for load_data in data["loads"]:
         load_data["bus"] = buses[load_data["bus"]]
-        load = AbstractLoad.from_dict(data=load_data, include_results=include_results)
+        load = AbstractLoad._from_dict(data=load_data, include_results=include_results)
         loads[load.id] = load
         has_results = has_results and not load._no_results
     sources: dict[Id, VoltageSource] = {}
     for source_data in data["sources"]:
         source_data["bus"] = buses[source_data["bus"]]
-        source = VoltageSource.from_dict(data=source_data, include_results=include_results)
+        source = VoltageSource._from_dict(data=source_data, include_results=include_results)
         sources[source.id] = source
         has_results = has_results and not source._no_results
 
@@ -126,7 +123,7 @@ def network_from_dict(
         line_data["bus1"] = buses[line_data["bus1"]]
         line_data["bus2"] = buses[line_data["bus2"]]
         line_data["parameters"] = lines_params[line_data.pop("params_id")]
-        line = Line.from_dict(data=line_data, include_results=include_results)
+        line = Line._from_dict(data=line_data, include_results=include_results)
         lines[line.id] = line
         has_results = has_results and not line._no_results
 
@@ -136,7 +133,7 @@ def network_from_dict(
         transformer_data["bus_hv"] = buses[transformer_data["bus_hv"]]
         transformer_data["bus_lv"] = buses[transformer_data["bus_lv"]]
         transformer_data["parameters"] = transformers_params[transformer_data.pop("params_id")]
-        transformer = Transformer.from_dict(data=transformer_data, include_results=include_results)
+        transformer = Transformer._from_dict(data=transformer_data, include_results=include_results)
         transformers[transformer.id] = transformer
         has_results = has_results and not transformer._no_results
 
@@ -145,7 +142,7 @@ def network_from_dict(
     for switch_data in data["switches"]:
         switch_data["bus1"] = buses[switch_data["bus1"]]
         switch_data["bus2"] = buses[switch_data["bus2"]]
-        switch = Switch.from_dict(data=switch_data, include_results=include_results)
+        switch = Switch._from_dict(data=switch_data, include_results=include_results)
         switches[switch.id] = switch
         has_results = has_results and not switch._no_results
 

--- a/roseau/load_flow_single/models/branches.py
+++ b/roseau/load_flow_single/models/branches.py
@@ -49,10 +49,6 @@ class AbstractBranchSide(AbstractConnectable[_CyB_co]):
     def __repr__(self) -> str:
         return f"<{type(self).__name__}: branch={self._branch.id!r}, side={self._side_value}>"
 
-    @classmethod
-    def from_dict(cls, data, *, include_results=True) -> Self:
-        raise NotImplementedError("Cannot create a branch side from a dict.")
-
     def _connect(self, *elements) -> None:
         # Connections are done in the branch
         pass
@@ -190,7 +186,7 @@ class AbstractBranch(Element[_CyB_co], Generic[_Side_co, _CyB_co]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         data["geometry"] = cls._parse_geometry(data.pop("geometry", None))
         results = data.pop("results", None)
         self = cls(**data)

--- a/roseau/load_flow_single/models/buses.py
+++ b/roseau/load_flow_single/models/buses.py
@@ -390,7 +390,7 @@ class Bus(AbstractTerminal[CyBus]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         if (initial_voltage := data.get("initial_voltage")) is not None:
             initial_voltage = complex(initial_voltage[0], initial_voltage[1])
         self = cls(

--- a/roseau/load_flow_single/models/line_parameters.py
+++ b/roseau/load_flow_single/models/line_parameters.py
@@ -753,7 +753,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         """Line parameters constructor from dict.
 
         Args:

--- a/roseau/load_flow_single/models/loads.py
+++ b/roseau/load_flow_single/models/loads.py
@@ -49,12 +49,12 @@ class AbstractLoad(AbstractDisconnectable[_CyL_co], ABC):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "Load":
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> "Load":
         load_type = data["type"]
         if load_type == "power":
             power = complex(data["power"][0], data["power"][1])
             if (fp_data := data.get("flexible_param")) is not None:
-                fp = FlexibleParameter.from_dict(data=fp_data, include_results=include_results)
+                fp = FlexibleParameter._from_dict(data=fp_data, include_results=include_results)
             else:
                 fp = None
             self = PowerLoad(id=data["id"], bus=data["bus"], power=power, flexible_param=fp)

--- a/roseau/load_flow_single/models/sources.py
+++ b/roseau/load_flow_single/models/sources.py
@@ -63,7 +63,7 @@ class VoltageSource(AbstractDisconnectable[CyVoltageSource]):
     # Json Mixin interface
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         self = cls(id=data["id"], bus=data["bus"], voltage=complex(*data["voltage"]))
         self._parse_results_from_dict(data, include_results=include_results)
         return self

--- a/roseau/load_flow_single/models/tests/test_loads.py
+++ b/roseau/load_flow_single/models/tests/test_loads.py
@@ -138,7 +138,7 @@ def test_loads_to_dict():
     flex_load = PowerLoad(id="load_f1", bus=bus, power=value, flexible_param=fp)
     assert flex_load.flexible_param is not None
     assert_json_close(flex_load.to_dict(include_results=False), expected_dict)
-    parsed_flex_load = PowerLoad.from_dict(expected_dict | {"bus": Bus(id="bus")})
+    parsed_flex_load = PowerLoad._from_dict(expected_dict | {"bus": Bus(id="bus")})
     assert isinstance(parsed_flex_load, PowerLoad)
     assert parsed_flex_load.id == flex_load.id
     assert parsed_flex_load.bus.id == flex_load.bus.id

--- a/roseau/load_flow_single/models/tests/test_switches.py
+++ b/roseau/load_flow_single/models/tests/test_switches.py
@@ -95,7 +95,7 @@ def test_switch_dict_roundtrip():
     sw_dict = sw.to_dict(include_results=True)
     sw_dict["bus1"] = bus1
     sw_dict["bus2"] = bus2
-    sw2 = Switch.from_dict(sw_dict, include_results=True)
+    sw2 = Switch._from_dict(sw_dict, include_results=True)
     assert sw2.id == sw.id
     assert sw2.bus1.id == sw.bus1.id
     assert sw2.bus2.id == sw.bus2.id

--- a/roseau/load_flow_single/network.py
+++ b/roseau/load_flow_single/network.py
@@ -692,7 +692,7 @@ class ElectricalNetwork(AbstractNetwork[Element]):
     # Data exchange
     #
     @classmethod
-    def from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
+    def _from_dict(cls, data: JsonDict, *, include_results: bool = True) -> Self:
         """Construct an electrical network from a dict created with :meth:`to_dict`.
 
         Args:


### PR DESCRIPTION
- Split `JsonMixin` into `ToJsonMixin` (to_* methods only) and `JsonMixin(ToJsonMixin)` (adds from_dict/from_json)
- Elements now inherit from `ToJsonMixin` instead of `JsonMixin`; Their `from_dict` and `to_dict` never round-tripped because `from_dict` depends on other elements
- `JsonMixin.from_dict` gains a `copy=True` parameter: only deepcopies the input dict when True (public-API safety), skips copy when False.
- `JsonMixin.from_json` calls `from_dict(copy=False)` — the JSON path never copies since the parsed dict is already a fresh throwaway.