### PR TITLE
Add a weighted merit function to the newton_goldstein solver

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,13 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 # Changelog
 
+## Unreleased
+
+- {gh-pr}`489` Improve the `newton_goldstein` solver's line search using an experimental weighted merit function that
+  normalizes the residuals of the different equations to avoid favoring one equation over the others. There are no known
+  scenarios where it worsens convergence, but as an experimental feature, it may be disabled using
+  `en.solve_load_flow(solver="newton_goldstein", solver_params={"weighted_merit": False})`.
+
 ## Version 0.16.0a1
 
 - {gh-pr}`484` Disallow buses from having both a short-circuit and a voltage source similar to the restriction for power

--- a/doc/advanced/Solvers.md
+++ b/doc/advanced/Solvers.md
@@ -137,6 +137,28 @@ The _Goldstein and Price_ solver accepts the following parameters:
 - `"m1"` the first constant of the _Goldstein and Price_ variant. By default: `0.1`.
 - `"m2"` the second constant of the _Goldstein and Price_ variant. By default: `0.9`. Note that the constraint
   $m_1 < m_2$ must be met.
+- `"weighted_merit"` whether to scale the residuals before applying the search criterion above. By default: `True`. See
+  [below](#weighted-merit-function).
+
+### Weighted merit function
+
+The criterion {eq}`goldstein_and_price` compares residuals against each other, but the entries of $F$ are not all on the
+same scale. How large a residual gets for a given error depends on the equation it comes from: a bus fed through a very
+low impedance produces a current mismatch orders of magnitude above one at the end of a long, weakly connected feeder,
+and a load under a steep voltage-dependent control law produces a larger one still. Measured by the raw norm $||F||_2$,
+the small-scale equations are nearly invisible: the line search can accept a step that quietly wrecks one of them as
+long as the large-scale equations improve.
+
+When `weighted_merit` is enabled (default), each residual is divided by $\max(1, ||J_i||_\infty)$, the infinity norm of
+its own Jacobian row, before the norm is taken:
+
+```{math}
+g(x) := \frac{1}{2} ||W F(x)||_2 \qquad W = \mathrm{diag}\left(\frac{1}{\max(1, ||J_i||_\infty)}\right)
+```
+
+The weights are recomputed from the current Jacobian at every iteration. This changes **only** which candidate $t$ is
+accepted; the convergence check against `tolerance` and the residual returned by `solve_load_flow` both stay on the raw,
+physical residuals.
 
 ## Backward-Forward
 

--- a/roseau/load_flow/_solvers.py
+++ b/roseau/load_flow/_solvers.py
@@ -8,7 +8,7 @@ from typing_extensions import TypeVar
 
 from roseau.load_flow.exceptions import RoseauLoadFlowException, RoseauLoadFlowExceptionCode
 from roseau.load_flow.license import activate_license, get_license
-from roseau.load_flow.typing import FloatArray, FloatArrayLike1D, FloatMatrix, JsonDict, Solver
+from roseau.load_flow.typing import FloatArray, FloatArrayLike1D, FloatMatrix, JsonDict
 from roseau.load_flow.utils import warn_external
 from roseau.load_flow_engine.cy_engine import (
     CyAbstractNewton,
@@ -19,13 +19,6 @@ from roseau.load_flow_engine.cy_engine import (
 )
 
 logger = logging.getLogger(__name__)
-
-_SOLVERS_PARAMS: dict[Solver, list[str]] = {
-    "newton": [],
-    "newton_goldstein": ["m1", "m2"],
-    "backward_forward": [],
-}
-SOLVERS = list(_SOLVERS_PARAMS)
 
 if TYPE_CHECKING:
     from roseau.load_flow.utils import AbstractElement, AbstractNetwork
@@ -70,7 +63,8 @@ class AbstractSolver(ABC, Generic[_CyS_co]):
         elif data["name"] == "newton_goldstein":
             m1 = data["params"].get("m1", NewtonGoldstein.DEFAULT_M1)
             m2 = data["params"].get("m2", NewtonGoldstein.DEFAULT_M2)
-            return NewtonGoldstein(network=network, m1=m1, m2=m2)
+            weighted_merit = data["params"].get("weighted_merit", NewtonGoldstein.DEFAULT_WEIGHTED_MERIT)
+            return NewtonGoldstein(network=network, m1=m1, m2=m2, weighted_merit=weighted_merit)
         elif data["name"] == "backward_forward":
             return BackwardForward(network=network)
         else:
@@ -294,6 +288,7 @@ class NewtonGoldstein(AbstractNewton[CyNewtonGoldstein]):
 
     DEFAULT_M1 = 0.1
     DEFAULT_M2 = 0.9
+    DEFAULT_WEIGHTED_MERIT: bool = True
 
     def __init__(
         self,
@@ -301,6 +296,7 @@ class NewtonGoldstein(AbstractNewton[CyNewtonGoldstein]):
         m1: float = DEFAULT_M1,
         m2: float = DEFAULT_M2,
         optimize_tape: bool = AbstractNewton.DEFAULT_TAPE_OPTIMIZATION,
+        weighted_merit: bool = DEFAULT_WEIGHTED_MERIT,
     ) -> None:
         """NewtonGoldstein constructor.
 
@@ -317,33 +313,53 @@ class NewtonGoldstein(AbstractNewton[CyNewtonGoldstein]):
 
             m2:
                 The second constant of the Goldstein and Price linear search.
+
+            weighted_merit:
+                If True, the linear search weights each residual by 1 / max(1, its Jacobian row's
+                infinity norm) before computing the merit function it accepts or rejects a step on.
         """
         super().__init__(network=network, optimize_tape=optimize_tape)
-        if m1 >= m2:
-            msg = "For the 'newton_goldstein' solver, the inequality m1 < m2 should be respected."
-            logger.error(msg)
-            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_SOLVER_PARAMS)
+        self._check_m1_m2(m1, m2)
         self.m1 = m1
         self.m2 = m2
+        self.weighted_merit = weighted_merit
         self._cy_solver = CyNewtonGoldstein(
-            network=network._cy_electrical_network, optimize_tape=optimize_tape, m1=m1, m2=m2
+            network=network._cy_electrical_network,
+            optimize_tape=optimize_tape,
+            m1=m1,
+            m2=m2,
+            weighted_merit=weighted_merit,
         )
 
     def update_network(self, network: "ElectricalNetwork") -> None:
         self._cy_solver = CyNewtonGoldstein(
-            network=network._cy_electrical_network, optimize_tape=self.optimize_tape, m1=self.m1, m2=self.m2
+            network=network._cy_electrical_network,
+            optimize_tape=self.optimize_tape,
+            m1=self.m1,
+            m2=self.m2,
+            weighted_merit=self.weighted_merit,
         )
+
+    @staticmethod
+    def _check_m1_m2(m1: float, m2: float) -> None:
+        if m1 >= m2:
+            msg = "For the 'newton_goldstein' solver, the inequality m1 < m2 should be respected."
+            logger.error(msg)
+            raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_SOLVER_PARAMS)
 
     def update_params(self, params: JsonDict) -> None:
         m1 = params.get("m1", NewtonGoldstein.DEFAULT_M1)
         m2 = params.get("m2", NewtonGoldstein.DEFAULT_M2)
