### PR TITLE
Remove warning about resistive off-diagonal elements in line matrices

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -21,6 +21,8 @@ og:description: See what's new in the latest release of Roseau Load Flow !
 
 ## Unreleased
 
+- {gh-pr}`497` Remove the warning by when the `z_line` or `y_shunt` matrix has off-diagonal elements with a non-zero
+  real part which commonly represents the resistance of a shared, non-ideal return path.
 - {gh-pr}`496` {gh-issue}`284` Fix `LineParameters.from_geometry` for twisted lines: the phase conductors physically
   rotate around the neutral along the length of the cable, so the inductance and capacitance are now averaged over the
   three symmetric rotations of the phase conductors instead of using a single, arbitrary cross-section snapshot. Also

--- a/doc/models/Line/Parameters.md
+++ b/doc/models/Line/Parameters.md
@@ -120,6 +120,22 @@ $\underline{Y_{\mathrm{m}}}$ as before and:
 respectively the phase-to-neutral series impedance (in $\Omega$/km), the neutral shunt admittance (in S/km) and the
 phase-to-neutral shunt admittance (in S/km).
 
+```{note}
+$\underline{Z_{\mathrm{s}}}$ and $\underline{Z_{\mathrm{m}}}$ are not only the phase conductors' own impedance:
+whenever $\underline{Z_0} \neq \underline{Z_1}$, part of them reflects the impedance of whatever shared, non-ideal
+return path (lossy earth, a bonded cable sheath, etc.) was present when the sequence data was computed or
+measured. This is expected, not a modelling error, and is why $\underline{Z_{\mathrm{m}}}$ commonly has a non-zero
+real part.
+
+The neutral conductor is the exception: when it is modelled explicitly (`zn` and `xpn` given), its own impedance
+and its coupling to the phases are meant to be captured separately by $\underline{Z_{\mathrm{n}}}$ and
+$\underline{Z_{p\mathrm{n}}}$, not folded into $\underline{Z_{\mathrm{s}}}$/$\underline{Z_{\mathrm{m}}}$. If the
+provided $\underline{Z_0}$ already accounts for a return path that the explicit neutral should represent instead
+(e.g. sequence data reported for the neutral-eliminated equivalent of the line), using it as-is together with
+`zn`/`xpn` double-counts that impedance. You can check for this by eliminating the neutral back with Kron's
+reduction (`LineParameters.to_sym(eliminate_neutral=True)`) and comparing the result to the original $\underline{Z_0}$.
+```
+
 ````{note}
 If the computed impedance matrix is non-invertible, the `from_sym` class method builds impedance
 and shunt admittance matrices using the following definitions:

--- a/roseau/load_flow/io/dgs/lines.py
+++ b/roseau/load_flow/io/dgs/lines.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import pandas as pd
 
