### PR TITLE
Fix twisted line params from geometry model

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,10 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`496` {gh-issue}`284` Fix `LineParameters.from_geometry` for twisted lines: the phase conductors physically
+  rotate around the neutral along the length of the cable, so the inductance and capacitance are now averaged over the
+  three symmetric rotations of the phase conductors instead of using a single, arbitrary cross-section snapshot. Also
+  add a missing check rejecting phase conductors that are too big and would physically overlap each other.
 - {gh-pr}`493` Set `en.name` to the network (`ElmNet`) name and `en.crs` to `EPSG:4326` when loading a network from a
   DGS file.
 - {gh-pr}`492` Improve import time of `roseau.load_flow` by caching the pint registry instantiation.

--- a/doc/models/Line/Parameters.md
+++ b/doc/models/Line/Parameters.md
@@ -451,6 +451,14 @@ From these figures, the following geometric positions can be deduced:
 The position $(x_{\mathrm{a}}, y_{\mathrm{a}})$ are the position of the point $A$, $(x_{\mathrm{b}}, y_{\mathrm{b}})$
 the point $B$, etc. The prime positions are the positions of the images of the conductor with respect to the ground.
 
+A twisted (aerial bundled) cable physically rotates its phase conductors around the neutral along its length, so points
+$A$, $B$ and $C$ above are only one cross-section snapshot; the phases spend an equal length of cable at the two other
+positions reached by rotating by $\dfrac{2\pi}{3}$ and $\dfrac{4\pi}{3}$ radians. The inductance matrix $L$ and the
+potential coefficients matrix $\lambda$ are therefore each computed once per rotation and averaged, which is equivalent
+to using the geometric mean distance between conductors (as is classically done for transposed overhead lines). This
+makes the phase-to-phase and phase-to-neutral mutual terms equal, matching the balancing effect of the twist. $R$ is
+unaffected (it does not depend on geometry), and $C$ is obtained by inverting the averaged $\lambda$ matrix as before.
+
 The formulas of the previous sections are used to get the impedance and shunt admittances matrices.
 
 ```pycon
@@ -465,23 +473,23 @@ The formulas of the previous sections are used to get the impedance and shunt ad
 ...     section=150,  # mm²
 ...     section_neutral=70,  # mm²
 ...     height=10,  # m
-...     external_diameter=rlf.Q_(4, "cm"),
+...     external_diameter=rlf.Q_(5, "cm"),
 ... )
 
 >>> line_parameters.z_line
 array(
-    [[0.188     +0.32828403j, 0.        +0.25483745j, 0.        +0.25483745j, 0.        +0.28935138j],
-     [0.        +0.25483745j, 0.188     +0.32828403j, 0.        +0.25483745j, 0.        +0.28935138j],
-     [0.        +0.25483745j, 0.        +0.25483745j, 0.188     +0.32828403j, 0.        +0.28935138j],
-     [0.        +0.28935138j, 0.        +0.28935138j, 0.        +0.28935138j, 0.40285714+0.35222736j]]
+    [[0.18842667+0.32828403j, 0.        +0.24081693j, 0.        +0.24081693j, 0.        +0.27533085j],
+     [0.        +0.24081693j, 0.18842667+0.32828403j, 0.        +0.24081693j, 0.        +0.27533085j],
+     [0.        +0.24081693j, 0.        +0.24081693j, 0.18842667+0.32828403j, 0.        +0.27533085j],
+     [0.        +0.27533085j, 0.        +0.27533085j, 0.        +0.27533085j, 0.40377143+0.35222736j]]
 ) <Unit('ohm / kilometer')>
 
 >>> line_parameters.y_shunt.to("uS/km")
 array(
-    [[0.09883654 +48.82465468j, 0.          -1.92652134j, 0.          -1.92555213j, 0.         -12.02706891j],
-     [0.          -1.92652134j, 0.09883654 +48.82465468j, 0.          -1.92555213j, 0.         -12.02706891j],
-     [0.          -1.92555213j, 0.          -1.92555213j, 0.09884227 +48.82653968j, 0.         -12.02801059j],
-     [0.         -12.02706891j, 0.         -12.02706891j, 0.         -12.02801059j, 0.21303236+107.09293474j]]
+    [[0.10014898+37.06479711j, 0.         -2.29347609j, 0.         -2.29347609j, 0.         -7.44059991j],
+     [0.         -2.29347609j, 0.10014898+37.06479711j, 0.         -2.29347609j, 0.         -7.44059991j],
+     [0.         -2.29347609j, 0.         -2.29347609j, 0.10014898+37.06479711j, 0.         -7.44059991j],
+     [0.         -7.44059991j, 0.         -7.44059991j, 0.         -7.44059991j, 0.17653382+66.45525429j]]
 ) <Unit('microsiemens / kilometer')>)
 ```
 