-        if m1 != self.m1 or m2 != self.m2:
-            self._cy_solver.update_params(m1=m1, m2=m2)
+        weighted_merit = params.get("weighted_merit", NewtonGoldstein.DEFAULT_WEIGHTED_MERIT)
+        if m1 != self.m1 or m2 != self.m2 or weighted_merit != self.weighted_merit:
+            self._check_m1_m2(m1, m2)
+            self._cy_solver.update_params(m1=m1, m2=m2, weighted_merit=weighted_merit)
             self.m1 = m1
             self.m2 = m2
+            self.weighted_merit = weighted_merit
 
     def params(self) -> JsonDict:
-        return {"m1": self.m1, "m2": self.m2}
+        return {"m1": self.m1, "m2": self.m2, "weighted_merit": self.weighted_merit}
 
 
 class BackwardForward(AbstractSolver[CyBackwardForward]):

--- a/roseau/load_flow/tests/test_solvers.py
+++ b/roseau/load_flow/tests/test_solvers.py
@@ -42,10 +42,17 @@ def test_solver():
     assert e.value.code == RoseauLoadFlowExceptionCode.BAD_SOLVER_PARAMS
 
     # Good ones
-    data = {"name": "newton_goldstein", "params": {"m1": 0.1, "m2": 0.9}}
+    data = {"name": "newton_goldstein", "params": {"m1": 0.1, "m2": 0.9, "weighted_merit": True}}
     solver = AbstractSolver.from_dict(data=data, network=en)
     data2 = solver.to_dict()
     assert data == data2
+
+    # A non-default weighted_merit survives the round trip
+    data = {"name": "newton_goldstein", "params": {"m1": 0.1, "m2": 0.9, "weighted_merit": False}}
+    solver = AbstractSolver.from_dict(data=data, network=en)
+    assert isinstance(solver, NewtonGoldstein)
+    assert solver.weighted_merit is False
+    assert solver.to_dict() == data
 
     data = {"name": "newton", "params": {}}
     solver = AbstractSolver.from_dict(data=data, network=en)


### PR DESCRIPTION
The line search of the `newton_goldstein` solver now accepts/rejects a candidate step by a residual norm weighted `1/max(1, row's Jacobian infinity norm)`, so equations at very different natural scales are compared fairly.