@@ -81,18 +80,16 @@ def typ_lne_to_lp(typ_lne: pd.DataFrame, line_params: dict[str, LineParameters],
         insulator = INSULATORS.get(this_typ_lne["imiso"]) if "imiso" in this_typ_lne else None
         section = this_typ_lne.get("qurs") or None  # Sometimes it is zero!! replace by None in this case
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings(action="ignore", message=r".* off-diagonal elements ", category=UserWarning)
-            lp = LineParameters(
-                id=type_id,
-                z_line=z_line,
-                y_shunt=y_shunt,
-                ampacities=ampacity,
-                line_type=line_type,
-                materials=material,
-                insulators=insulator,
-                sections=section,
-            )
+        lp = LineParameters(
+            id=type_id,
+            z_line=z_line,
+            y_shunt=y_shunt,
+            ampacities=ampacity,
+            line_type=line_type,
+            materials=material,
+            insulators=insulator,
+            sections=section,
+        )
         line_params[fid] = lp
 
 
@@ -149,9 +146,7 @@ def typ_lne_from_elm_lne_to_lp(
     z_line, y_shunt = LineParameters._sym_to_zy_simple(n=len(phases), z0=z0, y0=y0, z1=z1, y1=y1)
     LineParameters._check_z_line_matrix(id=typ_id, z_line=z_line)
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(action="ignore", message=r".* off-diagonal elements ", category=UserWarning)
-        lp = LineParameters(id=typ_id, z_line=z_line, y_shunt=y_shunt, line_type=line_type, sections=section)
+    lp = LineParameters(id=typ_id, z_line=z_line, y_shunt=y_shunt, line_type=line_type, sections=section)
 
     return lp
 

--- a/roseau/load_flow/models/line_parameters.py
+++ b/roseau/load_flow/models/line_parameters.py
@@ -2,7 +2,6 @@ import cmath
 import logging
 import math
 import re
-import warnings
 from collections.abc import Sequence
 from enum import StrEnum
 from importlib import resources
@@ -1176,19 +1175,16 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
             y_shunt[-1, -1] = 1j * bn * 1e-6
         cls._check_z_line_matrix(id=id, z_line=z_line)
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings(action="ignore", message=r".* off-diagonal elements ", category=UserWarning)
-            obj = cls(
-                id=id,
-                z_line=z_line,
-                y_shunt=y_shunt,
-                ampacities=params["ampacity"],
-                line_type=params["line_type"],
-                materials=params["material"],
-                insulators=params["insulator"],
-                sections=params["section"],
-            )
-        return obj
+        return cls(
+            id=id,
+            z_line=z_line,
+            y_shunt=y_shunt,
+            ampacities=params["ampacity"],
+            line_type=params["line_type"],
+            materials=params["material"],
+            insulators=params["insulator"],
+            sections=params["section"],
+        )
 
     @classmethod
     def _parse_open_dss_params(
@@ -1329,11 +1325,7 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
 
         params = cls._parse_open_dss_params(id=id, normamps=normamps, linetype=linetype)
 
-        # Create the RLF line parameters with off-diagonal resistance allowed
-        with warnings.catch_warnings():
-            warnings.filterwarnings(action="ignore", message=r".* off-diagonal elements ", category=UserWarning)
-            obj = cls(id=id, z_line=z, y_shunt=yc, ampacities=params["ampacities"], line_type=params["line_type"])
-        return obj
+        return cls(id=id, z_line=z, y_shunt=yc, ampacities=params["ampacities"], line_type=params["line_type"])
 
     #
     # Catalogue Mixin
@@ -1730,15 +1722,6 @@ class LineParameters(Identifiable, JsonMixin, CatalogueMixin[pd.DataFrame]):
         ]:
             if matrix_name == "y_shunt" and not self.with_shunt:
                 continue
-
-            # Check that the off-diagonal element have a zero real part
-            off_diagonal_elements = matrix[~np.eye(*matrix.shape, dtype=np.bool_)]
-            if not np.allclose(off_diagonal_elements.real, 0):
-                warn_external(
-                    f"The {matrix_name} matrix of line type {self.id!r} has off-diagonal elements "
-                    f"with a non-zero real part.",
-                    category=UserWarning,
-                )
 
             # Check that the real coefficients are non-negative
             if (matrix.real < 0.0).any():

--- a/roseau/load_flow/models/tests/test_line_parameters.py
+++ b/roseau/load_flow/models/tests/test_line_parameters.py
@@ -17,17 +17,15 @@ def test_line_parameters():
     bus2 = Bus(id="junction2", phases="abcn")
     ground = Ground("ground")
 
-    # Real element off the diagonal (Z)
+    # Real element off the diagonal (Z): allowed, e.g. represents a shared earth/neutral return
     z_line = np.ones(shape=(4, 4), dtype=complex)
     y_shunt = np.eye(4, dtype=complex)
-    with pytest.warns(UserWarning, match=r"z_line .* has off-diagonal elements with a non-zero"):
-        LineParameters("test", z_line=z_line, y_shunt=y_shunt)
+    LineParameters("test", z_line=z_line, y_shunt=y_shunt)
 
-    # Real element off the diagonal (Y)
+    # Real element off the diagonal (Y): allowed
     z_line = np.eye(3, dtype=complex)
     y_shunt = np.ones(shape=(3, 3), dtype=complex)
-    with pytest.warns(UserWarning, match=r"y_shunt .* has off-diagonal elements with a non-zero"):
-        LineParameters("test", z_line=z_line, y_shunt=y_shunt)
+    LineParameters("test", z_line=z_line, y_shunt=y_shunt)
 
     # Negative real values (Z)
     z_line = 2 * np.eye(4, dtype=complex)


### PR DESCRIPTION
Real parts of off-diagonal elements are actually very common and have a real physical meaning. They represent the resistance of the shared return path, like lossy earth or a cable sheath. Indeed, in all our conversions from other formats we were capturing the warning.