### PR TITLE
Cache pint registry for faster import time

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -19,6 +19,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 # Changelog
 
+## Unreleased
+
+- {gh-pr}`492` Improve import time of `roseau.load_flow` by caching the pint registry instantiation.
+
 ## Version 0.16.0a2
 
 - {gh-pr}`490` Fix the `backward_forward` solver silently swallowing `nan` values instead of raising an error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "geopandas>=1.0.0",
   "numpy>=2.0.0",
   "pandas>=2.1.0",
-  "pint>=0.21.0",
+  "pint>=0.24.0",
   "platformdirs>=4.0.0",
   "pyproj>=3.3.0",
   "roseau-load-flow-engine==0.19.2a3",

--- a/roseau/load_flow/units.py
+++ b/roseau/load_flow/units.py
@@ -37,11 +37,17 @@ from pint.util import UnitsContainer, to_units_container
 
 __all__ = ["ureg", "Q_", "ureg_wraps"]
 
-ureg: UnitRegistry = UnitRegistry(
-    preprocessors=[
-        lambda s: s.replace("%", " percent "),
-    ]
-)
+
+def _build_registry() -> UnitRegistry:
+    try:
+        # Cache the parsed unit definitions on disk; saves ~150ms on each import
+        return UnitRegistry(cache_folder=":auto:")
+    except OSError:
+        # If the cache folder is not writable, fall back to a non-cached registry
+        return UnitRegistry()
+
+
+ureg: UnitRegistry = _build_registry()
 ureg.define("volt_ampere_reactive = 1 * volt_ampere = VAr")
 
 # Copy types defined in pint but not exposed publicly

--- a/uv.lock
+++ b/uv.lock
@@ -1621,7 +1621,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "orjson", marker = "extra == 'fast-json'", specifier = ">=3.6.0" },
     { name = "pandas", specifier = ">=2.1.0" },
-    { name = "pint", specifier = ">=0.21.0" },
+    { name = "pint", specifier = ">=0.24.0" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pyproj", specifier = ">=3.3.0" },
     { name = "roseau-load-flow-engine", specifier = "==0.19.2a3" },


### PR DESCRIPTION
pint supports [caching](https://pint.readthedocs.io/en/develop/advanced/performance.html#speed-up-registry-instantiation) parsed unit registry on disk for faster instantiation. This cuts ~150 ms from our import time on a warm run which is currently very slow.

Also updated the minimum pint version to the one that supports numpy 2 which we require