--- a/roseau/load_flow/models/line_parameters.py
+++ b/roseau/load_flow/models/line_parameters.py
@@ -655,8 +655,17 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
                 )
                 logger.error(msg)
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINE_MODEL)
+            # The phase conductors sit on a circle of radius external_diameter/4 around the neutral,
+            # 120° apart, so they are external_diameter * sqrt(3) / 4 apart from each other.
+            if phase_radius * 2 > external_diameter * SQRT3 / 4:
+                msg = (
+                    f"Conductors too big for 'twisted' line parameter of id {id!r}. Inequality "
+                    f"`phase_radius*2 <= external_diameter * sqrt(3) / 4` is not satisfied."
+                )
+                logger.error(msg)
+                raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINE_MODEL)
         elif line_type == LineType.UNDERGROUND:
-            max_radii = external_diameter / 4 * np.sqrt(2)
+            max_radii = external_diameter / 4 * math.sqrt(2)
             if phase_radius + neutral_radius > max_radii:
                 msg = (
                     f"Conductors too big for 'underground' line parameter of id {id!r}. Inequality "
@@ -673,14 +682,30 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
                 raise RoseauLoadFlowException(msg=msg, code=RoseauLoadFlowExceptionCode.BAD_LINE_MODEL)
         else:
             pass  # TODO Overhead lines check
-        gmr = radius * np.exp(-0.25)  # geometric mean radius (m)
-        # distance between two wires (m)
-        coord_new_dim = coord[:, None, :]
-        diff = coord_new_dim - coord
-        distance = np.sqrt(np.einsum("ijk,ijk->ij", diff, diff))
-        # distance between a wire and the image of another wire (m)
-        diff = coord_new_dim - coord_prim
-        distance_prim = np.sqrt(np.einsum("ijk,ijk->ij", diff, diff))
+        gmr = radius * math.exp(-0.25)  # geometric mean radius (m)
+        epsilons = np.array([epsilon, epsilon, epsilon, epsilon_neutral], dtype=np.float64)
+
+        # A twisted cable's phase conductors physically rotate around the neutral along its
+        # length, so their inductance and capacitance are the average of the three symmetric
+        # rotations of the phase conductors around the neutral (equivalent to using the
+        # geometric mean distance), not of a single arbitrary cross-section snapshot. Other line
+        # types keep a fixed cross-section, i.e. a single "rotation".
+        phase_rotations = ((0, 1, 2), (1, 2, 0), (2, 0, 1)) if line_type == LineType.TWISTED else ((0, 1, 2),)
+        inductance = np.zeros((4, 4), dtype=np.float64)
+        lambdas = np.zeros((4, 4), dtype=np.float64)
+        for rotation in phase_rotations:
+            order = (*rotation, 3)
+            rotation_inductance, rotation_lambdas = cls._get_inductance_and_lambdas(
+                coord=coord[order, :],
+                coord_prim=coord_prim[order, :],
+                gmr=gmr,
+                radius=radius,
+                epsilons=epsilons,
+            )
+            inductance += rotation_inductance
+            lambdas += rotation_lambdas
+        inductance /= len(phase_rotations)
+        lambdas /= len(phase_rotations)
 
         # Useful matrices
         minus = -np.ones((4, 4), dtype=np.float64)
@@ -690,11 +715,6 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         materials = np.array([material, material, material, material_neutral], dtype=np.object_)
         rho = np.array([RHO[x].m for x in materials], dtype=np.float64)
         r = rho / sections_m2 * np.eye(4, dtype=np.float64) * 1e3  # resistance (ohm/km)
-        np.fill_diagonal(distance, gmr)
-        inductance = MU_0.m / (2 * PI) * np.log(1 / distance) * 1e3  # H/m->H/km
-        np.fill_diagonal(distance, radius)
-        epsilons = np.array([epsilon, epsilon, epsilon, epsilon_neutral], dtype=np.float64)
-        lambdas = 1 / (2 * PI * epsilons) * np.log(distance_prim / distance)  # m/F
 
         # Extract the conductivity and the capacities from the lambda (potential coefficients)
         lambda_inv = nplin.inv(lambdas) * 1e3  # capacities (F/km)
@@ -715,6 +735,27 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         np.fill_diagonal(y_shunt, np.einsum("ij->i", y))
 
         return z_line, y_shunt, line_type, materials, insulators, sections_mm2
+
+    @staticmethod
+    def _get_inductance_and_lambdas(
+        coord: FloatArray, coord_prim: FloatArray, gmr: FloatArray, radius: FloatArray, epsilons: FloatArray
+    ) -> tuple[FloatArray, FloatArray]:
+        """Compute the inductance matrix (H/km) and potential coefficients lambda matrix (m/F) for
+        one conductor cross-section.
+        """
+        # distance between two wires (m)
+        coord_new_dim = coord[:, None, :]
+        diff = coord_new_dim - coord
+        distance = np.sqrt(np.einsum("ijk,ijk->ij", diff, diff))
+        # distance between a wire and the image of another wire (m)
+        diff = coord_new_dim - coord_prim
+        distance_prim = np.sqrt(np.einsum("ijk,ijk->ij", diff, diff))
+
+        np.fill_diagonal(distance, gmr)
+        inductance = MU_0.m / (2 * PI) * np.log(1 / distance) * 1e3  # H/m->H/km
+        np.fill_diagonal(distance, radius)
+        lambdas = 1 / (2 * PI * epsilons) * np.log(distance_prim / distance)  # m/F
+        return inductance, lambdas
 
     @staticmethod
     def _get_geometric_configuration(

--- a/roseau/load_flow/models/tests/test_line_parameters.py
+++ b/roseau/load_flow/models/tests/test_line_parameters.py
@@ -360,6 +360,53 @@ def test_from_geometry():
     npt.assert_allclose(y_shunt, y_shunt_expected)
 
 
+def test_from_geometry_twisted_symmetric():
+    # twisted lines (aerial bundled cables) should have the same mutual impedance and admittance
+    # between any two phases, and between any phase and the neutral, because the twist balances the
+    # conductors along the length of the cable.
+    lp = LineParameters.from_geometry(
+        "twisted_symmetric",
+        line_type=LineType.TWISTED,
+        material=Material.AL,
+        insulator=Insulator.PEX,
+        section=150,
+        section_neutral=70,
+        height=10,
+        external_diameter=0.05,
+    )
+    z_line, y_shunt = lp.z_line.m, lp.y_shunt.m
+
+    # Phase-to-phase mutual terms are all equal, phase-to-neutral mutual terms are all equal
+    for m in (z_line, y_shunt):
+        npt.assert_allclose(m[0, 1], m[0, 2])
+        npt.assert_allclose(m[0, 1], m[1, 2])
+        npt.assert_allclose(m[0, 3], m[1, 3])
+        npt.assert_allclose(m[0, 3], m[2, 3])
+
+    # Diagonal terms are all equal for the phases (the neutral has a different section)
+    for m in (z_line, y_shunt):
+        npt.assert_allclose(m[0, 0], m[1, 1])
+        npt.assert_allclose(m[0, 0], m[2, 2])
+
+    # Overhead lines are not affected by the twisted-line averaging: unlike twisted lines, their
+    # shunt admittance mutual terms are not all equal (the inductance mutual terms happen to be
+    # equal too, but only because overhead and twisted lines currently share the same fixed
+    # cross-section geometry; see the TODO in `_get_geometric_configuration`).
+    _, y_shunt_overhead, *_ = LineParameters._from_geometry(
+        "test",
+        line_type=LineType.OVERHEAD,
+        material=Material.AL,
+        material_neutral=None,
+        insulator=Insulator.PEX,
+        insulator_neutral=None,
+        section=150,
+        section_neutral=70,
+        height=10,
+        external_diameter=0.04,
+    )
+    assert not np.isclose(y_shunt_overhead[0, 1], y_shunt_overhead[0, 2], rtol=1e-6, atol=0)
+
+
 def test_from_geometry_checks():
     # Wrong height
     with pytest.raises(RoseauLoadFlowException) as e:
@@ -384,6 +431,23 @@ def test_from_geometry_checks():
     assert e.value.msg == (
         "Conductors too big for 'twisted' line parameter of id 'test'. Inequality "
         "`neutral_radius + phase_radius <= external_diameter / 4` is not satisfied."
+    )
+    # Phase conductors alone are too big, even though the neutral is tiny enough to pass the check
+    # above: the phase conductors would physically overlap each other
+    with pytest.raises(RoseauLoadFlowException) as e:
+        LineParameters.from_geometry(
+            "test",
+            line_type="T",
+            material="AL",
+            section=1809.557,  # phase_radius = 0.024 m
+            section_neutral=0.01,  # negligible neutral radius
+            height=15,
+            external_diameter=0.1,  # phase-phase no-overlap distance = 0.1*sqrt(3)/4 = 0.0433 m < 2*0.024
+        )
+    assert e.value.code == RoseauLoadFlowExceptionCode.BAD_LINE_MODEL
+    assert e.value.msg == (
+        "Conductors too big for 'twisted' line parameter of id 'test'. Inequality "
+        "`phase_radius*2 <= external_diameter * sqrt(3) / 4` is not satisfied."
     )
     with pytest.raises(RoseauLoadFlowException) as e:
         LineParameters.from_geometry(


### PR DESCRIPTION
Two fixes are made to the twisted line `from_geometry` model:

- The geometric mean distance is now used to compute symmetric matrices instead of a single cross-section snapshot that produced asymmetric model
- The phase conductors radii are now verified against an upper bound so that they don't physically overlap if the neutral conductor is too small

Fixes #284 