### PR TITLE
Fix `backward_forward` silently swallowing `nan` values instead of raising an error

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,7 +21,7 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
-- {gh-pr}`490` Fix the `backward_forward` silently swallowing `nan` values instead of raising an error.
+- {gh-pr}`490` Fix the `backward_forward` solver silently swallowing `nan` values instead of raising an error.
 
 ## Version 0.16.0a1
 

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 # Changelog
 
+## Unreleased
+
+- {gh-pr}`490` Fix the `backward_forward` silently swallowing `nan` values instead of raising an error.
+
 ## Version 0.16.0a1
 
 - {gh-pr}`484` Disallow buses from having both a short-circuit and a voltage source similar to the restriction for power

--- a/roseau/load_flow/_solvers.py
+++ b/roseau/load_flow/_solvers.py
@@ -382,4 +382,21 @@ class BackwardForward(AbstractSolver[CyBackwardForward]):
 
     def _parse_solver_error(self, code: int, msg: str) -> tuple[str, RoseauLoadFlowExceptionCode]:
         assert code == 2, f"Unexpected error code {code} for a Backward-Forward solver."
+        if "NaN value encountered" in msg:
+            # Check that at least one power/flexible load is present in the network, to give a more
+            # precise error message. This is less accurate than the Newton solver that knows exactly
+            # which element is causing the problem, but it is better than nothing.
+            power_load = False
+            flexible_load = False
+            for load in self.network._elements_by_type["load"].values():
+                if load.element_type == "load" and load.type == "power":  # type: ignore
+                    power_load = True
+                    if load.is_flexible:  # type: ignore
+                        flexible_load = True
+                        break
+            if power_load:
+                msg += " This might be caused by a bad potential initialization of a power load"
+            if flexible_load:
+                msg += ", or by flexible loads with very high alpha or incorrect flexible parameters voltages."
+            return msg, RoseauLoadFlowExceptionCode.NAN_VALUE
         return msg, RoseauLoadFlowExceptionCode.NO_BACKWARD_FORWARD


### PR DESCRIPTION
Example reproducer:
```py
import roseau.load_flow_single as rlfs

bus1 = rlfs.Bus("Bus1", nominal_voltage=20e3, min_voltage_level=0.95, max_voltage_level=1.05)
bus2 = rlfs.Bus("Bus2", nominal_voltage=20e3, min_voltage_level=0.95, max_voltage_level=1.05)
rlfs.VoltageSource("Src", bus=bus1, voltage=20e3)
lp = rlfs.LineParameters.from_catalogue("T_AL_150")
rlfs.Line("Line1", bus1=bus1, bus2=bus2, parameters=lp, length=2)
fp = rlfs.FlexibleParameter.pq_u_consumption(
    up_min=18e3, up_down=19e3, uq_min=19e3, uq_down=19.5e3, uq_up=20.5e3, uq_max=21e3, s_max=500e6
)
rlfs.PowerLoad("Load", bus=bus2, power=60e6, flexible_param=fp)
en = rlfs.ElectricalNetwork.from_element(bus1)
en.solve_load_flow(solver="backward_forward")
bus2.res_voltage.m  # <------------ nan
```